### PR TITLE
Purchase Data Event Option

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -313,6 +313,37 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
+			'send_purchases_event'          => array(
+				'title'       => __( 'Purchase Data Event', 'woocommerce-convertkit' ),
+				'type'        => 'select',
+				'default'     => 'processing',
+				'description' => implode(
+					'<br />',
+					array(
+						__( 'When should purchase data be sent?', 'woocommerce-convertkit' ),
+						sprintf(
+							/* translators: %1$s: Status name, %2$s: Status description */
+							'<strong>%1$s</strong> %2$s',
+							__( 'Processing:', 'woocommerce-convertkit' ),
+							__( 'WooCommerce order created, payment received, order awaiting fulfilment.', 'woocommerce-convertkit' )
+						),
+						sprintf(
+							/* translators: %1$s: Status name, %2$s: Status description */
+							'<strong>%1$s</strong> %2$s',
+							__( 'Completed:', 'woocommerce-convertkit' ),
+							__( 'WooCommerce order created, payment received, order fulfiled.', 'woocommerce-convertkit' )
+						),
+					)
+				),
+				'desc_tip'    => false,
+				'options'     => array(
+					'processing' => __( 'Order Processing', 'woocommerce-convertkit' ),
+					'completed'  => __( 'Order Completed', 'woocommerce-convertkit' ),
+				),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe send_purchases',
+			),
 
 			// Debugging.
 			'debug'                         => array(

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -290,6 +290,16 @@ class CKWC_Order {
 	 */
 	public function send_purchase_data( $order_id, $status_old = 'new', $status_new = 'pending' ) {
 
+		// Bail if the old and new status are the same i.e. the Order status did not change.
+		if ( $status_old === $status_new ) {
+			return;
+		}
+
+		// Bail if the Purchase Data Event doesn't match the Order's status.
+		if ( $this->integration->get_option( 'send_purchases_event' ) !== $status_new ) {
+			return;
+		}
+
 		// Get WooCommerce Order.
 		$order = wc_get_order( $order_id );
 

--- a/resources/backend/js/integration.js
+++ b/resources/backend/js/integration.js
@@ -9,6 +9,7 @@
 var ckwcSettings = {
 	'enabled': false,
 	'display_opt_in': false,
+	'send_purchases': false
 };
 
 /**
@@ -30,6 +31,7 @@ jQuery( document ).ready(
 		ckwcSettings = {
 			'enabled': $( 'input[name="woocommerce_ckwc_enabled"]' ).prop( 'checked' ),
 			'display_opt_in': $( 'input[name="woocommerce_ckwc_display_opt_in"]' ).prop( 'checked' ),
+			'send_purchases': $( 'input[name="woocommerce_ckwc_send_purchases"]' ).prop( 'checked' )
 		};
 
 		// Refresh UI.
@@ -73,7 +75,7 @@ function ckwcRefreshUI() {
 				$( 'table.form-table tr' ).each(
 					function() {
 						// Skip if this table row is for the setting we've just checked/unchecked.
-						if ( $( '[id^="woocommerce_ckwc_' + setting + '"]', $( this ) ).length > 0 ) {
+						if ( $( '[id="woocommerce_ckwc_' + setting + '"]', $( this ) ).length > 0 ) {
 							return;
 						}
 

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -320,7 +320,12 @@ class Acceptance extends \Codeception\Module
 
 		// Define Send Purchase Data setting.
 		if ($sendPurchaseData) {
-			$I->checkOption('#woocommerce_ckwc_send_purchases');	
+			$I->checkOption('#woocommerce_ckwc_send_purchases');
+
+			// If sendPurchaseData is true, set send purchase data event to processing.
+			// Otherwise set to the string value of sendPurchaseData i.e. completed.
+			$sendPurchaseDataEvent = (($sendPurchaseData === true) ? 'processing' : $sendPurchaseData);
+			$I->selectOption('#woocommerce_ckwc_send_purchases_event', $sendPurchaseDataEvent);
 		} else {
 			$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 		}

--- a/tests/acceptance/PurchaseDataCest.php
+++ b/tests/acceptance/PurchaseDataCest.php
@@ -699,6 +699,46 @@ class PurchaseDataCest
 	}
 
 	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Send Purchase Data Event is set to Order Completed, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 * 
+	 * @since 	1.4.2
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testSendPurchaseDataOnOrderCompletedWithSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product
+			false, // Don't display Opt-In checkbox on Checkout
+			false, // Don't check Opt-In checkbox on Checkout
+			false, // Form to subscribe email address to (not used)
+			false, // Subscribe Event
+			'Order Completed' // Send purchase data to ConvertKit when the Order status = Order Completed
+		);
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+
+		// Change Order Status = Completed.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.


### PR DESCRIPTION
## Summary

Purchase data would be sent when the Order's status is first transitioned.  Whilst a WooCommerce Order's first status transition should typically transition from _pending_ to _processing_, some third party WooCommerce Plugins may transition Orders from e.g. _pending_ to _cancelled_, resulting in purchase data being sent to ConvertKit when it isn't needed, [as reported here](https://github.com/ConvertKit/tier3-issues/issues/2078).

This PR:
- Defaults sending purchase data when the WooCommerce Order's status is transitioned to _processing_
- Adds a Purchase Data Event option to determine when purchase data should be sent to ConvertKit, based on the Order's status (either _processing_ or _completed_), allowing store owners to choose if they'd prefer to only send purchase data to ConvertKit once an Order is fulfilled / marked as completed by the store owner:
![Screenshot 2022-03-11 at 15 36 12](https://user-images.githubusercontent.com/1462305/157899354-e88edcf0-3793-4ec8-86e9-00c4e9eaa14b.png)

## Testing

- `PurchaseDataCest:testSendPurchaseDataOnOrderCompletedWithSimpleProductCheckout`: Tests that purchase data is sent when an Order is marked as completed, if the Plugin is configured to only send purchase data on the completed status.
- `PurchaseDataCest:testSendPurchaseDataOnOrderCancelledWithSimpleProductCheckout`: Tests that purchase data is not sent when an Order is marked as cancelled

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)