### PR TITLE
Fix Order ID Race Condition in Purchase Data Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       DB_USER: root
       DB_PASS: root
       DB_HOST: localhost
-      INSTALL_PLUGINS: "disable-welcome-messages-and-tips woocommerce woocommerce-gateway-stripe" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS: "custom-order-numbers-for-woocommerce disable-welcome-messages-and-tips woocommerce woocommerce-gateway-stripe" # Don't include this repository's Plugin here.
       STRIPE_TEST_PUBLISHABLE_KEY: ${{ secrets.STRIPE_TEST_PUBLISHABLE_KEY }} # Stripe Test API Publishable Key, stored in the repository's Settings > Secrets
       STRIPE_TEST_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }} # Stripe Test API Secret Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -282,6 +282,17 @@ class Acceptance extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to setup the Custom Order Numbers Plugin.
+	 * 
+	 * @since 	1.0.0
+	 */
+	public function setupCustomOrderNumbersPlugin($I)
+	{
+		// Setup WooCommerce Order Number prefix based on the current date and PHP version.
+		$I->haveOptionInDatabase('alg_wc_custom_order_numbers_prefix', 'ckwc-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '-');
+	}
+
+	/**
 	 * Helper method to:
 	 * - configure the Plugin's opt in, subscribe event and purchase options,
 	 * - create a WooCommerce Product (simple|virtual|zero|subscription)
@@ -427,7 +438,7 @@ class Acceptance extends \Codeception\Module
 		return [
 			'email_address' => $emailAddress,
 			'product_id' => $productID,
-			'order_id' => (int) $I->grabTextFrom('.woocommerce-order-overview__order strong'),
+			'order_id' => $I->grabTextFrom('.woocommerce-order-overview__order strong'),
 			'subscription_id' => ( ( $productType == 'subscription' ) ? (int) filter_var($I->grabTextFrom('.woocommerce-orders-table__cell-order-number a'), FILTER_SANITIZE_NUMBER_INT) : 0 ),
 		];
 	}
@@ -446,6 +457,13 @@ class Acceptance extends \Codeception\Module
 		// We perform the order status change by editing the Order as a WordPress Administrator would,
 		// so that WooCommerce triggers its actions and filters that our integration hooks into.
 		$I->loginAsAdmin();
+
+		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
+		if (strpos($orderID, '-') !== false) {
+			$orderIDParts = explode('-', $orderID);
+			$orderID = $orderIDParts[count($orderIDParts)-1];
+		}
+		
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
 		$I->submitForm('form#post', [
 			'order_status' => $orderStatus,
@@ -770,6 +788,12 @@ class Acceptance extends \Codeception\Module
 		// Login as Administrator.
 		$I->loginAsAdmin();
 
+		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
+		if (strpos($orderID, '-') !== false) {
+			$orderIDParts = explode('-', $orderID);
+			$orderID = $orderIDParts[count($orderIDParts)-1];
+		}
+
 		// Load Edit Order screen.
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
 
@@ -790,6 +814,12 @@ class Acceptance extends \Codeception\Module
 	{
 		// Login as Administrator.
 		$I->loginAsAdmin();
+
+		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
+		if (strpos($orderID, '-') !== false) {
+			$orderIDParts = explode('-', $orderID);
+			$orderID = $orderIDParts[count($orderIDParts)-1];
+		}
 
 		// Load Edit Order screen.
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');

--- a/tests/_support/Helper/Acceptance.php
+++ b/tests/_support/Helper/Acceptance.php
@@ -758,16 +758,23 @@ class Acceptance extends \Codeception\Module
 		$I->click('#btn-ok');
 
 		// Create Order.
+		$I->executeJS('window.scrollTo(0,0);');
 		$I->click('button.save_order');
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Determine the Order ID.
+		$orderID = $I->grabTextFrom('h2.woocommerce-order-data__heading');
+		$orderID = str_replace('Order #', '', $orderID);
+		$orderID = str_replace('details', '', $orderID);
+		$orderID = trim($orderID);
+
 		// Return.
 		return [
 			'email_address' => $emailAddress,
 			'product_id' => $productID,
-			'order_id' => (int) filter_var($I->grabTextFrom('h2.woocommerce-order-data__heading'), FILTER_SANITIZE_NUMBER_INT),
+			'order_id' => $orderID,
 		];
 	}
 

--- a/tests/acceptance/PurchaseDataCest.php
+++ b/tests/acceptance/PurchaseDataCest.php
@@ -19,8 +19,15 @@ class PurchaseDataCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
+		// Activate Custom Order Numbers, so that we can prefix Order IDs with
+		// an environment-specific string.
+		$I->activateThirdPartyPlugin($I, 'custom-order-numbers-for-woocommerce');
+
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Setup Custom Order Numbers Plugin.
+		$I->setupCustomOrderNumbersPlugin($I);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -792,6 +799,7 @@ class PurchaseDataCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateConvertKitPlugin($I);
+		$I->deactivateThirdPartyPlugin($I, 'custom-order-numbers-for-woocommerce');
 		$I->resetConvertKitPlugin($I);
 	}
 }


### PR DESCRIPTION
## Summary

Purchase Data tests run in parallel across different environments may hit a race condition when retrieving a specific purchase from the `purchases` API endpoint, as evidenced [here](https://github.com/ConvertKit/convertkit-woocommerce/pull/93/checks), resulting in tests incorrectly failing:
![Screenshot 2022-03-28 at 16 49 34](https://user-images.githubusercontent.com/1462305/160437294-61c7a5b7-21cf-4ae9-bc72-b2bf6f5514bc.png)

In the above example, the following steps happened in order:
- purchase data tests were started by GitHub's action on PHP 7.2, 7.3, 7.4 and 8.0 in parallel
- the test on PHP 7.2 created purchase data on ConvertKit with the WooCommerce Order ID 20 with email address `wordpress-2022-03-28-13-09-32-php-70234@convertkit.com` at 13:09:32
- the test on PHP 8.0 created purchase data on ConvertKit with the WooCommerce Order ID 20 with email address `wordpress-2022-03-28-13-09-33-php-80016@convertkit.com` at 13:09:33 (a second later), therefore replacing the order's email address from PHP 7.2
- the test on PHP 7.2 then reads the purchase data from ConvertKit for WooCommerce Order ID 20, expecting its email address (`wordpress-2022-03-28-13-09-32-php-70234@convertkit.com`), but instead getting the email address from the test ran in parallel on PHP 8.0 (`wordpress-2022-03-28-13-09-33-php-80016@convertkit.com`).

The behaviour occurs for two reasons:
1. By default, WooCommerce's Order IDs are sequentially numbered starting from 1, on each environment.
2. Creating a purchase using the `purchases` API endpoint with an Order ID (Transaction ID in ConvertKit) that already exists in ConvertKit results in the existing purchase data being overwritten with the new data.

This PR resolves, by:
1. Installing and activating the Custom Order Numbers for WooCommerce Plugin, which adds functionality to define custom order IDs
2. For each Purchase Data test, define a truly unique WooCommerce Order ID in the format `ckwc-yyyy-mm-dd-hh-mm-ss-php-{build}-{order_id}`, where `{build}` is the PHP build version (unique to each environment), and `{order_id}` is the WooCommerce Order ID, starting at 1.

This results in every Purchase Data test truly having a unique Order ID, separate from any other environment and test:
![Screenshot 2022-03-28 at 17 03 22](https://user-images.githubusercontent.com/1462305/160439899-88ad3e62-b52d-49b4-9bac-0376d70be62d.png)

## Testing

Existing tests (specifically, purchase data tests) will now pass instead of failing.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)