### PR TITLE
[WIP] Add sync option to send past purchases to CK.

### DIFF
--- a/components/integration/class-ckwc-batch.php
+++ b/components/integration/class-ckwc-batch.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Class for Batch Processes.
+ */
+
+class CKWC_Batch {
+
+	/**
+	 * @var int
+	 */
+	protected $total = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $step  = 0;
+
+	/**
+	 * @var int
+	 */
+	protected $per_step = 20;
+
+	/**
+	 * CKWC_Batch constructor.
+	 *
+	 * @param integer $step
+	 * @param integer $total
+	 */
+	public function __construct( $step = 1, $total = 0, $per_step = 20 ) {
+		$this->total    = $total;
+		$this->step     = $step;
+		$this->per_step = $per_step;
+	}
+
+	/**
+	 * Return Total of Items.
+	 *
+	 * @return int
+	 */
+	public function get_total() {
+		return $this->total;
+	}
+
+	/**
+	 * Get the offset.
+	 *
+	 * @return int
+	 */
+	public function get_offset() {
+		return ( $this->step - 1 ) * $this->per_step;
+	}
+
+	/**
+	 * @return boolean|WP_Error
+	 */
+	public function process() {
+
+		$items = $this->get_items( $this->get_offset() );
+
+		if ( ! $items ) {
+			return new WP_Error( 'no-items', __( 'There were no items to process.' ) );
+		}
+
+		foreach ( $items as $item ) {
+			$this->process_item( $item );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get items for the batch process.
+	 *
+	 * @param $offset
+	 *
+	 * @return array
+	 */
+	public function get_items( $offset ) {
+		return array();
+	}
+
+	/**
+	 * Process one Item.
+	 *
+	 * @param $item
+	 */
+	public function process_item( $item ) {}
+
+	/**
+	 * Get the current progress;
+	 *
+	 * @return float|int
+	 */
+	public function get_progress() {
+		$total    = $this->get_total();
+
+		if ( 0 === $total ) {
+			return 100;
+		}
+
+		$progress = $this->step * $this->per_step / $total * 100;
+
+		if ( $progress > 100 ) {
+			$progress = 100;
+		}
+
+		return $progress;
+	}
+}

--- a/components/integration/class-ckwc-sync-orders-batch.php
+++ b/components/integration/class-ckwc-sync-orders-batch.php
@@ -1,0 +1,105 @@
+<?php
+
+if ( ! class_exists('CKWC_Batch' ) ) {
+	include 'class-ckwc-batch.php';
+}
+
+class CKWC_Sync_Orders_Batch extends CKWC_Batch {
+
+	/**
+	 * Storing unsynced orders for the current process.
+	 * @var null
+	 */
+	public $unsynced_orders = null;
+
+	/**
+	 * A method that will be used for processing each order.
+	 *
+	 * @var null
+	 */
+	public $method = null;
+
+	/**
+	 * Get items for the batch process.
+	 *
+	 * @param $offset
+	 *
+	 * @return array
+	 */
+	public function get_items( $offset ) {
+		$orders = get_option( 'ckwc_unsynched_orders', array() );
+		$items  = array();
+
+		$count  = 0;
+		foreach ( $orders as $row => $order_id ) {
+
+			if ( $row + 1 < $offset ) {
+				continue;
+			}
+
+			if ( $count > $this->per_step ) {
+				break;
+			}
+
+			$items[] = $order_id;
+
+			$count++;
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Process one Item.
+	 *
+	 * @param $item
+	 */
+	public function process_item( $item ) {
+		$method = $this->method;
+		$sent = call_user_func( $method, $item );
+		if ( $sent ) {
+			$this->unset_unsynced_order( $item );
+		}
+	}
+
+	/**
+	 * Get Unsynced Orders.
+	 *
+	 * @return array
+	 */
+	public function get_unsynced_orders() {
+		if ( null === $this->unsynced_orders ) {
+			$this->unsynced_orders = get_option( 'ckwc_unsynched_orders', array() );
+		}
+
+		return $this->unsynced_orders;
+	}
+
+	/**
+	 * Get Unsynced Orders.
+	 *
+	 * @return array
+	 */
+	public function unset_unsynced_order( $order_id ) {
+		$unsynced   = $this->get_unsynced_orders();
+		$index      = array_search( $order_id, $unsynced );
+		if ( false !== $index ) {
+			unset( $unsynced[ $index ] );
+		}
+		$this->unsynced_orders = array_unique( array_values( $unsynced ) );
+	}
+
+	/**
+	 * Return an array element if it's an order type.
+	 *
+	 * @see CKWC_Integration::get_order_count
+	 *
+	 * @param $object
+	 *
+	 * @return bool
+	 */
+	public function only_order_type( $object ) {
+		if ( 'shop_order' !== $object->type ) { return false; }
+		return true;
+	}
+}

--- a/components/integration/class-ckwc-unsynced-batch.php
+++ b/components/integration/class-ckwc-unsynced-batch.php
@@ -1,0 +1,106 @@
+<?php
+
+if ( ! class_exists('CKWC_Batch' ) ) {
+	include 'class-ckwc-batch.php';
+}
+
+class CKWC_Unsynced_Batch extends CKWC_Batch {
+
+	/**
+	 * Storing unsynced orders for the current process.
+	 * @var null
+	 */
+	public $unsynced_orders = null;
+
+	/**
+	 * Get items for the batch process.
+	 *
+	 * @param $offset
+	 *
+	 * @return array
+	 */
+	public function get_items( $offset ) {
+		return wc_get_orders( array( 'offset' => $offset, 'limit' => $this->per_step ) );
+	}
+
+	/**
+	 * Process one Item.
+	 *
+	 * @param $item
+	 */
+	public function process_item( $item ) {
+		if ( version_compare( '3.0.0', WC()->version, '>' ) ) {
+			$order_id = $item->id;
+		} else {
+			$order_id = $item->get_id();
+		}
+
+		$purchase_id = get_post_meta( $order_id, '_ck_purchase_id', true );
+
+		if ( ! $purchase_id ) {
+			$this->set_unsynced_order( $order_id );
+		}
+	}
+
+	/**
+	 * Get Unsynced Orders.
+	 *
+	 * @return array
+	 */
+	public function get_unsynced_orders() {
+		if ( null === $this->unsynced_orders ) {
+			$this->unsynced_orders = get_option( 'ckwc_unsynched_orders', array() );
+		}
+
+		return $this->unsynced_orders;
+	}
+
+	/**
+	 * Get Unsynced Orders.
+	 *
+	 * @return array
+	 */
+	public function set_unsynced_order( $order_id ) {
+		$unsynced = $this->get_unsynced_orders();
+		$unsynced[] = $order_id;
+		$this->unsynced_orders = array_unique( $unsynced );
+	}
+
+	/**
+	 * Get total. If zero, we'll try to find the total.
+	 */
+	public function get_total() {
+		if ( 0 === $this->total ) {
+			$this->total = $this->get_total_count();
+		}
+
+		return $this->total;
+	}
+
+	/**
+	 * Return the count of total orders.
+	 *
+	 * @return int
+	 */
+	private function get_total_count() {
+		// No WHERE clause for a faster retrieveal.
+		$system_status    = new WC_REST_System_Status_Controller();
+		$post_type_counts = $system_status->get_post_type_counts();
+		$post_type_counts = array_values( array_filter( $post_type_counts, array( $this, 'only_order_type' ) ) );
+		return $post_type_counts ? $post_type_counts[0]->count : 0;
+	}
+
+	/**
+	 * Return an array element if it's an order type.
+	 *
+	 * @see CKWC_Integration::get_order_count
+	 *
+	 * @param $object
+	 *
+	 * @return bool
+	 */
+	public function only_order_type( $object ) {
+		if ( 'shop_order' !== $object->type ) { return false; }
+		return true;
+	}
+}

--- a/components/integration/resources/integration.css
+++ b/components/integration/resources/integration.css
@@ -1,0 +1,49 @@
+.ckwc-order-data {
+    display: flex;
+    margin-top: 1em;
+}
+
+.ckwc-order-data .order-data {
+    border-radius: 3px;
+    background: white;
+    width: 300px;
+    text-align: center;
+    margin-right: 2em;
+    border: 1px dashed rgba( 0, 0, 0, 0.1 );
+    position: relative;
+}
+
+.ckwc-order-data .order-data svg {
+    color: #955a89;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: auto;
+    width: 50%;
+    height: 50%;
+    opacity: 0.15;
+}
+
+.ckwc-order-data .order-data strong,
+.ckwc-order-data .order-data p {
+    padding: 20px;
+    display: block;
+    margin: 0;
+}
+
+.ckwc-order-data .order-data strong {
+    color: #955a89;
+    font-size: 2em;
+}
+
+.ckwc-order-data .order-data p {
+    font-weight: 500;
+    padding-top: 0;
+}
+
+.ckwc-spinner {
+    margin-top:0;
+    float:none;
+}

--- a/components/integration/resources/integration.js
+++ b/components/integration/resources/integration.js
@@ -1,7 +1,99 @@
-jQuery(document).ready(function($) {
-	$('#woocommerce_ckwc_display_opt_in').change(function() {
-		var $dependents = $('[id^="woocommerce_ckwc_opt_in_"]').parents('tr');
+"use strict";
 
-		$dependents.toggle($(this).prop('checked'));
-	}).trigger('change');
-});
+(function($) {
+
+    /**
+	 * Find the Unsynced Orders.
+	 *
+     * @param step
+     * @param total
+     */
+    function ckFindUnsyncedOrders( step, total ) {
+        var _step  = step || 1,
+            _total = total || 0,
+			spinner = $( '#ckwcOrderData' ).parent().find('.spinner');
+
+        if ( ! spinner.hasClass('is-active') ) {
+        	spinner.addClass('is-active');
+		}
+
+        $.ajax({
+			url: ajaxurl,
+			data: { action: 'ckwc_find_unsynced_orders', step: _step, total: _total },
+			method: 'GET',
+			success: function( resp ) {
+				if ( resp.success ) {
+					if ( typeof resp.data.unsynced !== 'undefined' ) {
+						$('#unsyncedOrders').find('strong').html( resp.data.unsynced );
+						$('.ckwc-sync-unsynced').removeClass('hidden');
+					}
+					if ( ! resp.data.done ) {
+						var next_step = resp.data.step || _step++;
+                        ckFindUnsyncedOrders( next_step, _total );
+					} else {
+                        spinner.removeClass('is-active');
+					}
+				}
+			}
+        });
+    }
+
+    /**
+     * Find the Unsynced Orders.
+     *
+     * @param step
+     * @param total
+     */
+    function ckSyncOrders( step, total ) {
+        var _step    = step || 1,
+            spinner  = $( '#ckwcSyncOrders' ).parent().find('.spinner'),
+            progress = $( '#ckwcSyncOrders' ).parent().find('.ckwc-progress');
+
+        if ( ! spinner.hasClass('is-active') ) {
+            spinner.addClass('is-active');
+        }
+
+        progress.removeClass('hidden');
+        progress.html( '0%' );
+
+        $.ajax({
+            url: ajaxurl,
+            data: { action: 'ckwc_sync_orders', step: _step, total: total },
+            method: 'GET',
+            success: function( resp ) {
+                if ( resp.success ) {
+                    if ( ! resp.data.done ) {
+                        var next_step = resp.data.step || _step++;
+                        var _total    = resp.data.total || total;
+                        progress.html( resp.data.progress + '%' );
+                        ckSyncOrders( next_step, _total );
+                    } else {
+                        spinner.removeClass('is-active');
+                        progress.addClass('hidden');
+                    }
+                }
+            }
+        });
+    }
+
+	$(function(){
+        $('#woocommerce_ckwc_display_opt_in').change(function() {
+            var $dependents = $('[id^="woocommerce_ckwc_opt_in_"]').parents('tr');
+
+            $dependents.toggle($(this).prop('checked'));
+        }).trigger('change');
+
+        $('#ckwcOrderData').on( 'click', function(){
+            var step = 1,
+                total = parseInt( $(this).attr('data-order-count') );
+
+            ckFindUnsyncedOrders( 1, total );
+        });
+
+        $('#ckwcSyncOrders').on( 'click', function(){
+            var step = 1;
+            ckSyncOrders( step, 0 );
+		});
+	});
+
+})(jQuery);

--- a/components/integration/views/orders-data.php
+++ b/components/integration/views/orders-data.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Display Orders Data for Sync usage.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+$show_order_data_btn = false;
+if ( null === $unsynced ) {
+	$unsynced = __( 'N/A' );
+	$show_order_data_btn = true;
+} else {
+    $unsynced = count( $unsynced );
+}
+
+?>
+<div class="ckwc-order-data">
+	<div class="order-data">
+		<svg aria-hidden="true" data-prefix="fas" data-icon="shopping-cart" class="svg-inline--fa fa-shopping-cart fa-w-18" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M528.12 301.319l47.273-208C578.806 78.301 567.391 64 551.99 64H159.208l-9.166-44.81C147.758 8.021 137.93 0 126.529 0H24C10.745 0 0 10.745 0 24v16c0 13.255 10.745 24 24 24h69.883l70.248 343.435C147.325 417.1 136 435.222 136 456c0 30.928 25.072 56 56 56s56-25.072 56-56c0-15.674-6.447-29.835-16.824-40h209.647C430.447 426.165 424 440.326 424 456c0 30.928 25.072 56 56 56s56-25.072 56-56c0-22.172-12.888-41.332-31.579-50.405l5.517-24.276c3.413-15.018-8.002-29.319-23.403-29.319H218.117l-6.545-32h293.145c11.206 0 20.92-7.754 23.403-18.681z"></path></svg>
+		<strong><?php echo esc_html( $order_count ); ?></strong>
+		<p><?php esc_html_e( 'Total Orders' ); ?></p>
+	</div>
+	<div class="order-data" id="unsyncedOrders">
+		<svg aria-hidden="true" data-prefix="fas" data-icon="sync-alt" class="svg-inline--fa fa-sync-alt fa-w-16" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M370.72 133.28C339.458 104.008 298.888 87.962 255.848 88c-77.458.068-144.328 53.178-162.791 126.85-1.344 5.363-6.122 9.15-11.651 9.15H24.103c-7.498 0-13.194-6.807-11.807-14.176C33.933 94.924 134.813 8 256 8c66.448 0 126.791 26.136 171.315 68.685L463.03 40.97C478.149 25.851 504 36.559 504 57.941V192c0 13.255-10.745 24-24 24H345.941c-21.382 0-32.09-25.851-16.971-40.971l41.75-41.749zM32 296h134.059c21.382 0 32.09 25.851 16.971 40.971l-41.75 41.75c31.262 29.273 71.835 45.319 114.876 45.28 77.418-.07 144.315-53.144 162.787-126.849 1.344-5.363 6.122-9.15 11.651-9.15h57.304c7.498 0 13.194 6.807 11.807 14.176C478.067 417.076 377.187 504 256 504c-66.448 0-126.791-26.136-171.315-68.685L48.97 471.03C33.851 486.149 8 475.441 8 454.059V320c0-13.255 10.745-24 24-24z"></path></svg>
+		<strong><?php echo esc_html( $unsynced ); ?></strong>
+		<p><?php esc_html_e( 'Unsynced Orders' ); ?></p>
+	</div>
+</div>
+<?php
+
+if ( $show_order_data_btn ) {
+	?>
+	<p>
+		<button type="button" id="ckwcOrderData" data-order-count="<?php echo esc_attr( $order_count ); ?>" class="button button-primary"><?php esc_html_e( 'Find Unsynced Orders' ); ?></button>
+		<span class="spinner ckwc-spinner"></span>
+	</p>
+	<?php
+}
+
+?>
+<p class="<?php if ( $show_order_data_btn ) { echo 'hidden'; } ?> ckwc-sync-unsynced">
+    <button type="button" id="ckwcSyncOrders" class="button button-primary"><?php esc_html_e( 'Sync Orders' ); ?></button>
+    <span class="spinner ckwc-spinner"></span>
+    <span class="hidden ckwc-progress">0%</span>
+</p>


### PR DESCRIPTION
This PR adds a Sync option to send past purchases to ConvertKit.

A Sync Purchases button takes the customer to the sync page.
<img width="680" alt="woocommerce settings convertkit wordpress 2019-01-11 10-25-23" src="https://user-images.githubusercontent.com/290886/51046439-b1416080-158b-11e9-9682-5453d8f2d868.png">

The sync page shows total orders and unsynced orders.
<img width="1117" alt="woocommerce settings convertkit wordpress 2019-01-11 10-25-03" src="https://user-images.githubusercontent.com/290886/51046446-b3a3ba80-158b-11e9-9631-17f3a65230f0.png">

After finding orders, the sync option will send orders that are Completed (not Processing) to ConvertKit.
<img width="788" alt="woocommerce settings convertkit wordpress 2019-01-11 10-25-40" src="https://user-images.githubusercontent.com/290886/51046447-b3a3ba80-158b-11e9-9789-aa6baeee5eed.png">
