### PR TITLE
Change Subscription "Order Created" label to "Order Pending payment"

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -136,27 +136,30 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
-				'description' => implode('<br />', array(
-					__( 'When should customers be subscribed?', 'woocommerce-convertkit' ),
-					sprintf(
-						/* translators: %1$s: Status name, %2$s: Status description */
-						'<strong>%1$s</strong> %2$s',
-						__( 'Pending payment:', 'woocommerce-convertkit' ),
-						__( 'WooCommerce order created, payment not received.', 'woocommerce-convertkit' )
-					),
-					sprintf(
-						/* translators: %1$s: Status name, %2$s: Status description */
-						'<strong>%1$s</strong> %2$s',
-						__( 'Processing:', 'woocommerce-convertkit' ),
-						__( 'WooCommerce order created, payment received, order awaiting fulfilment.', 'woocommerce-convertkit' )
-					),
-					sprintf(
-						/* translators: %1$s: Status name, %2$s: Status description */
-						'<strong>%1$s</strong> %2$s',
-						__( 'Completed:', 'woocommerce-convertkit' ),
-						__( 'WooCommerce order created, payment received, order fulfiled.', 'woocommerce-convertkit' )
-					),
-				) ),
+				'description' => implode(
+					'<br />',
+					array(
+						__( 'When should customers be subscribed?', 'woocommerce-convertkit' ),
+						sprintf(
+							/* translators: %1$s: Status name, %2$s: Status description */
+							'<strong>%1$s</strong> %2$s',
+							__( 'Pending payment:', 'woocommerce-convertkit' ),
+							__( 'WooCommerce order created, payment not received.', 'woocommerce-convertkit' )
+						),
+						sprintf(
+							/* translators: %1$s: Status name, %2$s: Status description */
+							'<strong>%1$s</strong> %2$s',
+							__( 'Processing:', 'woocommerce-convertkit' ),
+							__( 'WooCommerce order created, payment received, order awaiting fulfilment.', 'woocommerce-convertkit' )
+						),
+						sprintf(
+							/* translators: %1$s: Status name, %2$s: Status description */
+							'<strong>%1$s</strong> %2$s',
+							__( 'Completed:', 'woocommerce-convertkit' ),
+							__( 'WooCommerce order created, payment received, order fulfiled.', 'woocommerce-convertkit' )
+						),
+					)
+				),
 				'desc_tip'    => false,
 				'options'     => array(
 					'pending'    => __( 'Order Pending payment', 'woocommerce-convertkit' ),

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -136,10 +136,30 @@ class CKWC_Integration extends WC_Integration {
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
-				'description' => __( 'When should customers be subscribed?', 'woocommerce-convertkit' ),
+				'description' => implode('<br />', array(
+					__( 'When should customers be subscribed?', 'woocommerce-convertkit' ),
+					sprintf(
+						/* translators: %1$s: Status name, %2$s: Status description */
+						'<strong>%1$s</strong> %2$s',
+						__( 'Pending payment:', 'woocommerce-convertkit' ),
+						__( 'WooCommerce order created, payment not received.', 'woocommerce-convertkit' )
+					),
+					sprintf(
+						/* translators: %1$s: Status name, %2$s: Status description */
+						'<strong>%1$s</strong> %2$s',
+						__( 'Processing:', 'woocommerce-convertkit' ),
+						__( 'WooCommerce order created, payment received, order awaiting fulfilment.', 'woocommerce-convertkit' )
+					),
+					sprintf(
+						/* translators: %1$s: Status name, %2$s: Status description */
+						'<strong>%1$s</strong> %2$s',
+						__( 'Completed:', 'woocommerce-convertkit' ),
+						__( 'WooCommerce order created, payment received, order fulfiled.', 'woocommerce-convertkit' )
+					),
+				) ),
 				'desc_tip'    => false,
 				'options'     => array(
-					'pending'    => __( 'Order Created', 'woocommerce-convertkit' ),
+					'pending'    => __( 'Order Pending payment', 'woocommerce-convertkit' ),
 					'processing' => __( 'Order Processing', 'woocommerce-convertkit' ),
 					'completed'  => __( 'Order Completed', 'woocommerce-convertkit' ),
 				),

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -261,9 +261,9 @@ class Acceptance extends \Codeception\Module
 		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are 
 		// saved and the Forms, Tags and Sequences are listed.
 		if ($pluginFormTagSequence) {
-      $I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
+			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
 		} else {
-      $I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
+			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
 		}
 
 		// Define Order to Custom Field mappings, now that the API credentials are 

--- a/tests/acceptance/SettingNameFormatCest.php
+++ b/tests/acceptance/SettingNameFormatCest.php
@@ -55,7 +55,7 @@ class SettingNameFormatCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -80,7 +80,7 @@ class SettingNameFormatCest
 	 */
 	public function testNameFormatBillingLastName(AcceptanceTester $I)
 	{
-		// Set Name Format = Billing First Name
+		// Set Name Format = Billing Last Name
 		$I->selectOption('#woocommerce_ckwc_name_format', 'Billing Last Name');
 
 		// Save
@@ -99,7 +99,7 @@ class SettingNameFormatCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -143,7 +143,7 @@ class SettingNameFormatCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 

--- a/tests/acceptance/SettingSubscribeEventCest.php
+++ b/tests/acceptance/SettingSubscribeEventCest.php
@@ -8,7 +8,7 @@
  * 
  * @since 	1.4.2
  */
-class SettingSubscribeEventsCest
+class SettingSubscribeEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -23,20 +23,20 @@ class SettingSubscribeEventsCest
 	}
 
 	/**
-	 * Test that the Order Created option is saved when selected at
+	 * Test that the Order Pending payment option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit.
 	 * 
 	 * @since 	1.4.2
 	 * 
 	 * @param 	AcceptanceTester 	$I 	Tester
 	 */
-	public function testOrderCreatedWithoutOptInCheckbox(AcceptanceTester $I)
+	public function testOrderPendingPaymentWithoutOptInCheckbox(AcceptanceTester $I)
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
-		// Set Subscribe Event = Order Created.
-		$I->selectOption('#woocommerce_ckwc_event', 'Order Created');
+		// Set Subscribe Event = Order Pending payment.
+		$I->selectOption('#woocommerce_ckwc_event', 'Order Pending payment');
 
 		// Save.
 		$I->click('Save changes');
@@ -45,7 +45,7 @@ class SettingSubscribeEventsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm the setting saved.
-		$I->seeOptionIsSelected('#woocommerce_ckwc_event', 'Order Created');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_event', 'Order Pending payment');
 			
 	}
 	/**

--- a/tests/acceptance/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/SubscribeOnOrderPendingPaymentEventCest.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form
- * or Tag on the Order Created event when an order is placed through WooCommerce.
+ * or Tag on the Order Pending payment (i.e. Order created) event when an order is placed through WooCommerce.
  * 
  * @since 	1.4.2
  */
-class SubscribeOnOrderCreatedEventCest
+class SubscribeOnOrderPendingPaymentEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -46,7 +46,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -77,7 +77,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			false, // Don't check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -107,7 +107,7 @@ class SubscribeOnOrderCreatedEventCest
 			false, // Don't display Opt-In checkbox on Checkout
 			false, // Don't check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -139,7 +139,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false, // Don't send purchase data to ConvertKit
 			false, // Don't define a Product level Form, Tag or Sequence
 			true // Map Order data to Custom Fields
@@ -176,7 +176,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false, // Don't send purchase data to ConvertKit
 			false, // Don't define a Product level Form, Tag or Sequence
 			true // Map Order data to Custom Fields
@@ -213,7 +213,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to
-			'Order Created', // Subscribe on WooCommerce "Order Processing" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false, // Don't send purchase data to ConvertKit
 			false, // Don't define a Product level Form, Tag or Sequence
 			true // Map Order data to Custom Fields
@@ -250,7 +250,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			true, // Check Opt-In checkbox on Checkout
 			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -282,7 +282,7 @@ class SubscribeOnOrderCreatedEventCest
 			true, // Display Opt-In checkbox on Checkout
 			false, // Don't check Opt-In checkbox on Checkout
 			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 
@@ -313,7 +313,7 @@ class SubscribeOnOrderCreatedEventCest
 			false, // Don't display Opt-In checkbox on Checkout
 			false, // Don't check Opt-In checkbox on Checkout
 			'Select a subscription option...', // Don't select a Form to subscribe the email address to
-			'Order Created', // Subscribe on WooCommerce "Order Created" event
+			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event
 			false // Don't send purchase data to ConvertKit
 		);
 


### PR DESCRIPTION
## Summary

WooCommerce Orders don't have a "Created" status.  When an Order is created, it is initially assigned the "Pending payment" status.

![Screenshot 2022-02-15 at 14 13 06](https://user-images.githubusercontent.com/1462305/154091305-77a24948-3feb-42b0-b58e-00db5384e157.png)

This PR changes the integration's settings to match the same labels as used in WooCommerce Orders, and adds a more verbose description to the settings field to reflect https://woocommerce.com/document/managing-orders/

![Screenshot 2022-02-15 at 15 18 53](https://user-images.githubusercontent.com/1462305/154091901-2b0d24d6-4bd5-4d2b-ad26-c837b754f1d9.png)

The underlying setting field's value, `pending` is accurate, and does not need to be changed.

## Testing

- `SettingNameFormatCest`: Use 'Order Payment processing' instead of 'Order Created' when selecting the Subscription Event by its label
- `SettingSubscribeEventCest`: Updated tests to use 'Order Payment processing' instead of 'Order Created' when selecting the Subscription Event by its label
- `SubscribeOnOrderPendingPaymentEventCest`: Again, use 'Order Payment processing' instead of 'Order Created' when selecting the Subscription Event by its label

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)