### PR TITLE
Map Order Data to Custom Fields

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -16,6 +16,42 @@
 class CKWC_Integration extends WC_Integration {
 
 	/**
+	 * Holds the Form resources instance.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     CKWC_Resource_Forms
+	 */
+	private $forms;
+
+	/**
+	 * Holds the Form resources instance.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     CKWC_Resource_Tags
+	 */
+	private $tags;
+
+	/**
+	 * Holds the Form resources instance.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     CKWC_Resource_Sequences
+	 */
+	private $sequences;
+
+	/**
+	 * Holds the Form resources instance.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     CKWC_Resource_Custom_Fields
+	 */
+	private $custom_fields;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   1.0.0
@@ -51,7 +87,7 @@ class CKWC_Integration extends WC_Integration {
 
 		$this->form_fields = array(
 			// Enable/Disable entire integration.
-			'enabled'         => array(
+			'enabled'                       => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce-convertkit' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable ConvertKit integration', 'woocommerce-convertkit' ),
@@ -59,7 +95,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// API Key and Secret.
-			'api_key'         => array(
+			'api_key'                       => array(
 				'title'       => __( 'API Key', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => '',
@@ -76,7 +112,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled',
 			),
-			'api_secret'      => array(
+			'api_secret'                    => array(
 				'title'       => __( 'API Secret', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => '',
@@ -95,7 +131,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Subscribe.
-			'event'           => array(
+			'event'                         => array(
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
@@ -110,7 +146,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'subscription'    => array(
+			'subscription'                  => array(
 				'title'       => __( 'Subscription', 'woocommerce-convertkit' ),
 				'type'        => 'subscription',
 				'default'     => '',
@@ -119,7 +155,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'name_format'     => array(
+			'name_format'                   => array(
 				'title'       => __( 'Name Format', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'first',
@@ -135,8 +171,55 @@ class CKWC_Integration extends WC_Integration {
 				'class'       => 'enabled subscribe',
 			),
 
+			// Custom Field Mappings.
+			'custom_field_phone'            => array(
+				'title'       => __( 'Send Phone Number', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Phone Number.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+			'custom_field_billing_address'  => array(
+				'title'       => __( 'Send Billing Address', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Billing Address.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+			'custom_field_shipping_address' => array(
+				'title'       => __( 'Send Shipping Address', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Shipping Address.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+			'custom_field_payment_method'   => array(
+				'title'       => __( 'Send Payment Method', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Payment Method.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+			'custom_field_customer_note'    => array(
+				'title'       => __( 'Send Customer Note', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Customer Note.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+
 			// Subscribe: Display Opt In Checkbox Settings.
-			'display_opt_in'  => array(
+			'display_opt_in'                => array(
 				'title'       => __( 'Opt-In Checkbox', 'woocommerce-convertkit' ),
 				'label'       => __( 'Display an Opt-In checkbox on checkout', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -151,7 +234,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'opt_in_label'    => array(
+			'opt_in_label'                  => array(
 				'title'       => __( 'Opt-In Checkbox: Label', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => __( 'I want to subscribe to the newsletter', 'woocommerce-convertkit' ),
@@ -161,7 +244,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_status'   => array(
+			'opt_in_status'                 => array(
 				'title'       => __( 'Opt-In Checkbox: Default Status', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'checked',
@@ -175,7 +258,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_location' => array(
+			'opt_in_location'               => array(
 				'title'       => __( 'Opt-In Checkbox: Display Location', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'billing',
@@ -191,7 +274,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Purchase Data.
-			'send_purchases'  => array(
+			'send_purchases'                => array(
 				'title'       => __( 'Purchase Data', 'woocommerce-convertkit' ),
 				'label'       => __( 'Send purchase data to ConvertKit.', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -208,7 +291,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Debugging.
-			'debug'           => array(
+			'debug'                         => array(
 				'title'       => __( 'Debug', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'label'       => __( 'Write data to a log file', 'woocommerce-convertkit' ),
@@ -281,31 +364,96 @@ class CKWC_Integration extends WC_Integration {
 		// If the integration isn't enabled, don't output a selection field.
 		if ( ! $this->is_enabled() ) {
 			ob_start();
-			require_once CKWC_PLUGIN_PATH . '/views/backend/settings/subscription-disabled.php';
+			require CKWC_PLUGIN_PATH . '/views/backend/settings/subscription-disabled.php';
 			return ob_get_clean();
 		}
 
-		// Get Forms, Tags and Sequences, refreshing them to fetch the latest data from the API.
-		$forms = new CKWC_Resource_Forms();
-		$forms->refresh();
-		$sequences = new CKWC_Resource_Sequences();
-		$sequences->refresh();
-		$tags = new CKWC_Resource_Tags();
-		$tags->refresh();
+		// Get Forms, Tags and Sequences, refreshing them to fetch the latest data from the API,
+		// if we haven't already fetched them.
+		if ( ! $this->forms ) {
+			$this->forms = new CKWC_Resource_Forms();
+			$this->forms->refresh();
+		}
+		if ( ! $this->sequences ) {
+			$this->sequences = new CKWC_Resource_Sequences();
+			$this->sequences->refresh();
+		}
+		if ( ! $this->tags ) {
+			$this->tags = new CKWC_Resource_Tags();
+			$this->tags->refresh();
+		}
 
 		// Get current subscription setting and other settings to render the subscription dropdown field.
 		$subscription = array(
-			'id'        => 'woocommerce_ckwc_subscription',
+			'id'        => $field,
 			'class'     => 'select ' . $data['class'],
 			'name'      => $field,
 			'value'     => $this->get_option( $key ),
-			'forms'     => $forms,
-			'tags'      => $tags,
-			'sequences' => $sequences,
+			'forms'     => $this->forms,
+			'tags'      => $this->tags,
+			'sequences' => $this->sequences,
 		);
 
 		ob_start();
-		require_once CKWC_PLUGIN_PATH . '/views/backend/settings/subscription.php';
+		require CKWC_PLUGIN_PATH . '/views/backend/settings/subscription.php';
+		return ob_get_clean();
+
+	}
+
+	/**
+	 * Output HTML for a Custom Field dropdown.
+	 *
+	 * Used when init_form_fields() field type is set to custom_field i.e. used
+	 * for Phone, Billing Address and Shipping Address to Custom Field mapping settings.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   string $key    Setting Field Key.
+	 * @param   array  $data   Setting Field Configuration.
+	 */
+	public function generate_custom_field_html( $key, $data ) {
+
+		$field    = $this->get_field_key( $key );
+		$defaults = array(
+			'title'             => '',
+			'disabled'          => false,
+			'class'             => '',
+			'css'               => '',
+			'placeholder'       => '',
+			'type'              => 'text',
+			'desc_tip'          => false,
+			'description'       => '',
+			'custom_attributes' => array(),
+			'options'           => array(),
+		);
+
+		$data = wp_parse_args( $data, $defaults );
+
+		// If the integration isn't enabled, don't output a selection field.
+		if ( ! $this->is_enabled() ) {
+			ob_start();
+			include CKWC_PLUGIN_PATH . '/views/backend/settings/custom-field-disabled.php';
+			return ob_get_clean();
+		}
+
+		// Get Custom Fields, refreshing them to fetch the latest data from the API,
+		// if we haven't already fetched them.
+		if ( ! $this->custom_fields ) {
+			$this->custom_fields = new CKWC_Resource_Custom_Fields();
+			$this->custom_fields->refresh();
+		}
+
+		// Get current custom field setting and other settings to render the custom field dropdown field.
+		$custom_field = array(
+			'id'            => $field,
+			'class'         => 'select ' . $data['class'],
+			'name'          => $field,
+			'value'         => $this->get_option( $key ),
+			'custom_fields' => $this->custom_fields,
+		);
+
+		ob_start();
+		include CKWC_PLUGIN_PATH . '/views/backend/settings/custom-field.php';
 		return ob_get_clean();
 
 	}
@@ -420,7 +568,7 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Deletes all cached Forms, Tags and Sequences from the options table.
+	 * Deletes all cached Forms, Tags, Sequences and Custom Fields from the options table.
 	 *
 	 * @since   1.4.2
 	 */
@@ -434,6 +582,9 @@ class CKWC_Integration extends WC_Integration {
 
 		$sequences = new CKWC_Resource_Sequences();
 		$sequences->delete();
+
+		$custom_fields = new CKWC_Resource_Custom_Fields();
+		$custom_fields->delete();
 
 	}
 

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -150,7 +150,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Subscription', 'woocommerce-convertkit' ),
 				'type'        => 'subscription',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Form, Tag or Sequence to subscribe Customers to.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit form, tag or sequence to subscribe customers to.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -176,7 +176,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Send Phone Number', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Phone Number.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit custom field to store the order\'s phone number.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -185,7 +185,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Send Billing Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Billing Address.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit custom field to store the order\'s billing address.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -194,7 +194,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Send Shipping Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Shipping Address.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit custom field to store the order\'s shipping address.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -203,7 +203,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Send Payment Method', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Payment Method.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit custom field to store the order\'s payment method.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -212,7 +212,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Send Customer Note', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
-				'description' => __( 'The ConvertKit Custom Field to store the Order\'s Customer Note.', 'woocommerce-convertkit' ),
+				'description' => __( 'The ConvertKit custom field to store the order\'s customer note.', 'woocommerce-convertkit' ),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
@@ -221,12 +221,12 @@ class CKWC_Integration extends WC_Integration {
 			// Subscribe: Display Opt In Checkbox Settings.
 			'display_opt_in'                => array(
 				'title'       => __( 'Opt-In Checkbox', 'woocommerce-convertkit' ),
-				'label'       => __( 'Display an Opt-In checkbox on checkout', 'woocommerce-convertkit' ),
+				'label'       => __( 'Display an opt-in checkbox on checkout', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'default'     => 'no',
 				'description' => __(
-					'If enabled, customers will <strong>only</strong> be subscribed to the chosen Forms, Tags and Sequences if they check the "Opt-In" checkbox at checkout.<br />
-									  If disabled, customers will <strong>always</strong> be subscribed to the chosen Forms, Tags and Sequences at checkout.',
+					'If enabled, customers will <strong>only</strong> be subscribed to the chosen forms, tags and sequences if they check the opt-in checkbox at checkout.<br />
+									  If disabled, customers will <strong>always</strong> be subscribed to the chosen forms, tags and sequences at checkout.',
 					'woocommerce-convertkit'
 				),
 				'desc_tip'    => false,
@@ -238,7 +238,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Opt-In Checkbox: Label', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => __( 'I want to subscribe to the newsletter', 'woocommerce-convertkit' ),
-				'description' => __( 'Optional (only used if the above field is checked): Customize the label next to the opt-in checkbox.', 'woocommerce-convertkit' ),
+				'description' => __( 'Customize the label next to the opt-in checkbox.', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
@@ -262,7 +262,7 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Opt-In Checkbox: Display Location', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'billing',
-				'description' => __( 'Where to display the opt-in checkbox on the checkout page (under Billing Info or Order Info).', 'woocommerce-convertkit' ),
+				'description' => __( 'Where to display the opt-in checkbox on the checkout page (under "Billing details" or "Additional information").', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 				'options'     => array(
 					'billing' => __( 'Billing', 'woocommerce-convertkit' ),
@@ -296,10 +296,10 @@ class CKWC_Integration extends WC_Integration {
 				'type'        => 'checkbox',
 				'label'       => __( 'Write data to a log file', 'woocommerce-convertkit' ),
 				'description' => sprintf(
-					/* translators: %1$s: URL to Log File, %2$s: View Log File text */
+					/* translators: %1$s: URL to Log File, %2$s: View log file text */
 					'<a href="%1$s" target="_blank">%2$s</a>',
 					admin_url( 'admin.php?page=wc-status&tab=logs' ),
-					__( 'View Log File', 'woocommerce-convertkit' )
+					__( 'View log file', 'woocommerce-convertkit' )
 				),
 				'default'     => 'no',
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -50,7 +50,7 @@ class CKWC_Order {
 			return;
 		}
 
-		// Subscribe customer's email address to a form or tag.
+		// Subscribe customer's email address to a form, tag or sequence.
 		add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'maybe_subscribe_customer' ), 99999, 1 );
 		add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_subscribe_customer' ), 99999, 3 );
 
@@ -96,6 +96,10 @@ class CKWC_Order {
 		if ( ! $order ) {
 			return;
 		}
+
+		// If configured in the Integration, map Phone, Billing and/or Shipping Addresses to ConvertKit
+		// Custom Fields now.
+		$fields = $this->custom_field_data( $order );
 
 		// Build an array of Forms, Tags and Sequences to subscribe the Customer to, based on
 		// the global integration settings and any Product-specific settings.
@@ -155,7 +159,8 @@ class CKWC_Order {
 				$subscription['id'],
 				$this->email( $order ),
 				$this->name( $order ),
-				$order_id
+				$order_id,
+				$fields
 			);
 		}
 
@@ -172,23 +177,24 @@ class CKWC_Order {
 	 * @param   string $email          Email Address.
 	 * @param   string $name           Customer Name.
 	 * @param   int    $order_id       WooCommerce Order ID.
+	 * @param   mixed  $custom_fields  Custom Fields (false | array).
 	 * @return  mixed                   WP_Error | array
 	 */
-	public function subscribe_customer( $resource_type, $resource_id, $email, $name, $order_id ) {
+	public function subscribe_customer( $resource_type, $resource_id, $email, $name, $order_id, $custom_fields ) {
 
 		// Call API to subscribe the email address to the given Form, Tag or Sequence.
 		switch ( $resource_type ) {
 			case 'form':
-				$result = $this->api->form_subscribe( $resource_id, $email, $name );
+				$result = $this->api->form_subscribe( $resource_id, $email, $name, $custom_fields );
 				break;
 
 			case 'tag':
-				$result = $this->api->tag_subscribe( $resource_id, $email );
+				$result = $this->api->tag_subscribe( $resource_id, $email, $custom_fields );
 				break;
 
 			case 'sequence':
 			case 'course':
-				$result = $this->api->sequence_subscribe( $resource_id, $email );
+				$result = $this->api->sequence_subscribe( $resource_id, $email, $custom_fields );
 				break;
 		}
 
@@ -454,7 +460,7 @@ class CKWC_Order {
 	/**
 	 * Returns the customer's email address for the given WooCommerce Order,
 	 * immediately before it is sent to ConvertKit when subscribing the Customer
-	 * to a Form or Tag.
+	 * to a Form, Tag or Sequence.
 	 *
 	 * @since   1.0.0
 	 *
@@ -469,7 +475,7 @@ class CKWC_Order {
 		/**
 		 * Returns the customer's email address for the given WooCommerce Order,
 		 * immediately before it is sent to ConvertKit when subscribing the Customer
-		 * to a Form or Tag.
+		 * to a Form, Tag or Sequence.
 		 *
 		 * @since   1.0.0
 		 *
@@ -573,7 +579,7 @@ class CKWC_Order {
 	/**
 	 * Returns the customer's last name for the given WooCommerce Order,
 	 * immediately before it is sent to ConvertKit when subscribing the Customer
-	 * to a Form or Tag.
+	 * to a Form, Tag or Sequence.
 	 *
 	 * @since   1.0.0
 	 *
@@ -588,7 +594,7 @@ class CKWC_Order {
 		/**
 		 * Returns the customer's last name for the given WooCommerce Order,
 		 * immediately before it is sent to ConvertKit when subscribing the Customer
-		 * to a Form or Tag.
+		 * to a Form, Tag or Sequence.
 		 *
 		 * @since   1.0.0
 		 *
@@ -599,6 +605,61 @@ class CKWC_Order {
 
 		// Return.
 		return $last_name;
+
+	}
+
+	/**
+	 * Returns an array of ConvertKit Custom Field Key/Value pairs, with values
+	 * comprising of Order data based, to be sent to ConvertKit when an Order's
+	 * Customer is subscribed via a Form, Tag or Sequence.
+	 *
+	 * Returns false if no Order data should be stored in ConvertKit Custom Fields.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   WC_Order|WC_Order_Refund $order  Order.
+	 * @return  mixed                            array | false
+	 */
+	private function custom_field_data( $order ) {
+
+		$fields = array();
+
+		if ( $this->integration->get_option( 'custom_field_phone' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_phone' ) ] = $order->get_billing_phone();
+		}
+		if ( $this->integration->get_option( 'custom_field_billing_address' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_billing_address' ) ] = str_replace( '<br/>', ', ', $order->get_formatted_billing_address() );
+		}
+		if ( $this->integration->get_option( 'custom_field_shipping_address' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_shipping_address' ) ] = str_replace( '<br/>', ', ', $order->get_formatted_shipping_address() );
+		}
+		if ( $this->integration->get_option( 'custom_field_payment_method' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_payment_method' ) ] = $order->get_payment_method();
+		}
+		if ( $this->integration->get_option( 'custom_field_customer_note' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_customer_note' ) ] = $order->get_customer_note();
+		}
+
+		/**
+		 * Returns an array of ConvertKit Custom Field Key/Value pairs, with values
+		 * comprising of Order data based, to be sent to ConvertKit when an Order's
+		 * Customer is subscribed via a Form, Tag or Sequence.
+		 *
+		 * Returns false if no Order data should be stored in ConvertKit Custom Fields.
+		 *
+		 * @since   1.4.3
+		 *
+		 * @param   mixed                       $fields     Custom Field Key/Value pairs (false | array).
+		 * @param   WC_Order|WC_Order_Refund    $order      WooCommerce Order.
+		 */
+		$fields = apply_filters( 'convertkit_for_woocommerce_custom_field_data', $fields, $order );
+
+		// If the fields array is empty, no Custom Field mappings exist.
+		if ( ! count( $fields ) ) {
+			return false;
+		}
+
+		return $fields;
 
 	}
 

--- a/includes/class-ckwc-resource-custom-fields.php
+++ b/includes/class-ckwc-resource-custom-fields.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * ConvertKit Custom Fields Resource class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Reads ConvertKit Custom Fields from the options table, and refreshes
+ * ConvertKit Custom Fields data stored locally from the API.
+ *
+ * @since   1.4.3
+ */
+class CKWC_Resource_Custom_Fields extends CKWC_Resource {
+
+	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @var     string
+	 */
+	public $settings_name = 'ckwc_custom_fields';
+
+	/**
+	 * The type of resource
+	 *
+	 * @var     string
+	 */
+	public $type = 'custom_fields';
+
+	/**
+	 * Holds the forms from the ConvertKit API
+	 *
+	 * @var     array
+	 */
+	public $resources = array();
+
+}

--- a/includes/class-ckwc-resource.php
+++ b/includes/class-ckwc-resource.php
@@ -124,6 +124,10 @@ class CKWC_Resource {
 			case 'tags':
 				$results = $api->get_tags();
 				break;
+
+			case 'custom_fields':
+				$results = $api->get_custom_fields();
+				break;
 		}
 
 		// Bail if an error occured.

--- a/resources/backend/js/integration.js
+++ b/resources/backend/js/integration.js
@@ -77,8 +77,8 @@ function ckwcRefreshUI() {
 							return;
 						}
 
-						// Hide this row if the input or select element within the row has the CSS class of the setting name.
-						if ( $( 'input, select', $( this ) ).hasClass( setting ) ) {
+						// Hide this row if the input, select, link or span element within the row has the CSS class of the setting name.
+						if ( $( 'input, select, a, span', $( this ) ).hasClass( setting ) ) {
 							$( this ).hide();
 						}
 					}

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -258,22 +258,32 @@ class Acceptance extends \Codeception\Module
 		// Save.
 		$I->click('Save changes');
 
-		// Define Form, Tag or Sequence to subscribe the Customer to, and/or Custom Field mappings,
-		// now that the API credentials are saved and the Forms, Tags and Sequences are listed.
-		if ($pluginFormTagSequence || $customFields) {
-			if ($pluginFormTagSequence) {
-				$I->selectOption('#woocommerce_ckwc_subscription', $pluginFormTagSequence);
-			}
-			if ($customFields) {
-				$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
-				$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
-				$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
-				$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
-				$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
-			}
-			$I->click('Save changes');
+		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are 
+		// saved and the Forms, Tags and Sequences are listed.
+		if ($pluginFormTagSequence) {
+			$I->selectOption('#woocommerce_ckwc_subscription', $pluginFormTagSequence);
+		} else {
+			$I->selectOption('#woocommerce_ckwc_subscription', 'Select a subscription option...');
 		}
 
+		// Define Order to Custom Field mappings, now that the API credentials are 
+		// saved and the Forms, Tags and Sequences are listed.
+		if ($customFields) {
+			$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
+			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
+			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
+			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
+		} else {
+			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send / map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send / map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send / map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send / map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send / map)');
+		}
+
+		$I->click('Save changes');
+		
 		// Create Product
 		switch ($productType) {
 			case 'zero':
@@ -652,6 +662,21 @@ class Acceptance extends \Codeception\Module
 		$I->assertEquals($subscriber['fields']['shipping_address'], '');
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
+	}
+
+	/**
+	 * Check the subscriber array's custom field data is empty.
+	 * 
+	 * @param 	AcceptanceTester $I 			AcceptanceTester
+	 * @param 	array 			$subscriber 	Subscriber from API
+	 */ 	
+	public function apiCustomFieldDataIsEmpty($I, $subscriber)
+	{
+		$I->assertEquals($subscriber['fields']['phone_number'], '');
+		$I->assertEquals($subscriber['fields']['billing_address'], '');
+		$I->assertEquals($subscriber['fields']['shipping_address'], '');
+		$I->assertEquals($subscriber['fields']['payment_method'], '');
+		$I->assertEquals($subscriber['fields']['notes'], '');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -275,11 +275,11 @@ class Acceptance extends \Codeception\Module
 			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
 			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
 		} else {
-			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send / map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send / map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send / map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send / map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send / map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send or map)');
 		}
 
 		$I->click('Save changes');

--- a/tests/acceptance/SettingCustomFieldsCest.php
+++ b/tests/acceptance/SettingCustomFieldsCest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests various setting combinations across the following settings:
+ * - Subscribe Event
+ * - Display Opt-In Checkbox
+ * - API Keys
+ * - Subscription Form
+ * 
+ * @since 	1.4.2
+ */
+class SettingCustomFieldsCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate WooCommerce and ConvertKit Plugins.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that Custom Field options are saved when selected at
+	 * WooCommerce > Settings > Integration > ConvertKit.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testCustomFields(AcceptanceTester $I)
+	{
+		// Set Order to Custom Field mappings.
+		$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
+		$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
+		$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+		$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
+		$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
+
+		// Save.
+		$I->click('Save changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the settings saved.
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
+	}
+}

--- a/tests/acceptance/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderCompletedEventCest.php
@@ -214,6 +214,135 @@ class SubscribeOnOrderCompletedEventCest
 
 	/**
 	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Completed', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address wasn't yet added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Change the Order status = Completed, to trigger the Order Completed event.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to
+			'Order Completed', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address wasn't yet added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Change the Order status = Completed, to trigger the Order Completed event.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to
+			'Order Completed', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address wasn't yet added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Change the Order status = Completed, to trigger the Order Completed event.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
 	 * - The opt in checkbox is disabled in the integration Settings, and
 	 * - No Form is selected in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
@@ -247,229 +376,5 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address wasn't yet added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is not subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address wasn't yet added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address wasn't yet added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address wasn't yet added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-	
+	}	
 }

--- a/tests/acceptance/SubscribeOnOrderCreatedEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderCreatedEventCest.php
@@ -119,6 +119,117 @@ class SubscribeOnOrderCreatedEventCest
 	}
 
 	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to
+			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to
+			'Order Created', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
 	 * Test that the Customer is not subscribed to ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
 	 * - No Form is selected in the integration Settings, and
@@ -212,192 +323,4 @@ class SubscribeOnOrderCreatedEventCest
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
 	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is not subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-	
 }

--- a/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
@@ -52,7 +52,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
@@ -119,7 +123,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
@@ -140,7 +148,7 @@ class SubscribeOnOrderProcessingEventCest
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testOptInWhenCheckedWithCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
@@ -149,6 +157,80 @@ class SubscribeOnOrderProcessingEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * 
+	 * @since 	1.4.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * 
+	 * @since 	1.4.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to
 			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
 			false, // Don't send purchase data to ConvertKit
 			false, // Don't define a Product level Form, Tag or Sequence
@@ -274,248 +356,6 @@ class SubscribeOnOrderProcessingEventCest
 	 * Test that the Customer is subscribed to ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithCustomFieldsAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false, // Don't send purchase data to ConvertKit
-			false, // Don't define a Product level Form, Tag or Sequence
-			true // Map Order data to Custom Fields
-		);
-
-		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Confirm the subscriber's custom field data exists and is correct.
-		$I->apiCustomFieldDataIsValid($I, $subscriber);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-			// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	}
-
-	/**
-	 * Test that the Customer is not subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenCheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			true, // Check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-	}
-
-	/**
-	 * Test that the Customer is NOT subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInWhenUncheckedWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			true, // Display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is disabled in the integration Settings, and
-	 * - No Form is selected in the integration Settings, and
-	 * - The Customer purchases a 'virtual' WooCommerce Product, and
-	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
-	 */
-	public function testOptInDisabledWithNoFormAndVirtualProduct(AcceptanceTester $I)
-	{
-		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'virtual', // Virtual Product
-			false, // Don't display Opt-In checkbox on Checkout
-			false, // Don't check Opt-In checkbox on Checkout
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
-			false // Don't send purchase data to ConvertKit
-		);
-
-		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
-
-		// Unsubscribe the email address, so we restore the account back to its previous state.
-		$I->apiUnsubscribe($result['email_address']);
-
-		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-	}
-
-	/**
-	 * Test that the Customer is subscribed to ConvertKit when:
-	 * - The opt in checkbox is enabled in the integration Settings, and
-	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The 'Simple' WooCommerce Product also defines a Form (separate to the Plugin settings), and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
@@ -539,7 +379,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
@@ -578,7 +422,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
@@ -617,7 +465,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
@@ -657,7 +509,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$I->apiCheckSubscriberExists($I, $result['email_address']);
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);

--- a/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
@@ -144,7 +144,7 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
 	 * 
-	 * @since 	1.4.2
+	 * @since 	1.4.3
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
@@ -181,7 +181,7 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
 	 * 
-	 * @since 	1.4.2
+	 * @since 	1.4.3
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
@@ -218,7 +218,7 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
 	 * 
-	 * @since 	1.4.2
+	 * @since 	1.4.3
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */

--- a/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderProcessingEventCest.php
@@ -129,6 +129,43 @@ class SubscribeOnOrderProcessingEventCest
 	}
 
 	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * 
+	 * @since 	1.4.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
 	 * Test that the Customer is not subscribed to ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
 	 * - No Form is selected in the integration Settings, and
@@ -265,6 +302,43 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * 
+	 * @since 	1.4.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testOptInWhenCheckedWithCustomFieldsAndVirtualProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'virtual', // Virtual Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false, // Don't send purchase data to ConvertKit
+			false, // Don't define a Product level Form, Tag or Sequence
+			true // Map Order data to Custom Fields
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
 	}
 
 	/**

--- a/views/backend/custom-field-dropdown-field.php
+++ b/views/backend/custom-field-dropdown-field.php
@@ -10,7 +10,7 @@
 
 <select class="<?php echo esc_attr( $custom_field['class'] ); ?>" id="<?php echo esc_attr( $custom_field['id'] ); ?>" name="<?php echo esc_attr( $custom_field['name'] ); ?>">
 	<option <?php selected( '', $custom_field['value'] ); ?> value="">
-		<?php esc_html_e( '(Don\'t send / map)', 'woocommerce-convertkit' ); ?>
+		<?php esc_html_e( '(Don\'t send or map)', 'woocommerce-convertkit' ); ?>
 	</option>
 
 	<?php

--- a/views/backend/custom-field-dropdown-field.php
+++ b/views/backend/custom-field-dropdown-field.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Outputs a dropdown field comprising of all Forms, Tags and Sequences for the ConvertKit account.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+?>
+
+<select class="<?php echo esc_attr( $custom_field['class'] ); ?>" id="<?php echo esc_attr( $custom_field['id'] ); ?>" name="<?php echo esc_attr( $custom_field['name'] ); ?>">
+	<option <?php selected( '', $custom_field['value'] ); ?> value="">
+		<?php esc_html_e( '(Don\'t send / map)', 'woocommerce-convertkit' ); ?>
+	</option>
+
+	<?php
+	if ( ! is_wp_error( $custom_field['custom_fields']->get() ) ) {
+		foreach ( $custom_field['custom_fields']->get() as $api_custom_field ) {
+			?>
+			<option value="<?php echo esc_attr( $api_custom_field['key'] ); ?>"<?php selected( esc_attr( $api_custom_field['key'] ), $custom_field['value'] ); ?>><?php echo esc_html( $api_custom_field['label'] ); ?></option>
+			<?php
+		}
+	}
+	?>
+</select>

--- a/views/backend/product/disabled.php
+++ b/views/backend/product/disabled.php
@@ -12,7 +12,7 @@
 	<?php
 	echo sprintf(
 		/* translators: %1$s: Post Type Singular Name, %2$s: Link to Integration Settings */
-		esc_html__( 'To configure the ConvertKit Form, Tag or Sequence to subscribe Customers to who purchase this %1$s, %2$s and enter a valid API Key and Secret.', 'woocommerce-convertkit' ),
+		esc_html__( 'To configure the ConvertKit form, tag or sequence to subscribe customers to who purchase this %1$s, %2$s and enter a valid API Key and API Secret.', 'woocommerce-convertkit' ),
 		esc_attr( $post_type->labels->singular_name ),
 		'<a href="' . esc_attr( admin_url( 'admin.php?page=wc-settings&tab=integration&section=ckwc' ) ) . '">' . esc_html__( 'enable the ConvertKit WooCommerce integration', 'woocommerce-convertkit' ) . '</a>'
 	);

--- a/views/backend/product/meta-box.php
+++ b/views/backend/product/meta-box.php
@@ -11,7 +11,7 @@ require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php'
 ?>
 
 <p class="description">
-	<?php esc_html_e( 'The ConvertKit Form, Tag or Sequence to subscribe Customers to who purchase this Product.', 'woocommerce-convertkit' ); ?>
+	<?php esc_html_e( 'The ConvertKit form, tag or sequence to subscribe customers to who purchase this product.', 'woocommerce-convertkit' ); ?>
 </p>
 
 <?php

--- a/views/backend/settings/custom-field-disabled.php
+++ b/views/backend/settings/custom-field-disabled.php
@@ -14,6 +14,8 @@
 		<?php echo esc_html( $this->get_tooltip_html( $data ) ); ?>
 	</th>
 	<td class="forminp">
-		<?php esc_html_e( 'To select the Custom Field to map this Order value to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+		<span class="<?php echo esc_attr( $data['class'] ); ?>">
+			<?php esc_html_e( 'To select the Custom Field to map this Order value to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+		</span>
 	</td>
 </tr>

--- a/views/backend/settings/custom-field-disabled.php
+++ b/views/backend/settings/custom-field-disabled.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Outputs the Custom Field setting table row for the integration's settings,
+ * when the integration is disabled or does not have valid API credentials.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+?>
+<tr valign="top">
+	<th scope="row" class="titledesc">
+		<label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+		<?php echo esc_html( $this->get_tooltip_html( $data ) ); ?>
+	</th>
+	<td class="forminp">
+		<?php esc_html_e( 'To select the Custom Field to map this Order value to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+	</td>
+</tr>

--- a/views/backend/settings/custom-field-disabled.php
+++ b/views/backend/settings/custom-field-disabled.php
@@ -15,7 +15,7 @@
 	</th>
 	<td class="forminp">
 		<span class="<?php echo esc_attr( $data['class'] ); ?>">
-			<?php esc_html_e( 'To select the Custom Field to map this Order value to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+			<?php esc_html_e( 'To select the custom field to map this order value to, specify a valid API Key, API Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
 		</span>
 	</td>
 </tr>

--- a/views/backend/settings/custom-field.php
+++ b/views/backend/settings/custom-field.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Outputs the Custom Field setting table row for the integration's settings.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+?>
+<tr valign="top">
+	<th scope="row" class="titledesc">
+		<label for="<?php echo esc_attr( $field ); ?>"><?php echo wp_kses_post( $data['title'] ); ?></label>
+		<?php echo esc_html( $this->get_tooltip_html( $data ) ); ?>
+	</th>
+	<td class="forminp">
+		<fieldset>
+			<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
+			<?php
+			// Load custom field dropdown field.
+			require CKWC_PLUGIN_PATH . '/views/backend/custom-field-dropdown-field.php';
+			echo $this->get_description_html( $data ); // phpcs:ignore
+			?>
+		</fieldset>
+	</td>
+</tr>

--- a/views/backend/settings/subscription-disabled.php
+++ b/views/backend/settings/subscription-disabled.php
@@ -14,6 +14,8 @@
 		<?php echo esc_html( $this->get_tooltip_html( $data ) ); ?>
 	</th>
 	<td class="forminp">
-		<?php esc_html_e( 'To select the Form, Tag or Sequence to subscribe Customers to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+		<span class="<?php echo esc_attr( $data['class'] ); ?>">
+			<?php esc_html_e( 'To select the Form, Tag or Sequence to subscribe Customers to, specify a valid API Key and Secret, and click Save changes.', 'woocommerce-convertkit' ); ?>
+		</span>
 	</td>
 </tr>

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -36,6 +36,7 @@ require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-api.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-checkout.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-order.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource.php';
+require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-custom-fields.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-forms.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-sequences.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-tags.php';


### PR DESCRIPTION
## Summary

Adds configuration options to map WooCommerce Order Data (Phone Number, Billing Address, Shipping Address, Payment Method, Customer Note) to the subscriber's Custom Fields in ConvertKit, as partly requested at https://wordpress.org/support/topic/push-phone-to-convertkit-from-woocommerce-orders/

New settings introduced at WordPress Admin > WooCommerce > Settings > Integrations > ConvertKit:
![Screenshot 2022-02-04 at 18 07 17](https://user-images.githubusercontent.com/1462305/152580470-528c067b-c1b2-45ce-9314-fc76d0ac439f.png)

Example of Order data mapped to a subscriber in ConvertKit:
![Screenshot 2022-02-04 at 18 07 27](https://user-images.githubusercontent.com/1462305/152580490-e8e02afe-c95b-46a4-88de-b271cf56c759.png)

## Testing

- `SettingCustomFieldsCest`: Added tests to confirm that defining Custom Field mappings in the Plugin's settings saves correctly.
- `SubscribeOnOrderProcessingEventCest`: Added tests to check custom fields do, or do not, get sent to ConvertKit, depending on the Plugin configuration.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)