### PR TITLE
Review Request Notification

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.19",
+            "version": "2.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "94fe587cb0a6c1695b1ddc650e877231be80b8bc"
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/94fe587cb0a6c1695b1ddc650e877231be80b8bc",
-                "reference": "94fe587cb0a6c1695b1ddc650e877231be80b8bc",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
+                "reference": "25c1fa0cd9a6e6d0d13863d8df8f050b6733f16d",
                 "shasum": ""
             },
             "require": {
@@ -51,9 +51,9 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.19"
+                "source": "https://github.com/antecedent/patchwork/tree/2.1.21"
             },
-            "time": "2022-01-20T04:47:04+00:00"
+            "time": "2022-02-07T07:28:34+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -176,16 +176,16 @@
         },
         {
             "name": "codeception/codeception",
-            "version": "4.1.28",
+            "version": "4.1.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "e9bc22a3819f9d356068c0e372193ebcc9b06014"
+                "reference": "f8dec8f2bf5347cc596aaf141753f4fb2504c17c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/e9bc22a3819f9d356068c0e372193ebcc9b06014",
-                "reference": "e9bc22a3819f9d356068c0e372193ebcc9b06014",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/f8dec8f2bf5347cc596aaf141753f4fb2504c17c",
+                "reference": "f8dec8f2bf5347cc596aaf141753f4fb2504c17c",
                 "shasum": ""
             },
             "require": {
@@ -232,13 +232,13 @@
                 "branch-alias": []
             },
             "autoload": {
+                "files": [
+                    "functions.php"
+                ],
                 "psr-4": {
                     "Codeception\\": "src/Codeception",
                     "Codeception\\Extension\\": "ext"
-                },
-                "files": [
-                    "functions.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -262,7 +262,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeception/Codeception/issues",
-                "source": "https://github.com/Codeception/Codeception/tree/4.1.28"
+                "source": "https://github.com/Codeception/Codeception/tree/4.1.29"
             },
             "funding": [
                 {
@@ -270,7 +270,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2022-01-05T16:41:25+00:00"
+            "time": "2022-01-29T16:56:03+00:00"
         },
         {
             "name": "codeception/lib-asserts",
@@ -832,27 +832,27 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -873,6 +873,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -884,6 +888,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -898,7 +903,7 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "dg/mysql-dump",
@@ -1428,7 +1433,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v8.81.0",
+            "version": "v8.82.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
@@ -1455,12 +1460,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
                 "files": [
                     "helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1482,7 +1487,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v8.81.0",
+            "version": "v8.82.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -1530,7 +1535,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v8.81.0",
+            "version": "v8.82.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -1576,16 +1581,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v8.81.0",
+            "version": "v8.82.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "fb33fd4bbcc075f641d5576b700a1c3d962acef0"
+                "reference": "910c5eb5d506013fdf60f9dc68c5512711857558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/fb33fd4bbcc075f641d5576b700a1c3d962acef0",
-                "reference": "fb33fd4bbcc075f641d5576b700a1c3d962acef0",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/910c5eb5d506013fdf60f9dc68c5512711857558",
+                "reference": "910c5eb5d506013fdf60f9dc68c5512711857558",
                 "shasum": ""
             },
             "require": {
@@ -1617,12 +1622,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Illuminate\\Support\\": ""
-                },
                 "files": [
                     "helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1640,20 +1645,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-01-25T16:10:28+00:00"
+            "time": "2022-01-28T16:29:10+00:00"
         },
         {
             "name": "lucatume/wp-browser",
-            "version": "3.0.22",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lucatume/wp-browser.git",
-                "reference": "c695d8e2fd075b85e89be57b1c10aec64530287a"
+                "reference": "35a8dcef9b06367405100071cd6fb9d2123691fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/c695d8e2fd075b85e89be57b1c10aec64530287a",
-                "reference": "c695d8e2fd075b85e89be57b1c10aec64530287a",
+                "url": "https://api.github.com/repos/lucatume/wp-browser/zipball/35a8dcef9b06367405100071cd6fb9d2123691fc",
+                "reference": "35a8dcef9b06367405100071cd6fb9d2123691fc",
                 "shasum": ""
             },
             "require": {
@@ -1734,7 +1739,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lucatume/wp-browser/issues",
-                "source": "https://github.com/lucatume/wp-browser/tree/3.0.22"
+                "source": "https://github.com/lucatume/wp-browser/tree/3.1.3"
             },
             "funding": [
                 {
@@ -1742,7 +1747,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-01-14T08:41:20+00:00"
+            "time": "2022-02-01T09:21:06+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",
@@ -1935,12 +1940,12 @@
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4377,16 +4382,16 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "1fb93b0aab42392aa0a742db205173b49afaf80f"
+                "reference": "18e73179c6a33d520de1b644941eba108dd811ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/1fb93b0aab42392aa0a742db205173b49afaf80f",
-                "reference": "1fb93b0aab42392aa0a742db205173b49afaf80f",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/18e73179c6a33d520de1b644941eba108dd811ad",
+                "reference": "18e73179c6a33d520de1b644941eba108dd811ad",
                 "shasum": ""
             },
             "require": {
@@ -4429,7 +4434,7 @@
             "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/browser-kit/tree/v5.4.2"
+                "source": "https://github.com/symfony/browser-kit/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4445,20 +4450,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T21:58:21+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e"
+                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a2c6b7ced2eb7799a35375fb9022519282b5405e",
-                "reference": "a2c6b7ced2eb7799a35375fb9022519282b5405e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
+                "reference": "a2a86ec353d825c75856c6fd14fac416a7bdb6b8",
                 "shasum": ""
             },
             "require": {
@@ -4528,7 +4533,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.2"
+                "source": "https://github.com/symfony/console/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4544,20 +4549,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-20T16:11:12+00:00"
+            "time": "2022-01-26T16:28:35+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "cfcbee910e159df402603502fe387e8b677c22fd"
+                "reference": "b0a190285cd95cb019237851205b8140ef6e368e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/cfcbee910e159df402603502fe387e8b677c22fd",
-                "reference": "cfcbee910e159df402603502fe387e8b677c22fd",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b0a190285cd95cb019237851205b8140ef6e368e",
+                "reference": "b0a190285cd95cb019237851205b8140ef6e368e",
                 "shasum": ""
             },
             "require": {
@@ -4594,7 +4599,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.4.2"
+                "source": "https://github.com/symfony/css-selector/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4610,7 +4615,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T21:58:21+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4681,16 +4686,16 @@
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "bb3bc3699779fc6d9646270789026a7e2cec7ec7"
+                "reference": "2634381fdf27a2a0a8ac8eb404025eb656c65d0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/bb3bc3699779fc6d9646270789026a7e2cec7ec7",
-                "reference": "bb3bc3699779fc6d9646270789026a7e2cec7ec7",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/2634381fdf27a2a0a8ac8eb404025eb656c65d0c",
+                "reference": "2634381fdf27a2a0a8ac8eb404025eb656c65d0c",
                 "shasum": ""
             },
             "require": {
@@ -4736,7 +4741,7 @@
             "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.2"
+                "source": "https://github.com/symfony/dom-crawler/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4752,20 +4757,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-28T17:15:56+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.0",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "27d39ae126352b9fa3be5e196ccf4617897be3eb"
+                "reference": "dec8a9f58d20df252b9cd89f1c6c1530f747685d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/27d39ae126352b9fa3be5e196ccf4617897be3eb",
-                "reference": "27d39ae126352b9fa3be5e196ccf4617897be3eb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dec8a9f58d20df252b9cd89f1c6c1530f747685d",
+                "reference": "dec8a9f58d20df252b9cd89f1c6c1530f747685d",
                 "shasum": ""
             },
             "require": {
@@ -4821,7 +4826,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4837,7 +4842,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-23T10:19:22+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4920,16 +4925,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e77046c252be48c48a40816187ed527703c8f76c"
+                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e77046c252be48c48a40816187ed527703c8f76c",
-                "reference": "e77046c252be48c48a40816187ed527703c8f76c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/231313534dded84c7ecaa79d14bc5da4ccb69b7d",
+                "reference": "231313534dded84c7ecaa79d14bc5da4ccb69b7d",
                 "shasum": ""
             },
             "require": {
@@ -4963,7 +4968,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.2"
+                "source": "https://github.com/symfony/finder/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -4979,7 +4984,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-15T11:06:13+00:00"
+            "time": "2022-01-26T16:34:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5094,12 +5099,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5175,12 +5180,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -5339,12 +5344,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -5418,12 +5423,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -5475,16 +5480,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "2b3ba8722c4aaf3e88011be5e7f48710088fb5e4"
+                "reference": "553f50487389a977eb31cf6b37faae56da00f753"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/2b3ba8722c4aaf3e88011be5e7f48710088fb5e4",
-                "reference": "2b3ba8722c4aaf3e88011be5e7f48710088fb5e4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/553f50487389a977eb31cf6b37faae56da00f753",
+                "reference": "553f50487389a977eb31cf6b37faae56da00f753",
                 "shasum": ""
             },
             "require": {
@@ -5517,7 +5522,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.2"
+                "source": "https://github.com/symfony/process/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5533,7 +5538,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-27T21:01:00+00:00"
+            "time": "2022-01-26T16:28:35+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5620,16 +5625,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d"
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
-                "reference": "e6a5d5ecf6589c5247d18e0e74e30b11dfd51a3d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/92043b7d8383e48104e411bc9434b260dbeb5a10",
+                "reference": "92043b7d8383e48104e411bc9434b260dbeb5a10",
                 "shasum": ""
             },
             "require": {
@@ -5686,7 +5691,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.2"
+                "source": "https://github.com/symfony/string/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5702,20 +5707,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T21:52:00+00:00"
+            "time": "2022-01-02T09:53:40+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "ff8bb2107b6a549dc3c5dd9c498dcc82c9c098ca"
+                "reference": "a9dd7403232c61e87e27fb306bbcd1627f245d70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/ff8bb2107b6a549dc3c5dd9c498dcc82c9c098ca",
-                "reference": "ff8bb2107b6a549dc3c5dd9c498dcc82c9c098ca",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a9dd7403232c61e87e27fb306bbcd1627f245d70",
+                "reference": "a9dd7403232c61e87e27fb306bbcd1627f245d70",
                 "shasum": ""
             },
             "require": {
@@ -5783,7 +5788,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.4.2"
+                "source": "https://github.com/symfony/translation/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5799,7 +5804,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-25T19:45:36+00:00"
+            "time": "2022-01-07T00:28:17+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5881,16 +5886,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v5.4.2",
+            "version": "v5.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "b9eb163846a61bb32dfc147f7859e274fab38b58"
+                "reference": "e80f87d2c9495966768310fc531b487ce64237a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b9eb163846a61bb32dfc147f7859e274fab38b58",
-                "reference": "b9eb163846a61bb32dfc147f7859e274fab38b58",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e80f87d2c9495966768310fc531b487ce64237a2",
+                "reference": "e80f87d2c9495966768310fc531b487ce64237a2",
                 "shasum": ""
             },
             "require": {
@@ -5936,7 +5941,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.4.2"
+                "source": "https://github.com/symfony/yaml/tree/v5.4.3"
             },
             "funding": [
                 {
@@ -5952,7 +5957,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-16T21:58:21+00:00"
+            "time": "2022-01-26T16:32:32+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -159,6 +159,12 @@ class CKWC_Order {
 			);
 		}
 
+		// The customer was subscribed to ConvertKit, so request a Plugin review.
+		// This can safely be called multiple times, as the review request
+		// class will ensure once a review request is dismissed by the user,
+		// it is never displayed again.
+		WP_CKWC()->get_class( 'review_request' )->request_review();
+
 	}
 
 	/**
@@ -371,6 +377,12 @@ class CKWC_Order {
 
 		// Add a note to the WooCommerce Order that the purchase data sent successfully.
 		$order->add_order_note( __( '[ConvertKit] Purchase Data sent successfully', 'woocommerce-convertkit' ) );
+
+		// The customer's purchase data was sent to ConvertKit, so request a Plugin review.
+		// This can safely be called multiple times, as the review request
+		// class will ensure once a review request is dismissed by the user,
+		// it is never displayed again.
+		WP_CKWC()->get_class( 'review_request' )->request_review();
 
 		// Return.
 		return $response;

--- a/includes/class-ckwc-review-request.php
+++ b/includes/class-ckwc-review-request.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * ConvertKit Review Request class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Displays a one time review request notification in the WordPress
+ * Administration interface.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+class CKWC_Review_Request {
+
+	/**
+	 * Holds the Plugin name.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     string
+	 */
+	private $plugin_name;
+
+	/**
+	 * Holds the Plugin slug.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     string
+	 */
+	private $plugin_slug;
+
+	/**
+	 * Holds the number of days after the Plugin requests a review to then
+	 * display the review notification in WordPress' Administration interface.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @var     int
+	 */
+	private $number_of_days_in_future = 3;
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   string $plugin_name    Plugin Name (e.g. ConvertKit).
+	 * @param   string $plugin_slug    Plugin Slug (e.g. convertkit).
+	 */
+	public function __construct( $plugin_name, $plugin_slug ) {
+
+		// Store the Plugin Name and Slug in the class.
+		$this->plugin_name = $plugin_name;
+		$this->plugin_slug = $plugin_slug;
+
+		// Register an AJAX action to dismiss the review.
+		add_action( 'wp_ajax_' . str_replace( '-', '_', $this->plugin_slug ) . '_dismiss_review', array( $this, 'dismiss_review' ) );
+
+		// Maybe display a review request in the WordPress Admin notices.
+		add_action( 'admin_notices', array( $this, 'maybe_display_review_request' ) );
+
+	}
+
+	/**
+	 * Displays a dismissible WordPress Administration notice requesting a review, if requested
+	 * by the main Plugin and the Review Request hasn't been disabled.
+	 *
+	 * @since   1.4.3
+	 */
+	public function maybe_display_review_request() {
+
+		// If we're not an Admin user, bail.
+		if ( ! function_exists( 'current_user_can' ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		// Don't display a review request on multisite.  This is so that existing Plugin
+		// users who existed prior to this feature don't get bombarded with the same
+		// notification across 100+ of their sites on a multisite network.
+		if ( is_multisite() ) {
+			return;
+		}
+
+		// If the review request was dismissed by the user, bail.
+		if ( $this->dismissed_review() ) {
+			return;
+		}
+
+		// If no review request has been set by the plugin, bail.
+		if ( ! $this->requested_review() ) {
+			return;
+		}
+
+		// If here, display the request for a review.
+		include_once CKWC_PLUGIN_PATH . '/views/backend/review/notice.php';
+
+	}
+
+	/**
+	 * Sets a flag in the options table requesting a review notification be displayed
+	 * in the WordPress Administration.
+	 *
+	 * @since   1.4.3
+	 */
+	public function request_review() {
+
+		// If a review has already been requested, bail.
+		$time = get_option( $this->plugin_slug . '-review-request' );
+		if ( ! empty( $time ) ) {
+			return;
+		}
+
+		// Request a review notification to be displayed beginning at a future timestamp.
+		update_option( $this->plugin_slug . '-review-request', time() + ( $this->number_of_days_in_future * DAY_IN_SECONDS ) );
+
+	}
+
+	/**
+	 * Flag to indicate whether a review has been requested by the Plugin,
+	 * and the minimum time has passed between the Plugin requesting a review
+	 * and now.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @return  bool    Review Requested
+	 */
+	public function requested_review() {
+
+		// Bail if no review was requested by the Plugin.
+		$start_displaying_review_at = get_option( $this->plugin_slug . '-review-request' );
+		if ( empty( $start_displaying_review_at ) ) {
+			return false;
+		}
+
+		// Bail if a review was requested by the Plugin, but it's too early to display it.
+		if ( $start_displaying_review_at > time() ) {
+			return false;
+		}
+
+		// The Plugin requested a review and it's time to display the notification.
+		return true;
+
+	}
+
+	/**
+	 * Dismisses the review notification, so it isn't displayed again.
+	 *
+	 * @since   1.4.3
+	 */
+	public function dismiss_review() {
+
+		update_option( $this->plugin_slug . '-review-dismissed', 1 );
+
+		// Send success response if called via AJAX.
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			wp_send_json_success( 1 );
+		}
+
+	}
+
+	/**
+	 * Flag to indicate whether a review request has been dismissed by the user.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @return  bool    Review Dismissed
+	 */
+	public function dismissed_review() {
+
+		return get_option( $this->plugin_slug . '-review-dismissed' );
+
+	}
+
+	/**
+	 * Returns the Review URL for this Plugin.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @return  string  Review URL
+	 */
+	public function get_review_url() {
+
+		return 'https://wordpress.org/support/plugin/' . $this->plugin_slug . '/reviews/?filter=5#new-post';
+
+	}
+
+	/**
+	 * Returns the Support URL for this Plugin.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @return  string  Review URL
+	 */
+	public function get_support_url() {
+
+		return 'https://convertkit.com/support';
+
+	}
+
+}

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -142,7 +142,8 @@ class WP_CKWC {
 	 */
 	private function initialize_global() {
 
-		$this->classes['order'] = new CKWC_Order();
+		$this->classes['order']          = new CKWC_Order();
+		$this->classes['review_request'] = new CKWC_Review_Request( 'ConvertKit for WooCommerce', 'convertkit-for-woocommerce' );
 
 		/**
 		 * Initialize integration classes for the frontend web site.

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -608,6 +608,18 @@ class Acceptance extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to delete option table rows for review requests.
+	 * Useful for resetting the review state between tests.
+	 * 
+	 * @since 	1.4.3
+	 */
+	public function deleteConvertKitReviewRequestOptions($I)
+	{
+		$I->dontHaveOptionInDatabase('convertkit-for-woocommerce-review-request');
+		$I->dontHaveOptionInDatabase('convertkit-for-woocommerce-review-dismissed');
+	}
+
+	/**
 	 * Check the given email address exists as a subscriber on ConvertKit.
 	 * 
 	 * @param 	AcceptanceTester $I 			AcceptanceTester

--- a/tests/acceptance/ReviewRequestCest.php
+++ b/tests/acceptance/ReviewRequestCest.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Tests the ConvertKit Review Notification.
+ * 
+ * @since 	1.4.3
+ */
+class ReviewRequestCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin($I);
+	}
+
+	/**
+	 * Test that the review request is set in the options table when a WooCommerce
+	 * Checkout is completed successfully.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestOnCheckoutWithOptInEnabled(AcceptanceTester $I)
+	{
+		// Clear options table settings for review request.
+		$I->deleteConvertKitReviewRequestOptions($I);
+
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			true, // Check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false // Don't send purchase data to ConvertKit
+		);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-for-woocommerce-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-for-woocommerce-review-dismissed');
+	}
+
+	/**
+	 * Test that the review request is not set in the options table when a WooCommerce
+	 * Checkout is completed successfully but the customer does not opt in.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestOnCheckoutWithOptInDisabled(AcceptanceTester $I)
+	{
+		// Clear options table settings for review request.
+		$I->deleteConvertKitReviewRequestOptions($I);
+
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			true, // Display Opt-In checkbox on Checkout
+			false, // Don't check Opt-In checkbox on Checkout
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
+			false // Don't send purchase data to ConvertKit
+		);
+
+		// Check that the options table does not have a review request set.
+		$I->dontSeeOptionInDatabase('convertkit-for-woocommerce-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-for-woocommerce-review-dismissed');
+	}
+
+	/**
+	 * Test that the review request is set in the options table when a WooCommerce
+	 * Checkout is completed successfully.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestOnCheckoutWithPurchaseDataEnabled(AcceptanceTester $I)
+	{
+		// Clear options table settings for review request.
+		$I->deleteConvertKitReviewRequestOptions($I);
+
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			false, // Don't display Opt-In checkbox on Checkout
+			false, // Don't check Opt-In checkbox on Checkout
+			false, // Form to subscribe email address to (not used)
+			false, // Subscribe Event
+			true // Send purchase data to ConvertKit
+		);
+
+		// Check that the options table does have a review request set.
+		$I->seeOptionInDatabase('convertkit-for-woocommerce-review-request');
+
+		// Check that the option table does not yet have a review dismissed set.
+		$I->dontSeeOptionInDatabase('convertkit-for-woocommerce-review-dismissed');
+	}
+
+	/**
+	 * Test that the review request is displayed when the options table entries
+	 * have the required values to display the review request notification.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
+	{
+		// Clear options table settings for review request.
+		$I->deleteConvertKitReviewRequestOptions($I);
+
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase('convertkit-for-woocommerce-review-request', time() - 3600 );
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review displays.
+		$I->seeElementInDOM('div.review-convertkit-for-woocommerce');
+
+		// Confirm links are correct.
+		$I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit-for-woocommerce/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
+		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
+	}
+
+	/**
+	 * Test that the review request is dismissed and does not reappear
+	 * on a subsequent page load.
+	 * 
+	 * @since 	1.4.3
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
+	{
+		// Clear options table settings for review request.
+		$I->deleteConvertKitReviewRequestOptions($I);
+
+		// Set review request option with a timestamp in the past, to emulate
+		// the Plugin having set this a few days ago.
+		$I->haveOptionInDatabase('convertkit-for-woocommerce-review-request', time() - 3600 );
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review displays.
+		$I->seeElementInDOM('div.review-convertkit-for-woocommerce');
+
+		// Dismiss the review request.
+		$I->click('div.review-convertkit-for-woocommerce button.notice-dismiss');
+
+		// Navigate to a screen in the WordPress Administration.
+		$I->amOnAdminPage('index.php');
+
+		// Confirm the review notification no longer displays.
+		$I->dontSeeElementInDOM('div.review-convertkit-for-woocommerce');
+	}
+}

--- a/views/backend/review/notice.php
+++ b/views/backend/review/notice.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Notification output for a review request.
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+
+<div class="notice notice-info is-dismissible review-<?php echo esc_attr( $this->plugin_slug ); ?>">
+	<p>
+		<?php
+		echo esc_html(
+			sprintf(
+				/* translators: Plugin Name */
+				__( 'We\'d be super grateful if you could spread the word about %s and give it a 5 star rating on WordPress?', 'woocommerce-convertkit' ),
+				$this->plugin_name
+			)
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_attr( $this->get_review_url() ); ?>" class="button button-primary" rel="noopener" target="_blank">
+			<?php esc_html_e( 'Yes, Leave Review', 'woocommerce-convertkit' ); ?>
+		</a>
+		<a href="<?php echo esc_attr( $this->get_support_url() ); ?>" class="button" rel="noopener" target="_blank">
+			<?php
+			echo esc_html(
+				sprintf(
+					/* translators: Plugin Name */
+					__( 'No, I\'m having issues with %s', 'woocommerce-convertkit' ),
+					$this->plugin_name
+				)
+			);
+			?>
+		</a>
+	</p>
+
+	<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			// Dismiss Review Notification.
+			$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).on( 'click', 'a, button.notice-dismiss', function( e ) {
+
+				// Do request
+				$.post( 
+					ajaxurl, 
+					{
+						action: '<?php echo esc_attr( str_replace( '-', '_', $this->plugin_slug ) ); ?>_dismiss_review',
+					},
+					function( response ) {
+					}
+				);
+
+				// Hide notice
+				$( 'div.review-<?php echo esc_attr( $this->plugin_slug ); ?>' ).hide();
+
+			} );
+		} );
+	</script>
+</div>
+

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -39,6 +39,7 @@ require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-forms.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-sequences.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-tags.php';
+require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-review-request.php';
 
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {


### PR DESCRIPTION
## Summary

Mirroring the main [ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/279), adds a notification in the WordPress Administration interface requesting the user leave a 5 star review on [wordpress.org](https://wordpress.org/support/plugin/convertkit-for-woocommerce/reviews/), to assist with the Plugin's ranking on search results within WordPress.

![Screenshot 2022-01-28 at 17 14 33](https://user-images.githubusercontent.com/1462305/151591906-75d1de18-5440-4a27-a5e6-2a13358e951e.png)

Clicking either button or the close button hides the notification for life; no other WordPress Administrator will see it.

Clicking `Yes, Leave Review` hides the notification, and opens a new browser tab at https://wordpress.org/support/plugin/convertkit-for-woocommerce/reviews/?filter=5#new-post
Clicking `No, I'm having issues with ConvertKit` opens a new browser tab at https://convertkit.com/support

This notification will only display when the following conditions are all met:
- The user is in the WordPress Administration interface,
- The user is an Administrator (lower roles, such as Editor or Author will not see this notification),
- A WooCommerce Checkout successfully completes, resulting in the customer either being subscribed to ConvertKit or their Purchase Data is sent successfully to ConvertKit
- It has been at least 3 days since an action was performed (this is to avoid bombarding the user with notifications so soon after using the Plugin)
- The notification has not previously been dismissed.
- The site is not a Multisite installation (Multisite allows multiple sites within a single WordPress instance; showing notifications on every site would therefore be frustrating for the site owner who most likely controls all sites in the single WordPress instance).

The conditions are deliberately restrictive, to avoid aggressively and persistently asking the user for a review, and to prevent us adding to the potential large number of notifications that various Themes and Plugins add to WordPress' Administration interface: https://wptavern.com/new-dobby-plugin-captures-and-hides-unwanted-wordpress-admin-notices

## Testing

- ReviewRequestCest: Tests to ensure the notification displays, or does not display, depending on the actions performed. Also tests that the notification never displays once dismissed.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)