### PR TITLE
PHPCS Cleanup

### DIFF
--- a/components/integration/functions/integration.php
+++ b/components/integration/functions/integration.php
@@ -6,6 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! function_exists( 'ckwc_instance' ) ) {
 	/**
+	 * Gets the CKWC_Integration instance.
+	 *
 	 * @return bool|CKWC_Integration
 	 */
 	function ckwc_instance() {
@@ -17,6 +19,8 @@ if ( ! function_exists( 'ckwc_instance' ) ) {
 
 if ( ! function_exists( 'ckwc_get_subscription_options' ) ) {
 	/**
+	 * Gets ConvertKit subscription options.
+	 *
 	 * @return array|mixed
 	 */
 	function ckwc_get_subscription_options() {
@@ -30,15 +34,26 @@ if ( ! function_exists( 'ckwc_get_subscription_options' ) ) {
 			/**
 			 * Alphabetize
 			 */
-			usort( $courses, function( $a, $b ) {
-				return strcmp( $a['name'], $b['name'] );
-			});
-			usort( $forms, function( $a, $b ) {
-				return strcmp( $a['name'], $b['name'] );
-			});
-			usort( $tags, function( $a, $b ) {
-				return strcmp( $a['name'], $b['name'] );
-			});
+			usort(
+				$courses,
+				function( $a, $b ) {
+					return strcmp( $a['name'], $b['name'] );
+				}
+			);
+
+			usort(
+				$forms,
+				function( $a, $b ) {
+					return strcmp( $a['name'], $b['name'] );
+				}
+			);
+
+			usort(
+				$tags,
+				function( $a, $b ) {
+					return strcmp( $a['name'], $b['name'] );
+				}
+			);
 
 			if ( ! is_wp_error( $courses ) && ! is_wp_error( $forms ) && ! is_wp_error( $tags ) ) {
 				$options = array(
@@ -76,59 +91,79 @@ if ( ! function_exists( 'ckwc_get_subscription_options' ) ) {
 	}
 }
 
+/**
+ * Bypasses cache (transient) to get fresh subscription options.
+ *
+ * @return array|mixed
+ */
 function ckwc_force_get_subscription_options() {
-		$courses = ckwc_convertkit_api_get_courses();
-		$forms   = ckwc_convertkit_api_get_forms();
-		$tags    = ckwc_convertkit_api_get_tags();
+	$courses = ckwc_convertkit_api_get_courses();
+	$forms   = ckwc_convertkit_api_get_forms();
+	$tags    = ckwc_convertkit_api_get_tags();
 
-		/**
-		 * Alphabetize
-		 */
-		usort( $courses, function( $a, $b ) {
+	/**
+	 * Alphabetize
+	 */
+	usort(
+		$courses,
+		function( $a, $b ) {
 			return strcmp( $a['name'], $b['name'] );
-		});
-		usort( $forms, function( $a, $b ) {
-			return strcmp( $a['name'], $b['name'] );
-		});
-		usort( $tags, function( $a, $b ) {
-			return strcmp( $a['name'], $b['name'] );
-		});
-
-		if ( ! is_wp_error( $courses ) && ! is_wp_error( $forms ) && ! is_wp_error( $tags ) ) {
-			$options = array(
-				array(
-					'key'     => 'course',
-					'name'    => __( 'Courses', 'woocommerce-convertkit' ),
-					'options' => array_combine(
-						wp_list_pluck( $courses, 'id' ),
-						wp_list_pluck( $courses, 'name' )
-					),
-				),
-				array(
-					'key'     => 'form',
-					'name'    => __( 'Forms', 'woocommerce-convertkit' ),
-					'options' => array_combine(
-						wp_list_pluck( $forms, 'id' ),
-						wp_list_pluck( $forms, 'name' )
-					),
-				),
-				array(
-					'key'     => 'tag',
-					'name'    => __( 'Tags', 'woocommerce-convertkit' ),
-					'options' => array_combine(
-						wp_list_pluck( $tags, 'id' ),
-						wp_list_pluck( $tags, 'name' )
-					),
-				),
-			);
-
-			ckwc_update_stored_subscription_options( $options );
 		}
+	);
+
+	usort(
+		$forms,
+		function( $a, $b ) {
+			return strcmp( $a['name'], $b['name'] );
+		}
+	);
+
+	usort(
+		$tags,
+		function( $a, $b ) {
+			return strcmp( $a['name'], $b['name'] );
+		}
+	);
+
+	if ( ! is_wp_error( $courses ) && ! is_wp_error( $forms ) && ! is_wp_error( $tags ) ) {
+		$options = array(
+			array(
+				'key'     => 'course',
+				'name'    => __( 'Courses', 'woocommerce-convertkit' ),
+				'options' => array_combine(
+					wp_list_pluck( $courses, 'id' ),
+					wp_list_pluck( $courses, 'name' )
+				),
+			),
+			array(
+				'key'     => 'form',
+				'name'    => __( 'Forms', 'woocommerce-convertkit' ),
+				'options' => array_combine(
+					wp_list_pluck( $forms, 'id' ),
+					wp_list_pluck( $forms, 'name' )
+				),
+			),
+			array(
+				'key'     => 'tag',
+				'name'    => __( 'Tags', 'woocommerce-convertkit' ),
+				'options' => array_combine(
+					wp_list_pluck( $tags, 'id' ),
+					wp_list_pluck( $tags, 'name' )
+				),
+			),
+		);
+
+		ckwc_update_stored_subscription_options( $options );
+	}
 
 	return $options;
 }
 
+/**
+ * Updates cached subscription value in transients.
+ *
+ * @param array|null $options Optional array of subscriptions to save.
+ */
 function ckwc_update_stored_subscription_options( $options = null ) {
 	set_transient( 'ckwc_subscription_options', $options, 5 * MINUTE_IN_SECONDS );
-
 }

--- a/components/integration/integration.php
+++ b/components/integration/integration.php
@@ -10,63 +10,87 @@ if ( ! defined( 'ABSPATH' ) ) {
 class CKWC_Integration extends WC_Integration {
 
 	/**
-     * @var string
-     */
+	 * ConvertKit API key.
+	 *
+	 * @var string
+	 */
 	public $api_key;
 
 	/**
-     * @var string
-     */
+	 * ConvertKit API secret.
+	 *
+	 * @var string
+	 */
 	private $api_secret;
 
 	/**
-     * @var string
-     */
+	 * Default subscription chosen in settings from array of subscription options.
+	 *
+	 * @var string
+	 */
 	private $subscription;
 
 	/**
-     * @var string
-     */
+	 * Is the integration enabled or not?
+	 *
+	 * @var bool
+	 */
 	public $enabled;
 
 	/**
-     * @var string
-     */
+	 * The WooCommerce event when this integration should fire.
+	 *
+	 * @var string
+	 */
 	private $event;
 
 	/**
-     * @var string
-     */
+	 * Should purchase data be sent?
+	 *
+	 * @var bool
+	 */
 	private $send_purchases;
 
 	/**
-	 * @var string
+	 * Should manual purchase data be sent?
+	 *
+	 * @var bool
 	 */
 	private $send_manual_purchases;
 
 	/**
-     * @var string
-     */
+	 * Should an opt-in field be displayed?
+	 *
+	 * @var string
+	 */
 	private $display_opt_in;
 
 	/**
-     * @var string
-     */
+	 * The label for the opt-in field.
+	 *
+	 * @var string
+	 */
 	private $opt_in_label;
 
 	/**
-     * @var string
-     */
+	 * Opt in status.
+	 *
+	 * @var string
+	 */
 	private $opt_in_status;
 
 	/**
-     * @var string
-     */
+	 * Where the opt-in field should show.
+	 *
+	 * @var string
+	 */
 	private $opt_in_location;
 
 	/**
-     * @var string
-     */
+	 * Name format.
+	 *
+	 * @var string
+	 */
 	private $name_format;
 
 	/**
@@ -77,24 +101,24 @@ class CKWC_Integration extends WC_Integration {
 		$this->method_title       = __( 'ConvertKit', 'woocommerce-convertkit' );
 		$this->method_description = __( 'Enter your ConvertKit settings below to control how WooCommerce integrates with your ConvertKit account.', 'woocommerce-convertkit' );
 
-		// Initialize form fields
+		// Initialize form fields.
 		$this->init_form_fields();
 
-		// Initialize settings
+		// Initialize settings.
 		$this->init_settings();
 
-		// API interaction
+		// API interaction.
 		$this->api_key      = $this->get_option( 'api_key' );
 		$this->api_secret   = $this->get_option( 'api_secret' );
 		$this->subscription = $this->get_option( 'subscription' );
 
-		// Enabled and when it should take place
+		// Enabled and when it should take place.
 		$this->enabled               = $this->get_option( 'enabled' );
 		$this->event                 = $this->get_option( 'event' );
 		$this->send_purchases        = $this->get_option( 'send_purchases' );
 		$this->send_manual_purchases = $this->get_option( 'send_manual_purchases' );
 
-		// Opt-in field
+		// Opt-in field.
 		$this->display_opt_in  = $this->get_option( 'display_opt_in' );
 		$this->opt_in_label    = $this->get_option( 'opt_in_label' );
 		$this->opt_in_status   = $this->get_option( 'opt_in_status' );
@@ -111,7 +135,6 @@ class CKWC_Integration extends WC_Integration {
 			add_action( 'add_meta_boxes_product', array( $this, 'add_meta_boxes' ) );
 			add_action( 'save_post_product', array( $this, 'save_product' ) );
 
-
 			add_action( 'wp_ajax_ckwc_refresh_subscription_options', array( $this, 'refresh_subscription_options' ) );
 		}
 
@@ -120,28 +143,32 @@ class CKWC_Integration extends WC_Integration {
 		}
 
 		if ( 'yes' === $this->enabled ) {
-			add_action( 'woocommerce_checkout_update_order_meta',  array( $this, 'save_opt_in_checkbox' ) );
+			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'save_opt_in_checkbox' ) );
 
-			add_action( 'woocommerce_checkout_update_order_meta',  array( $this, 'order_status' ), 99999, 1 );
-			add_action( 'woocommerce_order_status_changed',        array( $this, 'order_status' ), 99999, 3 );
+			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'order_status' ), 99999, 1 );
+			add_action( 'woocommerce_order_status_changed', array( $this, 'order_status' ), 99999, 3 );
 
-			if ( 'yes' === $this->send_purchases ){
-				add_action( 'woocommerce_payment_complete',        array( $this, 'send_payment' ), 99999, 1 );
-				add_action( 'woocommerce_order_status_changed',    array( $this, 'handle_cod_or_check_order_completion' ), 99999, 4 );
+			if ( 'yes' === $this->send_purchases ) {
+				add_action( 'woocommerce_payment_complete', array( $this, 'send_payment' ), 99999, 1 );
+				add_action( 'woocommerce_order_status_changed', array( $this, 'handle_cod_or_check_order_completion' ), 99999, 4 );
 			}
 		}
 
 	}
 
 	/**
-	 * @param $post
+	 * Add the ConvertKit WooCommerce integration metabox.
+	 *
+	 * @param WP_Post $post The WP_Post object of the object being edited.
 	 */
 	public function add_meta_boxes( $post ) {
 		add_meta_box( 'ckwc', __( 'ConvertKit Integration', 'woocommerce-convertkit' ), array( $this, 'display_meta_box' ), null, 'side', 'default' );
 	}
 
 	/**
-	 * @param $post
+	 * Renders the ConvertKit WooCommerce integration metabox.
+	 *
+	 * @param WP_Post $post The WP_Post object of the object being edited.
 	 */
 	public function display_meta_box( $post ) {
 		$subscription = get_post_meta( $post->ID, 'ckwc_subscription', true );
@@ -151,7 +178,9 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param $post_id
+	 * Save the subscription/product choice on post save.
+	 *
+	 * @param int $post_id WordPress post ID of the object being saved.
 	 */
 	public function save_product( $post_id ) {
 		$data = stripslashes_deep( $_POST ); // WPCS: input var okay. CSRF ok.
@@ -162,18 +191,17 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 *
+	 * Settings fields for the integration.
 	 */
 	public function init_form_fields() {
 		$this->form_fields = array(
-			'enabled' => array(
-				'title'       => __( 'Enable/Disable', 'woocommerce-convertkit' ),
-				'type'        => 'checkbox',
-				'label'       => __( 'Enable ConvertKit integration', 'woocommerce-convertkit' ),
-				'default'     => 'no',
+			'enabled'               => array(
+				'title'   => __( 'Enable/Disable', 'woocommerce-convertkit' ),
+				'type'    => 'checkbox',
+				'label'   => __( 'Enable ConvertKit integration', 'woocommerce-convertkit' ),
+				'default' => 'no',
 			),
-
-			'event' => array(
+			'event'                 => array(
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
@@ -185,8 +213,7 @@ class CKWC_Integration extends WC_Integration {
 					'completed'  => __( 'Order Completed', 'woocommerce-convertkit' ),
 				),
 			),
-
-			'display_opt_in' => array(
+			'display_opt_in'        => array(
 				'title'       => __( 'Display Opt-In Checkbox', 'woocommerce-convertkit' ),
 				'label'       => __( 'Display an Opt-In checkbox on checkout', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -194,16 +221,14 @@ class CKWC_Integration extends WC_Integration {
 				'description' => __( 'If enabled, customers will only be subscribed if the "Opt-In" checkbox presented on checkout is checked.', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 			),
-
-			'opt_in_label' => array(
+			'opt_in_label'          => array(
 				'title'       => __( 'Opt-In Checkbox Label', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => __( 'I want to subscribe to the newsletter', 'woocommerce-convertkit' ),
 				'description' => __( 'Optional (only used if the above field is checked): Customize the label next to the opt-in checkbox.', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 			),
-
-			'opt_in_status' => array(
+			'opt_in_status'         => array(
 				'title'       => __( 'Opt-In Checkbox<br />Default Status', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'checked',
@@ -214,8 +239,7 @@ class CKWC_Integration extends WC_Integration {
 					'unchecked' => __( 'Unchecked', 'woocommerce-convertkit' ),
 				),
 			),
-
-			'opt_in_location' => array(
+			'opt_in_location'       => array(
 				'title'       => __( 'Opt-In Checkbox<br />Display Location', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'billing',
@@ -226,8 +250,7 @@ class CKWC_Integration extends WC_Integration {
 					'order'   => __( 'Order', 'woocommerce-convertkit' ),
 				),
 			),
-
-			'api_key' => array(
+			'api_key'               => array(
 				'title'       => __( 'API Key', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => '',
@@ -235,8 +258,7 @@ class CKWC_Integration extends WC_Integration {
 				'description' => sprintf( __( 'If you already have an account, <a href="%1$s" target="_blank">click here to retrieve your API Key</a>.<br />If you don\'t have a ConvertKit account, you can <a href="%2$s" target="_blank">sign up for one here</a>.', 'woocommerce-convertkit' ), esc_attr( esc_html( 'https://app.convertkit.com/account/edit' ) ), esc_attr( esc_url( 'http://convertkit.com/pricing/' ) ) ),
 				'desc_tip'    => false,
 			),
-
-			'api_secret' => array(
+			'api_secret'            => array(
 				'title'       => __( 'API Secret', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => '',
@@ -244,43 +266,38 @@ class CKWC_Integration extends WC_Integration {
 				'description' => sprintf( __( 'If you already have an account, <a href="%1$s" target="_blank">click here to retrieve your API Secret</a>.<br />If you don\'t have a ConvertKit account, you can <a href="%2$s" target="_blank">sign up for one here</a>', 'woocommerce-convertkit.' ), esc_attr( esc_html( 'https://app.convertkit.com/account/edit' ) ), esc_attr( esc_url( 'http://convertkit.com/pricing/' ) ) ),
 				'desc_tip'    => false,
 			),
-
-			'subscription' => array(
+			'subscription'          => array(
 				'title'       => __( 'Subscription', 'woocommerce-convertkit' ),
 				'type'        => 'subscription',
 				'default'     => '',
 				'description' => __( 'Customers will be added to the selected item', 'woocommerce-convertkit' ),
 			),
-
-			'refresh_forms' => array(
+			'refresh_forms'         => array(
 				'title'       => __( 'Refresh forms', 'woocommerce-convertkit' ),
 				'type'        => 'refresh',
 				'default'     => '',
 				'description' => __( 'Refresh forms', 'woocommerce-convertkit' ),
 			),
-
-			'name_format' => array(
+			'name_format'           => array(
 				'title'       => __( 'Name Format', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'first',
 				'description' => __( 'How should the customer name be sent to ConvertKit?', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 				'options'     => array(
-					'first'   => __( 'Billing First Name', 'woocommerce-convertkit' ),
-					'last'    => __( 'Billing Last Name', 'woocommerce-convertkit' ),
-					'both'    => __( 'Billing First Name + Billing Last Name', 'woocommerce-convertkit' ),
+					'first' => __( 'Billing First Name', 'woocommerce-convertkit' ),
+					'last'  => __( 'Billing Last Name', 'woocommerce-convertkit' ),
+					'both'  => __( 'Billing First Name + Billing Last Name', 'woocommerce-convertkit' ),
 				),
 			),
-
-			'send_purchases' => array(
+			'send_purchases'        => array(
 				'title'       => __( 'Purchases', 'woocommerce-convertkit' ),
 				'label'       => __( 'Send purchase data to ConvertKit.', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'default'     => 'no',
-				'description' => __( '', 'woocommerce-convertkit' ),
+				'description' => '',
 				'desc_tip'    => false,
 			),
-
 			'send_manual_purchases' => array(
 				'label'       => __( 'Send purchase data from manual orders to ConvertKit.', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -288,11 +305,10 @@ class CKWC_Integration extends WC_Integration {
 				'description' => __( 'Purchase data from orders created manually in the admin area will be sent to ConvertKit.', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 			),
-
-			'debug' => array(
+			'debug'                 => array(
 				'title'       => __( 'Debug', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
-				'label'       => __('Write data to a log file', 'woocommerce-convertkit'),
+				'label'       => __( 'Write data to a log file', 'woocommerce-convertkit' ),
 				'description' => __( 'You can view the log file by going to WooCommerce > Status, click the Logs tab, then selecting convertkit.', 'woocommerce-convertkit' ),
 				'default'     => 'no',
 			),
@@ -306,8 +322,10 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param $key
-	 * @param $data
+	 * Generates the HTML for the "subscription options" dropdown on the settings page.
+	 *
+	 * @param string $key Field key.
+	 * @param array  $data Field attributes.
 	 *
 	 * @return string
 	 */
@@ -343,28 +361,36 @@ class CKWC_Integration extends WC_Integration {
 				<?php echo $this->get_tooltip_html( $data ); ?>
 			</th>
 			<td class="forminp">
-				<?php if ( $options ) { ?>
-				<fieldset>
-					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
-					<select class="select <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?>>
-						<option <?php selected( '', $this->get_option( $key ) ); ?> value=""><?php _e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
-						<?php foreach ( $options as $option_group ) {
-							if ( empty( $option_group['options'] ) ) {
-								continue;
-							} ?>
-						<optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
-							<?php foreach ( $option_group['options'] as $id => $name ) {
-								$value = "{$option_group['key']}:{$id}"; ?>
-							<option <?php selected( $value, $this->get_option( $key ) ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
-							<?php } ?>
-						</optgroup>
-						<?php } ?>
-					</select>
-					<?php echo $this->get_description_html( $data ); ?>
-				</fieldset>
-				<?php } else { ?>
-				<p class="description"><?php _e( 'Please provide a valid ConvertKit API Key.', 'woocommerce-convertkit' ); ?></p>
-				<?php } ?>
+
+				<?php if ( $options ) : ?>
+					<fieldset>
+
+						<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+
+						<select class="select <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); ?>>
+							<option <?php selected( '', $this->get_option( $key ) ); ?> value=""><?php _e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
+							<?php
+							foreach ( $options as $option_group ) :
+								if ( empty( $option_group['options'] ) ) {
+									continue;
+								}
+								?>
+								<optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
+									<?php
+									foreach ( $option_group['options'] as $id => $name ) :
+										$value = "{$option_group['key']}:{$id}";
+										?>
+										<option <?php selected( $value, $this->get_option( $key ) ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
+									<?php endforeach; ?>
+								</optgroup>
+							<?php endforeach; ?>
+						</select>
+						<?php echo $this->get_description_html( $data ); ?>
+
+					</fieldset>
+				<?php else : ?>
+					<p class="description"><?php _e( 'Please provide a valid ConvertKit API Key.', 'woocommerce-convertkit' ); ?></p>
+				<?php endif; ?>
 			</td>
 		</tr>
 		<?php
@@ -373,10 +399,10 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-     * Generates the HTML for the "Refresh subscription options" button on the settings page
-     *
-	 * @param $key
-	 * @param $data
+	 * Generates the HTML for the "Refresh subscription options" button on the settings page.
+	 *
+	 * @param string $key Field key.
+	 * @param array  $data Field attributes.
 	 *
 	 * @return string
 	 */
@@ -401,23 +427,25 @@ class CKWC_Integration extends WC_Integration {
 
 		$html = '<input ' . ( $has_api ? '' : 'style="display:none;"' ) . ' type="submit" name="refresh" id="refresh_ckwc_subscription_options" class="button" value="' . __( 'Refresh subscription options', 'convertkit' ) . '"><span id="refreshCKSpinner" class="spinner"></span>';
 
-	    ob_start();
-	    ?>
-        <tr valign="top">
-        <th scope="row" class="titledesc">
-            <label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
-	        <?php echo $this->get_tooltip_html( $data ); ?>
-        </th>
-        <td class="forminp">
-            <?php echo $html; ?>
-        </td>
-        <?php
+		ob_start();
+		?>
+		<tr valign="top">
+		<th scope="row" class="titledesc">
+			<label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+			<?php echo $this->get_tooltip_html( $data ); ?>
+		</th>
+		<td class="forminp">
+			<?php echo $html; ?>
+		</td>
+		<?php
 
-        return ob_get_clean();
+		return ob_get_clean();
 	}
 
 	/**
-	 * @param $settings
+	 * Settings sanitization callback.
+	 *
+	 * @param array $settings Unsanitized settings.
 	 *
 	 * @return mixed
 	 */
@@ -428,7 +456,9 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param $key
+	 * Validates the API key.
+	 *
+	 * @param string $key Field key.
 	 *
 	 * @return mixed
 	 */
@@ -450,7 +480,7 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 *
+	 * Render settings page errors.
 	 */
 	public function display_errors() {
 		if ( ! empty( $this->errors ) ) {
@@ -461,7 +491,9 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param $fields
+	 * Adds opt in checkbox field to existing array of field.
+	 *
+	 * @param array $fields Existing array of fields.
 	 *
 	 * @return mixed
 	 */
@@ -478,18 +510,22 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param $order_id
+	 * Save value of the opt-in field to order meta.
+	 *
+	 * @param int $order_id WooCommerce order ID.
 	 */
 	public function save_opt_in_checkbox( $order_id ) {
-		$opt_in = ('no' === $this->display_opt_in || isset( $_POST['ckwc_opt_in'] )) ? 'yes' : 'no'; // WPCS: CSRF ok.
+		$opt_in = ( 'no' === $this->display_opt_in || isset( $_POST['ckwc_opt_in'] ) ) ? 'yes' : 'no'; // WPCS: CSRF ok.
 
 		update_post_meta( $order_id, 'ckwc_opt_in', $opt_in );
 	}
 
 	/**
-	 * @param int $order_id
-	 * @param string $status_old
-	 * @param string $status_new
+	 * Order status change callback for maybe processing adding subscriber to ConvertKit.
+	 *
+	 * @param int    $order_id WooCommerce order ID.
+	 * @param string $status_old WooCommerce order old status.
+	 * @param string $status_new WooCommerce order new status.
 	 */
 	public function order_status( $order_id, $status_old = 'new', $status_new = 'pending' ) {
 
@@ -504,14 +540,14 @@ class CKWC_Integration extends WC_Integration {
 			$name  = $this->name_format( $this->first_name( $order ), $this->last_name( $order ) );
 
 			/**
-			 * $subscriptions is an array of type:id pairs, e.g. tag:123456
+			 * $subscriptions is an array of type:id pairs, e.g. tag:123456.
 			 *
-			 * First we fill it with the global one in the WooCommerce Integration settings
+			 * First we fill it with the global one in the WooCommerce Integration settings.
 			 */
 			$subscriptions = array( $this->subscription );
 
 			/**
-			 * Then we add any product-specific subscriptions for items in this order
+			 * Then we add any product-specific subscriptions for items in this order.
 			 */
 			foreach ( $items as $item ) {
 				$subscriptions[] = get_post_meta( $item['product_id'], 'ckwc_subscription', true );
@@ -521,33 +557,38 @@ class CKWC_Integration extends WC_Integration {
 			 * Then we keep only unique elements
 			 */
 			$subscriptions = array_filter( array_unique( $subscriptions ) );
+
 			$this->process_convertkit_subscriptions( $subscriptions, $email, $name, $order_id );
 		}
 	}
 
 	/**
-	 * @param int $order_id
-	 * @param string $status_old
-	 * @param string $status_new
-	 * @param WC_Order $order
+	 * Callback for cash/check order completions.
+	 *
+	 * @param int      $order_id WooCommerce order ID.
+	 * @param string   $status_old Old WooCommerce order status.
+	 * @param string   $status_new New WooCommerce order status.
+	 * @param WC_Order $order WooCommerce order.
 	 */
 	public function handle_cod_or_check_order_completion( $order_id, $status_old, $status_new, $order ) {
 		$api_key_correct = ! empty( $this->api_key );
-		$correct_status = $status_new === 'completed';
+		$correct_status  = 'completed' === $status_new;
 		$payment_methods = array( 'cod', 'cheque', 'check' );
 
-		if ( 'yes' === $this->send_manual_purchases ){
-		    $payment_methods[] = '';
+		if ( 'yes' === $this->send_manual_purchases ) {
+			$payment_methods[] = '';
 		}
 
-		if ( $api_key_correct && $correct_status && in_array( $order->get_payment_method( null ), $payment_methods ) ) {
+		if ( $api_key_correct && $correct_status && in_array( $order->get_payment_method( null ), $payment_methods, true ) ) {
 
 			$products = array();
 
-			foreach( $order->get_items( ) as $item_key => $item ) {
+			foreach ( $order->get_items() as $item_key => $item ) {
+
 				if ( ! $item->get_product() ) {
 					continue;
 				}
+
 				$products[] = array(
 					'pid'        => $item->get_product()->get_id(),
 					'lid'        => $item_key,
@@ -560,26 +601,27 @@ class CKWC_Integration extends WC_Integration {
 
 			$purchase_options = array(
 				'api_secret' => $this->api_secret,
-				'purchase' => array(
+				'purchase'   => array(
 					'transaction_id'   => $order->get_order_number(),
 					'email_address'    => $order->get_billing_email(),
 					'first_name'       => $order->get_billing_first_name(),
 					'currency'         => $order->get_currency(),
 					'transaction_time' => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
-					'subtotal'         => (double) $order->get_subtotal(),
-					'tax'              => (double) $order->get_total_tax( 'edit' ),
-					'shipping'         => (double) $order->get_shipping_total( 'edit' ),
-					'discount'         => (double) $order->get_discount_total( 'edit' ),
-					'total'            => (double) $order->get_total( 'edit' ),
+					'subtotal'         => round( floatval( $order->get_subtotal() ), 2 ),
+					'tax'              => round( floatval( $order->get_total_tax( 'edit' ) ), 2 ),
+					'shipping'         => round( floatval( $order->get_shipping_total( 'edit' ) ), 2 ),
+					'discount'         => round( floatval( $order->get_discount_total( 'edit' ) ), 2 ),
+					'total'            => round( floatval( $order->get_total( 'edit' ) ), 2 ),
 					'status'           => 'paid',
 					'products'         => $products,
-					'integration'      => 'WooCommerce'
-				)
+					'integration'      => 'WooCommerce',
+				),
 			);
 
 			$query_args = is_null( $this->api_key ) ? array() : array(
 				'api_key' => $this->api_key,
 			);
+
 			$body = $purchase_options;
 			$args = array( 'method' => 'POST' );
 
@@ -587,25 +629,23 @@ class CKWC_Integration extends WC_Integration {
 
 			$response = ckwc_convertkit_api_request( 'purchases', $query_args, $body, $args );
 
-			if ( is_wp_error( $response ) ){
+			if ( is_wp_error( $response ) ) {
 				$order->add_order_note( 'Send payment to ConvertKit error: ' . $response->get_error_code() . ' ' . $response->get_error_message(), 0, 'ConvertKit plugin' );
 				$this->debug_log( 'Send payment response WP Error: ' . $response->get_error_code() . ' ' . $response->get_error_message() );
 			} else {
 				$order->add_order_note( 'Payment data sent to ConvertKit', 0, false );
 				$this->debug_log( 'send payment response: ' . print_r( $response, true ) );
 			}
-
 		}
 	}
 
 	/**
-	 * For each subscription (sequence, tag, form) attached to a product,
-	 * perform the relevant actions (subscribe & add order note)
+	 * For each subscription (sequence, tag, form) attached to a product, perform the relevant actions (subscribe & add order note).
 	 *
-	 * @param array $subscriptions
-	 * @param string $email
-	 * @param string $name
-	 * @param string $order_id
+	 * @param array  $subscriptions ConvertKit subscriptions.
+	 * @param string $email Subscriber email.
+	 * @param string $name Subscriber name.
+	 * @param string $order_id WooCommerce order ID.
 	 */
 	public function process_convertkit_subscriptions( $subscriptions, $email, $name, $order_id ) {
 
@@ -619,16 +659,16 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * For each subscription (sequence, tag, form) attached to a product,
-	 * perform the relevant actions (subscribe & add order note)
+	 * For each subscription (sequence, tag, form) attached to a product, perform the relevant actions (subscribe & add order note).
 	 *
-	 * @param array $subscription
-	 * @param string $email
-	 * @param string $name
-	 * @param string $order_id
+	 * @param array  $subscription ConvertKit subscription.
+	 * @param string $email Subscriber email.
+	 * @param string $name Subscriber name.
+	 * @param string $order_id WooCommerce order ID.
 	 */
 	public function process_item_subscription( $subscription, $email, $name, $order_id ) {
-	    // TODO add else{} block here to debug_log if function does not exist
+
+		// TODO add else{} block here to debug_log if function does not exist.
 		if ( function_exists( $subscription['function'] ) ) {
 			$response = call_user_func( $subscription['function'], $subscription['id'], $email, $name );
 
@@ -648,23 +688,25 @@ class CKWC_Integration extends WC_Integration {
 					$items = $option['options'];
 				}
 				if ( $items ) {
-					// we then check if the item ID we sent is in this array, and if so add an order note
+					// We then check if the item ID we sent is in this array, and if so add an order note.
 					if ( isset( $items[ $subscription['id'] ] ) ) {
 						switch ( $subscription['type'] ) {
 							case 'tag':
 							case 'form':
-								wc_create_order_note( $order_id,
-								                      sprintf( __( '[ConvertKit] Customer subscribed to the %s: %s',
-								                                   'woocommerce-convertkit' ), $subscription['type'],
-								                               $items[ $subscription['id'] ] ) );
+								wc_create_order_note(
+									$order_id,
+									/* Translators: Placeholders are for the ConvertKit subscription or sequence type, and that item's ID in ConvertKit. */
+									sprintf( __( '[ConvertKit] Customer subscribed to the %1$s: %2$s', 'woocommerce-convertkit' ), $subscription['type'], $items[ $subscription['id'] ] )
+								);
 								break;
 
-							// Sequences are called "courses" for legacy reasons, so they get a special case
+							// Sequences are called "courses" for legacy reasons, so they get a special case.
 							case 'course':
-								wc_create_order_note( $order_id,
-								                      sprintf( __( '[ConvertKit] Customer subscribed to the %s: %s',
-								                                   'woocommerce-convertkit' ), 'sequence',
-								                               $items[ $subscription['id'] ] ) );
+								wc_create_order_note(
+									$order_id,
+									/* Translators: Placeholders are for the ConvertKit subscription or sequence type, and that item's ID in ConvertKit. */
+									sprintf( __( '[ConvertKit] Customer subscribed to the %1$s: %2$s', 'woocommerce-convertkit' ), 'sequence', $items[ $subscription['id'] ] )
+								);
 								break;
 						}
 					}
@@ -672,14 +714,15 @@ class CKWC_Integration extends WC_Integration {
 			}
 
 			if ( 'yes' === $this->get_option( 'debug' ) ) {
-				$this->debug_log( 'API call: ' . $subscription['type'] . "\nResponse: \n" . print_r( $response,
-				                                                                                     true ) );
+				$this->debug_log( 'API call: ' . $subscription['type'] . "\nResponse: \n" . print_r( $response, true ) );
 			}
 		}
 	}
 
 	/**
-	 * @param bool|WC_Order|WC_Order_Refund $order
+	 * Get billing email from specified order.
+	 *
+	 * @param bool|WC_Order|WC_Order_Refund $order WooCommerce order.
 	 *
 	 * @return string
 	 */
@@ -690,32 +733,36 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * @param bool|WC_Order|WC_Order_Refund $order
+	 * Get first name from specified order.
+	 *
+	 * @param bool|WC_Order|WC_Order_Refund $order WooCommerce order.
 	 *
 	 * @return string
 	 */
 	public function first_name( $order ) {
-		$first_name = version_compare( WC()->version, '3.0.0',
-		                               '>=' ) ? $order->get_billing_first_name() : $order->billing_first_name;
+		$first_name = version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_billing_first_name() : $order->billing_first_name;
 
 		return apply_filters( 'convertkit_for_woocommerce_first_name', $first_name, $order );
 	}
 
 	/**
-	 * @param bool|WC_Order|WC_Order_Refund $order
+	 * Get last name from specified order.
+	 *
+	 * @param bool|WC_Order|WC_Order_Refund $order WooCommerce order.
 	 *
 	 * @return string
 	 */
 	public function last_name( $order ) {
-		$last_name = version_compare( WC()->version, '3.0.0',
-		                              '>=' ) ? $order->get_billing_last_name() : $order->billing_last_name;
+		$last_name = version_compare( WC()->version, '3.0.0', '>=' ) ? $order->get_billing_last_name() : $order->billing_last_name;
 
 		return apply_filters( 'convertkit_for_woocommerce_last_name', $last_name, $order );
 	}
 
 	/**
-	 * @param string $first_name
-	 * @param string $last_name
+	 * Get name in specified name format.
+	 *
+	 * @param string $first_name First name.
+	 * @param string $last_name Last name.
 	 *
 	 * @return string
 	 */
@@ -728,60 +775,63 @@ class CKWC_Integration extends WC_Integration {
 				return $last_name;
 				break;
 			default:
-				return sprintf( "%s %s", $first_name, $last_name );
+				return sprintf( '%1$s %2$s', $first_name, $last_name );
 				break;
-
 		}
 	}
 
 	/**
-	 * Send order data to ConvertKit
+	 * Send order data to ConvertKit.
 	 *
-	 * @param int $order_id
+	 * @param int $order_id WooCommerce order ID.
 	 */
-	public function send_payment( $order_id ){
+	public function send_payment( $order_id ) {
 		$api_key_correct = ! empty( $this->api_key );
-		$order = wc_get_order( $order_id );
+		$order           = wc_get_order( $order_id );
+
 		if ( $api_key_correct && ! is_wp_error( $order ) && $order ) {
 
 			$products = array();
 
-			foreach( $order->get_items( ) as $item_key => $item ) {
+			foreach ( $order->get_items() as $item_key => $item ) {
+
 				if ( ! $item->get_product() ) {
 					continue;
 				}
+
 				$products[] = array(
-				        'pid'        => $item->get_product()->get_id(),
-						'lid'        => $item_key,
-						'name'       => $item->get_name(),
-						'sku'        => $item->get_product()->get_sku(),
-						'unit_price' => $item->get_product()->get_price(),
-						'quantity'   => $item->get_quantity(),
-					);
+					'pid'        => $item->get_product()->get_id(),
+					'lid'        => $item_key,
+					'name'       => $item->get_name(),
+					'sku'        => $item->get_product()->get_sku(),
+					'unit_price' => $item->get_product()->get_price(),
+					'quantity'   => $item->get_quantity(),
+				);
 			}
 
 			$purchase_options = array(
 				'api_secret' => $this->api_secret,
-				'purchase' => array(
+				'purchase'   => array(
 					'transaction_id'   => $order->get_order_number(),
 					'email_address'    => $order->get_billing_email(),
 					'first_name'       => $order->get_billing_first_name(),
 					'currency'         => $order->get_currency(),
 					'transaction_time' => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
-					'subtotal'         => (double) $order->get_subtotal(),
-					'tax'              => (double) $order->get_total_tax( 'edit' ),
-					'shipping'         => (double) $order->get_shipping_total( 'edit' ),
-					'discount'         => (double) $order->get_discount_total( 'edit' ),
-					'total'            => (double) $order->get_total( 'edit' ),
+					'subtotal'         => round( floatval( $order->get_subtotal() ), 2 ),
+					'tax'              => round( floatval( $order->get_total_tax( 'edit' ) ), 2 ),
+					'shipping'         => round( floatval( $order->get_shipping_total( 'edit' ) ), 2 ),
+					'discount'         => round( floatval( $order->get_discount_total( 'edit' ) ), 2 ),
+					'total'            => round( floatval( $order->get_total( 'edit' ) ), 2 ),
 					'status'           => 'paid',
 					'products'         => $products,
-					'integration'      => 'WooCommerce'
-				)
+					'integration'      => 'WooCommerce',
+				),
 			);
 
 			$query_args = is_null( $this->api_key ) ? array() : array(
 				'api_key' => $this->api_key,
 			);
+
 			$body = $purchase_options;
 			$args = array( 'method' => 'POST' );
 
@@ -789,17 +839,19 @@ class CKWC_Integration extends WC_Integration {
 
 			$response = ckwc_convertkit_api_request( 'purchases', $query_args, $body, $args );
 
-			if ( is_wp_error( $response ) ){
+			if ( is_wp_error( $response ) ) {
 				$order->add_order_note( 'Send payment to ConvertKit error: ' . $response->get_error_code() . ' ' . $response->get_error_message(), 0, 'ConvertKit plugin' );
 				$this->debug_log( 'Send payment response WP Error: ' . $response->get_error_code() . ' ' . $response->get_error_message() );
 			} else {
-			    $order->add_order_note( 'Payment data sent to ConvertKit', 0, false );
+				$order->add_order_note( 'Payment data sent to ConvertKit', 0, false );
 				$this->debug_log( 'send payment response: ' . print_r( $response, true ) );
 			}
-
 		}
 	}
 
+	/**
+	 * Update values in the Subscription option settings field.
+	 */
 	public function refresh_subscription_options() {
 
 		$key   = 'subscription';
@@ -817,20 +869,24 @@ class CKWC_Integration extends WC_Integration {
 		ob_start();
 
 		?>
-        <select class="select" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="">
-            <option <?php selected( '', $this->get_option( $key ) ); ?> value=""><?php _e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
-			<?php foreach ( $options as $option_group ) {
+		<select class="select" name="<?php echo esc_attr( $field ); ?>" id="<?php echo esc_attr( $field ); ?>" style="">
+			<option <?php selected( '', $this->get_option( $key ) ); ?> value=""><?php _e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
+			<?php
+			foreach ( $options as $option_group ) :
 				if ( empty( $option_group['options'] ) ) {
 					continue;
-				} ?>
-                <optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
-					<?php foreach ( $option_group['options'] as $id => $name ) {
-						$value = "{$option_group['key']}:{$id}"; ?>
-                        <option <?php selected( $value, $this->get_option( $key ) ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
-					<?php } ?>
-                </optgroup>
-			<?php } ?>
-        </select>
+				}
+				?>
+				<optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
+					<?php
+					foreach ( $option_group['options'] as $id => $name ) :
+						$value = "{$option_group['key']}:{$id}";
+						?>
+						<option <?php selected( $value, $this->get_option( $key ) ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
+					<?php endforeach; ?>
+				</optgroup>
+			<?php endforeach; ?>
+		</select>
 		<?php
 
 		$html = ob_get_clean();
@@ -840,12 +896,13 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Write API request results to a debug log
-	 * @param $message
+	 * Write API request results to a debug log.
+	 *
+	 * @param string $message Message to log.
 	 */
 	public function debug_log( $message ) {
-
 		$debug = $this->get_option( 'debug' );
+
 		if ( class_exists( 'WC_Logger' ) && ( 'yes' === $debug ) ) {
 			$logger = new WC_Logger();
 			$logger->add( 'convertkit', $message );
@@ -853,27 +910,26 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Plugin Links.
+	 * Plugin links.
 	 *
-	 * @param $links
+	 * @param array $links Existing plugin row links.
 	 * @return array
 	 */
 	function plugin_links( $links ) {
-
 		$plugin_links = array(
 			'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=integration&section=ckwc' ) . '">' . __( 'Settings', 'woocommerce-convertkit' ) . '</a>',
 		);
 
 		return array_merge( $plugin_links, $links );
 	}
-
-
 }
 
 require_once( 'functions/integration.php' );
 
 /**
- * @param array $integrations
+ * Register the ConvertKit WooCommerce integration with WooCommerce.
+ *
+ * @param array $integrations Existing integrations.
  *
  * @return array
  */
@@ -882,4 +938,5 @@ function ckwc_woocommerce_integrations( $integrations ) {
 
 	return $integrations;
 }
+
 add_filter( 'woocommerce_integrations', 'ckwc_woocommerce_integrations' );

--- a/components/integration/views/meta-box.php
+++ b/components/integration/views/meta-box.php
@@ -1,26 +1,36 @@
-<?php if ( 'yes' !== $this->enabled || empty( $this->api_key ) ) { ?>
-<p>
-	<strong><?php esc_html_e( 'Important:', 'woocommerce-convertkit' ); ?></strong>
-	<?php esc_html_e( 'The ConvertKit integration for WooCommerce is currently disabled. Customers will not be subscribed when purchasing.', 'woocommerce-convertkit' ); ?>
-</p>
-<?php } ?>
+<?php if ( 'yes' !== $this->enabled || empty( $this->api_key ) ) : ?>
+	<p>
+		<strong><?php esc_html_e( 'Important:', 'woocommerce-convertkit' ); ?></strong>
+		<?php esc_html_e( 'The ConvertKit integration for WooCommerce is currently disabled. Customers will not be subscribed when purchasing.', 'woocommerce-convertkit' ); ?>
+	</p>
+<?php endif; ?>
 
-<?php if ( $options ) { ?>
-<select class="widefat" id="ckwc_subscription" name="ckwc_subscription">
-	<option <?php selected( '', $subscription ); ?> value=""><?php esc_html_e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
-	<?php foreach ( $options as $option_group ) { if ( empty( $option_group['options'] ) ) { continue; } ?>
-	<optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
-		<?php foreach ( $option_group['options'] as $id => $name ) {
-			$value = "{$option_group['key']}:{$id}"; ?>
-		<option <?php selected( $value, $subscription ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
-		<?php } ?>
-	</optgroup>
-	<?php } ?>
-</select>
-<?php } else { ?>
-<p>
-	<?php esc_html_e( 'Please enter a valid ConvertKit API Key on the ConvertKit Integration Settings page.', 'woocommerce-convertkit' ); ?>
-</p>
-<?php } ?>
+<?php if ( $options ) : ?>
+	<select class="widefat" id="ckwc_subscription" name="ckwc_subscription">
+		<option <?php selected( '', $subscription ); ?> value=""><?php esc_html_e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?></option>
+
+		<?php
+		foreach ( $options as $option_group ) :
+			if ( empty( $option_group['options'] ) ) {
+				continue;
+			}
+			?>
+
+			<optgroup label="<?php echo esc_attr( $option_group['name'] ); ?>">
+				<?php
+				foreach ( $option_group['options'] as $id => $name ) :
+					$value = "{$option_group['key']}:{$id}";
+					?>
+					<option <?php selected( $value, $subscription ); ?> value="<?php echo esc_attr( $value ); ?>"><?php echo esc_html( $name ); ?></option>
+				<?php endforeach; ?>
+			</optgroup>
+
+		<?php endforeach; ?>
+	</select>
+<?php else : ?>
+	<p>
+		<?php esc_html_e( 'Please enter a valid ConvertKit API Key on the ConvertKit Integration Settings page.', 'woocommerce-convertkit' ); ?>
+	</p>
+<?php endif; ?>
 
 <?php wp_nonce_field( 'ckwc', 'ckwc_nonce' ); ?>

--- a/functions/convertkit.php
+++ b/functions/convertkit.php
@@ -1,31 +1,39 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
- * @param string $path
- * @param array $query_args
- * @param null $request_body
- * @param array $request_args
+ * Makes consistently-formatted requests to the ConvertKit API.
+ *
+ * @param string $path API path.
+ * @param array  $query_args Optional query args.
+ * @param null   $request_body Optional request body to be json-encoded and sent with the request.
+ * @param array  $request_args Optional API request args.
  *
  * @return array|mixed|object|WP_Error
  */
 function ckwc_convertkit_api_request( $path, $query_args = array(), $request_body = null, $request_args = array() ) {
-	$path         = ltrim( $path, '/' );
-	$request_url  = "https://api.convertkit.com/v3/{$path}";
+	$path        = ltrim( $path, '/' );
+	$request_url = "https://api.convertkit.com/v3/{$path}";
+
 	if ( ! is_null( $request_body ) ) {
 		$request_body = wp_json_encode( $request_body );
 	}
 
-	$request_args = array_merge(array(
-		'body'    => $request_body,
-		'headers' => array(
-			'Accept' => 'application/json',
-			'Content-Type' => 'application/json; charset=utf-8',
+	$request_args = array_merge(
+		array(
+			'body'    => $request_body,
+			'headers' => array(
+				'Accept'       => 'application/json',
+				'Content-Type' => 'application/json; charset=utf-8',
+			),
+			'method'  => 'GET',
+			'timeout' => 5,
 		),
-		'method'  => 'GET',
-		'timeout' => 5,
-	), $request_args);
+		$request_args
+	);
 
 	if ( ! isset( $query_args['api_key'] ) ) {
 		$query_args['api_key'] = ckwc_instance()->api_key;
@@ -51,7 +59,9 @@ function ckwc_convertkit_api_request( $path, $query_args = array(), $request_bod
 }
 
 /**
- * @param string|null $api_key
+ * Get courses from the specific ConvertKit account.
+ *
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -59,13 +69,16 @@ function ckwc_convertkit_api_get_courses( $api_key = null ) {
 	$query_args = is_null( $api_key ) ? array() : array(
 		'api_key' => $api_key,
 	);
-	$response   = ckwc_convertkit_api_request( 'courses', $query_args, null );
 
-	return is_wp_error( $response ) ? $response : (isset( $response['courses'] ) ? array_combine( wp_list_pluck( $response['courses'], 'id' ), $response['courses'] ) : array());
+	$response = ckwc_convertkit_api_request( 'courses', $query_args, null );
+
+	return is_wp_error( $response ) ? $response : ( isset( $response['courses'] ) ? array_combine( wp_list_pluck( $response['courses'], 'id' ), $response['courses'] ) : array() );
 }
 
 /**
- * @param string|null $api_key
+ * Get forms from the specific ConvertKit account.
+ *
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -73,13 +86,16 @@ function ckwc_convertkit_api_get_forms( $api_key = null ) {
 	$query_args = is_null( $api_key ) ? array() : array(
 		'api_key' => $api_key,
 	);
-	$response   = ckwc_convertkit_api_request( 'forms', $query_args, null );
 
-	return is_wp_error( $response ) ? $response : (isset( $response['forms'] ) ? array_combine( wp_list_pluck( $response['forms'], 'id' ), $response['forms'] ) : array());
+	$response = ckwc_convertkit_api_request( 'forms', $query_args, null );
+
+	return is_wp_error( $response ) ? $response : ( isset( $response['forms'] ) ? array_combine( wp_list_pluck( $response['forms'], 'id' ), $response['forms'] ) : array() );
 }
 
 /**
- * @param string|null $api_key
+ * Get tags from the specific ConvertKit account.
+ *
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -87,16 +103,19 @@ function ckwc_convertkit_api_get_tags( $api_key = null ) {
 	$query_args = is_null( $api_key ) ? array() : array(
 		'api_key' => $api_key,
 	);
-	$response   = ckwc_convertkit_api_request( 'tags', $query_args, null );
 
-	return is_wp_error( $response ) ? $response : (isset( $response['tags'] ) ? array_combine( wp_list_pluck( $response['tags'], 'id' ), $response['tags'] ) : array());
+	$response = ckwc_convertkit_api_request( 'tags', $query_args, null );
+
+	return is_wp_error( $response ) ? $response : ( isset( $response['tags'] ) ? array_combine( wp_list_pluck( $response['tags'], 'id' ), $response['tags'] ) : array() );
 }
 
 /**
- * @param string $course
- * @param string $email
- * @param string $name
- * @param string|null $api_key
+ * Add a subscriber (by name and email) to a specified Course.
+ *
+ * @param string      $course The course in the ConvertKit account.
+ * @param string      $email The subscriber email.
+ * @param string      $name The subscriber name.
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -105,19 +124,26 @@ function ckwc_convertkit_api_add_subscriber_to_course( $course, $email, $name, $
 		'api_key' => $api_key,
 	);
 
-	return ckwc_convertkit_api_request(sprintf( 'courses/%d/subscribe', $course ), $query_args, array(
-		'name'  => $name,
-		'email' => $email,
-		), array(
-		'method' => 'POST',
-	));
+	return ckwc_convertkit_api_request(
+		sprintf( 'courses/%d/subscribe', $course ),
+		$query_args,
+		array(
+			'name'  => $name,
+			'email' => $email,
+		),
+		array(
+			'method' => 'POST',
+		)
+	);
 }
 
 /**
- * @param string $form
- * @param string $email
- * @param string $name
- * @param string|null $api_key
+ * Add a subscriber (by name and email) to a specified Form.
+ *
+ * @param string      $form The form in the ConvertKit account.
+ * @param string      $email The subscriber email.
+ * @param string      $name The subscriber name.
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -126,19 +152,26 @@ function ckwc_convertkit_api_add_subscriber_to_form( $form, $email, $name, $api_
 		'api_key' => $api_key,
 	);
 
-	return ckwc_convertkit_api_request(sprintf( 'forms/%d/subscribe', $form ), $query_args, array(
-		'name'  => $name,
-		'email' => $email,
-		), array(
-		'method' => 'POST',
-	));
+	return ckwc_convertkit_api_request(
+		sprintf( 'forms/%d/subscribe', $form ),
+		$query_args,
+		array(
+			'name'  => $name,
+			'email' => $email,
+		),
+		array(
+			'method' => 'POST',
+		)
+	);
 }
 
 /**
- * @param string $tag
- * @param string $email
- * @param string $name
- * @param string|null $api_key
+ * Add a subscriber (by name and email) to a specified Tag.
+ *
+ * @param string      $tag The tag in the ConvertKit account.
+ * @param string      $email The subscriber email.
+ * @param string      $name The subscriber name.
+ * @param string|null $api_key ConvertKit API key.
  *
  * @return array|mixed|object|WP_Error
  */
@@ -147,10 +180,15 @@ function ckwc_convertkit_api_add_subscriber_to_tag( $tag, $email, $name, $api_ke
 		'api_key' => $api_key,
 	);
 
-	return ckwc_convertkit_api_request(sprintf( 'tags/%d/subscribe', $tag ), $query_args, array(
-		'name'  => $name,
-		'email' => $email,
-		), array(
-		'method' => 'POST',
-	));
+	return ckwc_convertkit_api_request(
+		sprintf( 'tags/%d/subscribe', $tag ),
+		$query_args,
+		array(
+			'name'  => $name,
+			'email' => $email,
+		),
+		array(
+			'method' => 'POST',
+		)
+	);
 }

--- a/functions/utility.php
+++ b/functions/utility.php
@@ -1,13 +1,15 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 if ( ! function_exists( 'ckwc_debug' ) ) {
 	/**
 	 * If logging is enabled using the `CKWC_DEBUG` constant, then dump the values passed into this
 	 * function into the error log.
 	 *
-	 * @param mixed $variable,... unlimited optional number of additional variables to debug
+	 * @param mixed $variable Additional variables to debug.
 	 * @return void
 	 */
 	function ckwc_debug( $variable ) {
@@ -37,8 +39,8 @@ if ( ! function_exists( 'ckwc_redirect' ) ) {
 	 * Wrapper function for `wp_redirect` so a developer doesn't have to remember
 	 * to call `exit` after `wp_redirect`.
 	 *
-	 * @param string $url The url to redirect the requestor to
-	 * @param int $code The HTTP status code to send when redirecting
+	 * @param string $url The url to redirect the requestor to.
+	 * @param int    $code The HTTP status code to send when redirecting.
 	 * @return void
 	 */
 	function ckwc_redirect( $url, $code = 302 ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,7 +2,10 @@
 <ruleset name="ConvertKit for WooCommerce Plugin Coding Standards">
 	<description>ConvertKit for WooCommerce Plugin Coding Standards</description>
 
-	<rule ref="WordPress-Core" />
+	<rule ref="WordPress-Core">
+		<!-- Disable requiring class- prefix in class file filenames. -->
+		<exclude name="WordPress.Files.FileName" />
+	</rule>
 
 	<rule ref="WordPress-Docs">
 		<!-- Disable file comment requirement; classes are commented, so file comments would be mostly redundant. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="ConvertKit for WooCommerce Plugin Coding Standards">
+	<description>ConvertKit for WooCommerce Plugin Coding Standards</description>
+
+	<rule ref="WordPress-Core" />
+
+	<rule ref="WordPress-Docs">
+		<!-- Disable file comment requirement; classes are commented, so file comments would be mostly redundant. -->
+		<exclude name="Squiz.Commenting.FileComment" />
+	</rule>
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<!-- Show progress and sniff codes in all reports -->
+	<arg value="ps"/>
+
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+</ruleset>

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -12,7 +12,9 @@
  */
 
 
-if ( ! defined( 'ABSPATH' ) ) { exit; }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 if ( ! defined( 'CKWC_CACHE_PERIOD' ) ) {
 	define( 'CKWC_CACHE_PERIOD', 6 * HOUR_IN_SECONDS );
@@ -51,13 +53,17 @@ if ( ! defined( 'CKWC_SHORT_TITLE' ) ) {
 }
 
 // Require the plugin's function definitions
-// These files provide generic functions that don't really belong as part of a component
+// These files provide generic functions that don't really belong as part of a component.
 require_once( path_join( CKWC_PLUGIN_DIRPATH, 'functions/convertkit.php' ) );
 require_once( path_join( CKWC_PLUGIN_DIRPATH, 'functions/utility.php' ) );
 
+/**
+ * Ensures WooCommerce is present before initializing the integration.
+ */
 function ckwc_plugins_loaded() {
 	if ( ckwc_requirements_met() ) {
 		require_once( path_join( CKWC_PLUGIN_DIRPATH, 'components/integration/integration.php' ) );
 	}
 }
+
 add_action( 'plugins_loaded', 'ckwc_plugins_loaded' );


### PR DESCRIPTION
## Summary

Brings over the `convertkit-wordpress` PHPCS rules and cleans up PHP files according to those already-established rules.
