### PR TITLE
Add PHPStan for Static Analysis

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -15,12 +15,10 @@ codeception.dist.yml
 codeception.yml
 composer.json
 composer.lock
-convertkit.zip
-DEPLOYMENT.md
-DEVELOPMENT.md
+convertkit-for-woocommerce.zip
 LICENSE
-log.txt
 phpcs.xml
+phpstan.neon
+phpstan.neon.dist
+phpstan.neon.example
 README.md
-SETUP.md
-TESTING.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,6 +198,11 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: php vendor/bin/phpcs ./ -v
 
+      # Run PHPStan for static analysis.
+      - name: Run PHPStan Static Analysis
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpstan --memory-limit=512M
+
       # Build Codeception Tests.
       - name: Build Tests
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+.DS_Store
 .env
 .env.testing
-.DS_Store
+codeception.yml
+composer.lock
 log.txt
+phpstan.neon
 tests/_output
 vendor
-codeception.yml
 *.zip

--- a/admin/class-ckwc-admin-ajax.php
+++ b/admin/class-ckwc-admin-ajax.php
@@ -16,6 +16,15 @@
 class CKWC_Admin_AJAX {
 
 	/**
+	 * Holds the WooCommerce Integration instance for this Plugin.
+	 *
+	 * @since   1.4.5
+	 *
+	 * @var     CKWC_Integration
+	 */
+	private $integration;
+
+	/**
 	 * Constructor
 	 *
 	 * @since   1.0.0

--- a/admin/class-ckwc-admin-product.php
+++ b/admin/class-ckwc-admin-product.php
@@ -20,7 +20,7 @@ class CKWC_Admin_Product {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @var     WC_Integration
+	 * @var     CKWC_Integration
 	 */
 	private $integration;
 
@@ -71,7 +71,7 @@ class CKWC_Admin_Product {
 		}
 
 		// Enqueue CSS.
-		wp_enqueue_style( 'ckwc-product', CKWC_PLUGIN_URL . '/resources/backend/css/product.css', false, CKWC_PLUGIN_VERSION );
+		wp_enqueue_style( 'ckwc-product', CKWC_PLUGIN_URL . '/resources/backend/css/product.css', array(), CKWC_PLUGIN_VERSION );
 
 		// Enqueue Select2 CSS.
 		ckwc_select2_enqueue_styles();

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
         "codeception/util-universalframework": "^1.0",
         "squizlabs/php_codesniffer": "3.*",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*"
+        "wp-coding-standards/wpcs": "*",
+        "phpstan/phpstan": "^1.4",
+        "szepeviktor/phpstan-wordpress": "^1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -17,23 +17,23 @@ class CKWC_API {
 	/**
 	 * ConvertKit API Key
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_key;
+	protected $api_key = false;
 
 	/**
 	 * ConvertKit API Secret
 	 *
-	 * @var string
+	 * @var mixed   bool | string
 	 */
-	protected $api_secret;
+	protected $api_secret = false;
 
 	/**
 	 * Save debug data to log
 	 *
-	 * @var  string
+	 * @var  bool
 	 */
-	protected $debug;
+	protected $debug = false;
 
 	/**
 	 * Version of ConvertKit API
@@ -61,9 +61,9 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @param   string $api_key        ConvertKit API Key.
-	 * @param   string $api_secret     ConvertKit API Secret.
-	 * @param   string $debug          Save data to log.
+	 * @param   mixed $api_key        ConvertKit API Key.
+	 * @param   mixed $api_secret     ConvertKit API Secret.
+	 * @param   bool  $debug         Save data to log.
 	 */
 	public function __construct( $api_key = false, $api_secret = false, $debug = false ) {
 
@@ -80,7 +80,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function account() {
 
@@ -100,7 +100,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscription_forms() {
 
@@ -121,7 +121,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_forms() {
 
@@ -145,16 +145,16 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @param   string $form_id    Form ID.
+	 * @param   int    $form_id       Form ID.
 	 * @param   string $email      Email Address.
 	 * @param   string $first_name First Name.
 	 * @param   mixed  $fields     Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function form_subscribe( $form_id, $email, $first_name = '', $fields = false ) {
 
 		// Backward compat. if $email is an array comprising of email and name keys.
-		if ( is_array( $email ) ) {
+		if ( is_array( $email ) ) { // @phpstan-ignore-line.
 			_deprecated_function( __FUNCTION__, '1.4.2', 'form_subscribe( $form_id, $email, $first_name )' );
 			$first_name = $email['name'];
 			$email      = $email['email'];
@@ -163,7 +163,7 @@ class CKWC_API {
 		$this->log( 'API: form_subscribe(): [ form_id: ' . $form_id . ', email: ' . $email . ', first_name: ' . $first_name . ' ]' );
 
 		// Sanitize some parameters.
-		$form_id    = trim( $form_id );
+		$form_id    = absint( $form_id );
 		$email      = trim( $email );
 		$first_name = trim( $first_name );
 
@@ -200,7 +200,7 @@ class CKWC_API {
 		 * @since   1.4.2
 		 *
 		 * @param   array   $response   API Response
-		 * @param   string  $form_id    Form ID
+		 * @param   int     $form_id    Form ID
 		 * @param   string  $email      Email Address
 		 * @param   string  $first_name First Name
 		 * @param   mixed   $fields     Custom Fields (false|array)
@@ -216,7 +216,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_landing_pages() {
 
@@ -240,7 +240,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_sequences() {
 
@@ -264,11 +264,11 @@ class CKWC_API {
 
 		// If no sequences exist, return WP_Error.
 		if ( ! isset( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'woocommerce-convertkit' ) );
 		}
 		if ( ! count( $response['courses'] ) ) {
-			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_sequences(): Error: No sequences exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No sequences exist in ConvertKit. Visit your ConvertKit account and create your first sequence.', 'woocommerce-convertkit' ) );
 		}
 
@@ -285,18 +285,18 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @param   string $sequence_id Sequence ID.
+	 * @param   int    $sequence_id Sequence ID.
 	 * @param   string $email       Email Address.
 	 * @param   string $first_name  First Name.
 	 * @param   mixed  $fields      Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function sequence_subscribe( $sequence_id, $email, $first_name = '', $fields = false ) {
 
 		$this->log( 'API: sequence_subscribe(): [ sequence_id: ' . $sequence_id . ', email: ' . $email . ']' );
 
 		// Sanitize some parameters.
-		$sequence_id = trim( $sequence_id );
+		$sequence_id = absint( $sequence_id );
 		$email       = trim( $email );
 		$first_name  = trim( $first_name );
 
@@ -333,7 +333,7 @@ class CKWC_API {
 		 * @since   1.4.2
 		 *
 		 * @param   array   $response       API Response
-		 * @param   string  $sequence_id    Sequence ID
+		 * @param   int     $sequence_id    Sequence ID
 		 * @param   string  $email          Email Address
 		 * @param   mixed   $fields         Custom Fields (false|array)
 		 */
@@ -348,7 +348,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_tags() {
 
@@ -372,11 +372,11 @@ class CKWC_API {
 
 		// If no tags exist, return WP_Error.
 		if ( ! isset( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'woocommerce-convertkit' ) );
 		}
 		if ( ! count( $response['tags'] ) ) {
-			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_tags(): Error: No tags exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No tags exist in ConvertKit. Visit your ConvertKit account and create your first tag.', 'woocommerce-convertkit' ) );
 		}
 
@@ -393,18 +393,18 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @param   string $tag_id     Tag ID.
+	 * @param   int    $tag_id     Tag ID.
 	 * @param   string $email      Email Address.
 	 * @param   string $first_name First Name.
 	 * @param   mixed  $fields     Custom Fields (false|array).
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function tag_subscribe( $tag_id, $email, $first_name = '', $fields = false ) {
 
 		$this->log( 'API: tag_subscribe(): [ tag_id: ' . $tag_id . ', email: ' . $email . ']' );
 
 		// Sanitize some parameters.
-		$tag_id     = trim( $tag_id );
+		$tag_id     = absint( $tag_id );
 		$email      = trim( $email );
 		$first_name = trim( $first_name );
 
@@ -441,7 +441,7 @@ class CKWC_API {
 		 * @since   1.4.2
 		 *
 		 * @param   array   $response   API Response
-		 * @param   string  $tag_id     Tag ID
+		 * @param   int     $tag_id     Tag ID
 		 * @param   string  $email      Email Address
 		 * @param   mixed   $fields     Custom Fields (false|array).
 		 */
@@ -457,7 +457,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   string $email  Email Address.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_by_email( $email ) {
 
@@ -512,14 +512,14 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   int $subscriber_id  Subscriber ID.
-	 * @return  mixed                   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_by_id( $subscriber_id ) {
 
 		$this->log( 'API: get_subscriber_by_id(): [ subscriber_id: ' . $subscriber_id . ']' );
 
 		// Sanitize some parameters.
-		$subscriber_id = trim( $subscriber_id );
+		$subscriber_id = absint( $subscriber_id );
 
 		// Return error if no Subscriber ID is specified.
 		if ( empty( $subscriber_id ) ) {
@@ -566,14 +566,14 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   int $subscriber_id  Subscriber ID.
-	 * @return  mixed                   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber_tags( $subscriber_id ) {
 
 		$this->log( 'API: get_subscriber_tags(): [ subscriber_id: ' . $subscriber_id . ']' );
 
 		// Sanitize some parameters.
-		$subscriber_id = trim( $subscriber_id );
+		$subscriber_id = absint( $subscriber_id );
 
 		// Return error if no Subscriber ID is specified.
 		if ( empty( $subscriber_id ) ) {
@@ -620,7 +620,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   string $email_address  Email Address.
-	 * @return  mixed                   WP_Error | int
+	 * @return  WP_Error|int
 	 */
 	public function get_subscriber_id( $email_address ) {
 
@@ -643,7 +643,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   string $email      Email Address.
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function unsubscribe( $email ) {
 
@@ -689,9 +689,9 @@ class CKWC_API {
 	/**
 	 * Gets all custom fields from the API.
 	 *
-	 * @since   1.4.4
+	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_custom_fields() {
 
@@ -715,11 +715,11 @@ class CKWC_API {
 
 		// If no custom fields exist, return WP_Error.
 		if ( ! isset( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'woocommerce-convertkit' ) );
 		}
 		if ( ! count( $response['custom_fields'] ) ) {
-			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.', 'woocommerce-convertkit' );
+			$this->log( 'API: get_custom_fields(): Error: No custom fields exist in ConvertKit.' );
 			return new WP_Error( 'convertkit_api_error', __( 'No custom fields exist in ConvertKit. Visit your ConvertKit account and create your first custom field.', 'woocommerce-convertkit' ) );
 		}
 
@@ -737,7 +737,7 @@ class CKWC_API {
 	 * This isn't specifically an API function, but for now it's best suited here.
 	 *
 	 * @param   int $id     Form ID.
-	 * @return  string          HTML
+	 * @return  WP_Error|string     HTML
 	 */
 	public function get_form_html( $id ) {
 
@@ -773,7 +773,7 @@ class CKWC_API {
 		// Inject JS for subscriber forms to work.
 		$scripts = new WP_Scripts();
 		$script  = "<script type='text/javascript' src='" . trailingslashit( $scripts->base_url ) . "wp-includes/js/jquery/jquery.js?ver=1.4.0'></script>"; // phpcs:ignore
-		$script .= "<script type='text/javascript' src='" . CKWC_PLUGIN_VERSION . 'resources/frontend/js/convertkit.js?ver=' . CKWC_PLUGIN_VERSION . "'></script>"; // phpcs:ignore
+		$script .= "<script type='text/javascript' src='" . CKWC_PLUGIN_URL . 'resources/frontend/js/convertkit.js?ver=' . CKWC_PLUGIN_VERSION . "'></script>"; // phpcs:ignore
 		$script .= "<script type='text/javascript'>/* <![CDATA[ */var convertkit = {\"ajaxurl\":\"" . admin_url( 'admin-ajax.php' ) . '"};/* ]]> */</script>'; // phpcs:ignore
 
 		$body = str_replace( '</head>', '</head>' . $script, $body );
@@ -788,7 +788,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   array $purchase   Purchase Data.
-	 * @return  mixed               WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function purchase_create( $purchase ) {
 
@@ -831,12 +831,12 @@ class CKWC_API {
 	public function update_resources( $api_key, $api_secret ) { // phpcs:ignore
 
 		// Warn the developer that they shouldn't use this function.
-		_deprecated_function( __FUNCTION__, '1.4.2', 'refresh() in CKWC_Resource_Forms, CKWC_Resource_Landing_Pages and CKWC_Resource_Tags classes.' );
+		_deprecated_function( __FUNCTION__, '1.4.2', 'refresh() in ConvertKit_Resource_Forms, ConvertKit_Resource_Landing_Pages and ConvertKit_Resource_Tags classes.' );
 
 		// Initialize resource classes.
-		$forms         = new CKWC_Resource_Forms();
-		$landing_pages = new CKWC_Resource_Landing_Pages();
-		$tags          = new CKWC_Resource_Tags();
+		$forms         = new ConvertKit_Resource_Forms();
+		$landing_pages = new ConvertKit_Resource_Landing_Pages();
+		$tags          = new ConvertKit_Resource_Tags();
 
 		// Refresh resources by calling the API and storing the results.
 		$forms->refresh();
@@ -851,7 +851,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   int $id     Subscriber ID.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function get_subscriber( $id ) {
 
@@ -870,7 +870,7 @@ class CKWC_API {
 	 *
 	 * @param   int   $tag    Tag ID.
 	 * @param   array $args   Arguments.
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function add_tag( $tag, $args ) {
 
@@ -888,7 +888,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   string $url    URL.
-	 * @return  mixed           WP_Error | string
+	 * @return  WP_Error|string
 	 */
 	public function get_resource( $url ) {
 
@@ -906,7 +906,7 @@ class CKWC_API {
 	 * @since   1.4.2
 	 *
 	 * @param   array $args   Arguments (single email key).
-	 * @return  mixed           WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	public function form_unsubscribe( $args ) {
 
@@ -925,7 +925,7 @@ class CKWC_API {
 	 *
 	 * @param   string $url    URL of Form or Landing Page.
 	 * @param   bool   $body_only   Return HTML between <body> and </body> tags only.
-	 * @return  string          HTML
+	 * @return  WP_Error|string
 	 */
 	private function get_html( $url, $body_only = true ) {
 
@@ -999,7 +999,7 @@ class CKWC_API {
 	/**
 	 * Determines if the given string is JSON.
 	 *
-	 * @since   1.4.4
+	 * @since   1.4.2
 	 *
 	 * @param   string $string     Possible JSON String.
 	 * @return  bool                Is JSON String.
@@ -1017,9 +1017,9 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @param   array  $elements   Elements.
-	 * @param   string $attribute  HTML Attribute.
-	 * @param   string $url        Absolute URL to prepend to relative URLs.
+	 * @param   DOMNodeList<DOMElement> $elements   Elements.
+	 * @param   string                  $attribute  HTML Attribute.
+	 * @param   string                  $url        Absolute URL to prepend to relative URLs.
 	 */
 	private function convert_relative_to_absolute_urls( $elements, $attribute, $url ) {
 
@@ -1050,7 +1050,7 @@ class CKWC_API {
 	/**
 	 * Strips <html>, <head> and <body> opening and closing tags from the given markup.
 	 *
-	 * @since   1.4.4
+	 * @since   1.4.2
 	 *
 	 * @param   string $markup     HTML Markup.
 	 * @return  string              HTML Markup
@@ -1073,7 +1073,7 @@ class CKWC_API {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @return  mixed   WP_Error | array
+	 * @return  WP_Error|array
 	 */
 	private function get_forms_landing_pages() {
 
@@ -1132,7 +1132,7 @@ class CKWC_API {
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
-	 * @return  mixed                   WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function get( $endpoint, $params ) {
 
@@ -1147,7 +1147,7 @@ class CKWC_API {
 	 *
 	 * @param   string $endpoint       API Endpoint.
 	 * @param   array  $params         Params.
-	 * @return  mixed                   WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function post( $endpoint, $params ) {
 
@@ -1164,7 +1164,7 @@ class CKWC_API {
 	 * @param   string $method                  HTTP Method (optional).
 	 * @param   mixed  $params                  Params (array|boolean|string).
 	 * @param   bool   $retry_if_rate_limit_hit Retry request if rate limit hit.
-	 * @return  mixed                           WP_Error | object
+	 * @return  WP_Error|array
 	 */
 	private function request( $endpoint, $method = 'get', $params = array(), $retry_if_rate_limit_hit = true ) {
 
@@ -1192,6 +1192,17 @@ class CKWC_API {
 						'body'            => wp_json_encode( $params ),
 						'timeout'         => $this->get_timeout(),
 						'user-agent'      => $this->get_user_agent(),
+					)
+				);
+				break;
+
+			default:
+				$result = new WP_Error(
+					'convertkit_api_error',
+					sprintf(
+						/* translators: HTTP method */
+						__( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
+						$method
 					)
 				);
 				break;
@@ -1264,11 +1275,13 @@ class CKWC_API {
 	 */
 	private function get_user_agent() {
 
+		global $wp_version;
+
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';
 
 		return sprintf(
-			'WordPress/%1$s;PHP/%2$s;ConvertKitWooCommerce/%3$s;%4$s',
+			'WordPress/%1$s;PHP/%2$s;ConvertKit/%3$s;%4$s',
 			$wp_version,
 			phpversion(),
 			CKWC_PLUGIN_VERSION,
@@ -1294,7 +1307,7 @@ class CKWC_API {
 	/**
 	 * Adds the supplied array of parameters as query arguments to the URL.
 	 *
-	 * @since   1.4.4
+	 * @since   1.4.2
 	 *
 	 * @param   string $url        URL.
 	 * @param   array  $params     Parameters for request.

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -821,31 +821,6 @@ class CKWC_API {
 	}
 
 	/**
-	 * Backward compat. function for updating Forms, Landing Pages and Tags in WordPress options table.
-	 *
-	 * @since   1.0.0
-	 *
-	 * @param   string $api_key    API Key.
-	 * @param   string $api_secret API Secret.
-	 */
-	public function update_resources( $api_key, $api_secret ) { // phpcs:ignore
-
-		// Warn the developer that they shouldn't use this function.
-		_deprecated_function( __FUNCTION__, '1.4.2', 'refresh() in ConvertKit_Resource_Forms, ConvertKit_Resource_Landing_Pages and ConvertKit_Resource_Tags classes.' );
-
-		// Initialize resource classes.
-		$forms         = new ConvertKit_Resource_Forms();
-		$landing_pages = new ConvertKit_Resource_Landing_Pages();
-		$tags          = new ConvertKit_Resource_Tags();
-
-		// Refresh resources by calling the API and storing the results.
-		$forms->refresh();
-		$landing_pages->refresh();
-		$tags->refresh();
-
-	}
-
-	/**
 	 * Backward compat. function for getting a ConvertKit subscriber by their ID.
 	 *
 	 * @since   1.4.2

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -21,7 +21,7 @@ class CKWC_Checkout {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @var     WC_Integration
+	 * @var     CKWC_Integration
 	 */
 	private $integration;
 

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -535,7 +535,7 @@ class CKWC_Integration extends WC_Integration {
 			 * Sync Past Orders Screen.
 			 */
 			case 'sync_past_orders':
-				wp_enqueue_style( 'ckwc-sync-past-orders', CKWC_PLUGIN_URL . '/resources/backend/css/sync-past-orders.css', false, CKWC_PLUGIN_VERSION );
+				wp_enqueue_style( 'ckwc-sync-past-orders', CKWC_PLUGIN_URL . '/resources/backend/css/sync-past-orders.css', array(), CKWC_PLUGIN_VERSION );
 				break;
 
 			/**
@@ -586,15 +586,15 @@ class CKWC_Integration extends WC_Integration {
 
 		// Get Forms, Tags and Sequences, refreshing them to fetch the latest data from the API,
 		// if we haven't already fetched them.
-		if ( ! $this->forms ) {
+		if ( ! $this->forms ) { // @phpstan-ignore-line
 			$this->forms = new CKWC_Resource_Forms();
 			$this->forms->refresh();
 		}
-		if ( ! $this->sequences ) {
+		if ( ! $this->sequences ) { // @phpstan-ignore-line
 			$this->sequences = new CKWC_Resource_Sequences();
 			$this->sequences->refresh();
 		}
-		if ( ! $this->tags ) {
+		if ( ! $this->tags ) { // @phpstan-ignore-line
 			$this->tags = new CKWC_Resource_Tags();
 			$this->tags->refresh();
 		}
@@ -654,7 +654,7 @@ class CKWC_Integration extends WC_Integration {
 
 		// Get Custom Fields, refreshing them to fetch the latest data from the API,
 		// if we haven't already fetched them.
-		if ( ! $this->custom_fields ) {
+		if ( ! $this->custom_fields ) { // @phpstan-ignore-line
 			$this->custom_fields = new CKWC_Resource_Custom_Fields();
 			$this->custom_fields->refresh();
 		}
@@ -833,7 +833,7 @@ class CKWC_Integration extends WC_Integration {
 	 *
 	 * @since   1.4.3
 	 *
-	 * @return  string  Integration Settings Screen.
+	 * @return  bool|string  Integration Settings Screen.
 	 */
 	private function get_integration_screen_name() {
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -22,7 +22,7 @@ class CKWC_Order {
 	 *
 	 * @since   1.4.2
 	 *
-	 * @var     WC_Integration
+	 * @var     CKWC_Integration
 	 */
 	private $integration;
 
@@ -177,7 +177,7 @@ class CKWC_Order {
 			list( $subscription['type'], $subscription['id'] ) = explode( ':', $subscription_raw );
 			$this->subscribe_customer(
 				$subscription['type'],
-				$subscription['id'],
+				(int) $subscription['id'],
 				$this->email( $order ),
 				$this->name( $order ),
 				$order_id,
@@ -222,6 +222,17 @@ class CKWC_Order {
 			case 'sequence':
 			case 'course':
 				$result = $this->api->sequence_subscribe( $resource_id, $email, $name, $custom_fields );
+				break;
+
+			default:
+				$result = new WP_Error(
+					'convertkit_for_woocommerce_order_subscribe_customer_error',
+					sprintf(
+						/* translators: Resource Type */
+						__( 'Resource type %s is not supported in CKWC_Order::subscribe_customer()', 'woocommerce-convertkit' ),
+						$resource_type
+					)
+				);
 				break;
 		}
 
@@ -354,17 +365,17 @@ class CKWC_Order {
 		$products = array();
 		foreach ( $order->get_items() as $item_key => $item ) {
 			// If this Order Item's Product could not be found, skip it.
-			if ( ! $item->get_product() ) {
+			if ( ! $item->get_product() ) { // @phpstan-ignore-line
 				continue;
 			}
 
 			// Add Product to array of Products.
 			$products[] = array(
-				'pid'        => $item->get_product()->get_id(),
+				'pid'        => $item->get_product()->get_id(), // @phpstan-ignore-line
 				'lid'        => $item_key,
 				'name'       => $item->get_name(),
-				'sku'        => $item->get_product()->get_sku(),
-				'unit_price' => $item->get_product()->get_price(),
+				'sku'        => $item->get_product()->get_sku(), // @phpstan-ignore-line
+				'unit_price' => $item->get_product()->get_price(), // @phpstan-ignore-line
 				'quantity'   => $item->get_quantity(),
 			);
 		}

--- a/includes/class-ckwc-resource.php
+++ b/includes/class-ckwc-resource.php
@@ -15,6 +15,27 @@
 class CKWC_Resource {
 
 	/**
+	 * Holds the Settings Key that stores site wide ConvertKit settings
+	 *
+	 * @var     string
+	 */
+	public $settings_name = '';
+
+	/**
+	 * The type of resource
+	 *
+	 * @var     string
+	 */
+	public $type = '';
+
+	/**
+	 * Holds the resources from the ConvertKit API
+	 *
+	 * @var     WP_Error|array
+	 */
+	public $resources = array();
+
+	/**
 	 * Constructor. Populate the resources array of e.g. forms, landing pages or tags.
 	 *
 	 * @since   1.4.2
@@ -128,6 +149,16 @@ class CKWC_Resource {
 			case 'custom_fields':
 				$results = $api->get_custom_fields();
 				break;
+
+			default:
+				$results = new WP_Error(
+					'convertkit_for_woocommerce_resource_refresh_error',
+					sprintf(
+						/* translators: Resource Type */
+						__( 'Resource type %s is not supported in CKWC_Resource class.', 'woocommerce-convertkit' ),
+						$this->type
+					)
+				);
 		}
 
 		// Bail if an error occured.
@@ -153,27 +184,6 @@ class CKWC_Resource {
 	public function delete() {
 
 		delete_option( $this->settings_name );
-
-	}
-
-	/**
-	 * Sorts the given array of resources by name.
-	 *
-	 * @since   1.4.2
-	 *
-	 * @param   array $data   Forms or Landing Pages from API.
-	 * @return  array           Sorted Forms or Landing Pages.
-	 */
-	private function sort_alphabetically( $data ) {
-
-		return usort(
-			$data,
-			function( $a, $b ) {
-
-				return strcmp( $a['name'], $b['name'] );
-
-			}
-		);
 
 	}
 

--- a/includes/class-ckwc-review-request.php
+++ b/includes/class-ckwc-review-request.php
@@ -22,7 +22,7 @@ class CKWC_Review_Request {
 	 *
 	 * @var     string
 	 */
-	private $plugin_name;
+	private $plugin_name; // @phpstan-ignore-line
 
 	/**
 	 * Holds the Plugin slug.

--- a/includes/class-ckwc-wc-subscriptions.php
+++ b/includes/class-ckwc-wc-subscriptions.php
@@ -32,9 +32,9 @@ class CKWC_WC_Subscriptions {
 	 *
 	 * @since   1.4.4
 	 *
-	 * @var     decimal
+	 * @var     string
 	 */
-	private $minimum_supported_version = 1;
+	private $minimum_supported_version = '1.0.0';
 
 	/**
 	 * The third party Plugin functions that must exist for this classes code
@@ -57,6 +57,8 @@ class CKWC_WC_Subscriptions {
 	 * @since   1.4.4
 	 */
 	public function __construct() {
+
+		add_action( 'admin_init', array( $this, 'is_plugin_active' ) );
 
 		// Check if the Order should opt in the Customer.
 		add_filter( 'convertkit_for_woocommerce_order_should_opt_in_customer', array( $this, 'order_should_opt_in_customer' ), 10, 2 );
@@ -110,7 +112,7 @@ class CKWC_WC_Subscriptions {
 	 *
 	 * @return  bool    Plugin is Active
 	 */
-	private function is_plugin_active() {
+	public function is_plugin_active() {
 
 		// Load is_plugin_active() function if not available i.e. this is a cron request.
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -128,7 +130,7 @@ class CKWC_WC_Subscriptions {
 		}
 
 		// If the third party Plugin doesn't match the minimum supported version, deem it as not active.
-		if ( $this->minimum_supported_version && $this->get_version() < $this->minimum_supported_version ) {
+		if ( ! version_compare( $this->get_version(), $this->minimum_supported_version, '>=' ) ) {
 			return false;
 		}
 
@@ -151,11 +153,11 @@ class CKWC_WC_Subscriptions {
 	 *
 	 * @since   1.4.4
 	 *
-	 * @return  decimal     Version
+	 * @return  string     Version
 	 */
 	private function get_version() {
 
-		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $this->plugin_folder_filename, array( 'Version' => 'Version' ), false );
+		$plugin_data = get_file_data( WP_PLUGIN_DIR . '/' . $this->plugin_folder_filename, array( 'Version' => 'Version' ) );
 		return $plugin_data['Version'];
 
 	}

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -163,7 +163,7 @@ class WP_CKWC {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'woocommerce-convertkit', false, basename( dirname( CKWC_PLUGIN_FILE ) ) . '/languages/' );
+		load_plugin_textdomain( 'woocommerce-convertkit', false, basename( dirname( CKWC_PLUGIN_FILE ) ) . '/languages/' ); // @phpstan-ignore-line
 
 	}
 
@@ -194,7 +194,7 @@ class WP_CKWC {
 			// Admin UI.
 			if ( is_admin() ) {
 				wp_die(
-					esc_attr( $error ),
+					esc_attr( $error->get_error_message() ),
 					esc_html__( 'ConvertKit for WooCommerce Error', 'woocommerce-convertkit' ),
 					array(
 						'back_link' => true,
@@ -220,7 +220,7 @@ class WP_CKWC {
 	 */
 	public static function get_instance() {
 
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {
+		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) { // @phpstan-ignore-line
 			self::$instance = new self();
 		}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -87,7 +87,7 @@ function ckwc_select2_enqueue_scripts() {
  */
 function ckwc_select2_enqueue_styles() {
 
-	wp_enqueue_style( 'ckwc-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', false, CKWC_PLUGIN_VERSION );
-	wp_enqueue_style( 'ckwc-admin-select2', CKWC_PLUGIN_URL . '/resources/backend/css/select2.css', false, CKWC_PLUGIN_VERSION );
+	wp_enqueue_style( 'ckwc-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', array(), CKWC_PLUGIN_VERSION );
+	wp_enqueue_style( 'ckwc-admin-select2', CKWC_PLUGIN_URL . '/resources/backend/css/select2.css', array(), CKWC_PLUGIN_VERSION );
 
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,4 +29,5 @@ parameters:
     # so they're false positives.
     ignoreErrors:
         - '#Constant WPINC not found.#'
+        - '#Constant WP_PLUGIN_DIR not found.#'
         - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,32 @@
+# PHPStan configuration for GitHub Actions.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - woocommerce-convertkit.php
+        - admin/
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - woocommerce-convertkit.php
+
+    # Location of WordPress installation
+    scanDirectories:
+        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Constant WPINC not found.#'
+        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,0 +1,32 @@
+# PHPStan configuration for local static analysis.
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - woocommerce-convertkit.php
+        - admin/
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - woocommerce-convertkit.php
+
+    # Location of WordPress installation
+    scanDirectories:
+        - /Users/tim/Local Sites/convertkit-github/app/public
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Constant WPINC not found.#'
+        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -29,4 +29,5 @@ parameters:
     # so they're false positives.
     ignoreErrors:
         - '#Constant WPINC not found.#'
+        - '#Constant WP_PLUGIN_DIR not found.#'
         - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -74,7 +74,7 @@ function WP_CKWC_Integration() { // phpcs:ignore
 	}
 
 	// Bail if integrations is null.
-	if ( is_null( WC()->integrations ) ) {
+	if ( is_null( WC()->integrations ) ) { // @phpstan-ignore-line
 		return false;
 	}
 


### PR DESCRIPTION
## Summary

[PHPStan](https://phpstan.org/blog/find-bugs-in-your-code-without-writing-tests) performs static analysis on the Plugin's PHP code.  This adds to our tests, PHP Coding Standards and WordPress Coding Standards by ensuring:

- DocBlocks declarations are valid and uniform
- DocBlocks declarations for WordPress `do_action()` and `apply_filters()` calls are valid
- Typehinting variables and return types declared in DocBlocks are correctly cast
- Any unused functions are detected
- Unnecessary checks / code is highlighted for possible removal
- Conditions that do not evaluate can be fixed/removed as necessary

This isn't a replacement for writing tests; rather, an addition to ensure our code continues to meet the high standards expected, reducing ambiguity on how code should be written and ensuring uniformity in what we produce.

Code changes to pass PHPStan's static analysis also included in this PR, given there are not many changes.  These broadly cover:
- Incorrect DocBlock parameter types (e.g. `string` when it is an `int`)
- More accurate DocBlock return types (e.g. `WP_Error|array` instead of `mixed`)

## Testing

Existing tests confirm working functionality of Plugin.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)