### PR TITLE
Add expiration to cached resources

### DIFF
--- a/includes/class-ckwc-resource-custom-fields.php
+++ b/includes/class-ckwc-resource-custom-fields.php
@@ -28,11 +28,4 @@ class CKWC_Resource_Custom_Fields extends CKWC_Resource {
 	 */
 	public $type = 'custom_fields';
 
-	/**
-	 * Holds the forms from the ConvertKit API
-	 *
-	 * @var     array
-	 */
-	public $resources = array();
-
 }

--- a/includes/class-ckwc-resource-forms.php
+++ b/includes/class-ckwc-resource-forms.php
@@ -28,11 +28,4 @@ class CKWC_Resource_Forms extends CKWC_Resource {
 	 */
 	public $type = 'forms';
 
-	/**
-	 * Holds the forms from the ConvertKit API
-	 *
-	 * @var     array
-	 */
-	public $resources = array();
-
 }

--- a/includes/class-ckwc-resource-sequences.php
+++ b/includes/class-ckwc-resource-sequences.php
@@ -28,11 +28,4 @@ class CKWC_Resource_Sequences extends CKWC_Resource {
 	 */
 	public $type = 'sequences';
 
-	/**
-	 * Holds the sequences from the ConvertKit API
-	 *
-	 * @var     array
-	 */
-	public $resources = array();
-
 }

--- a/includes/class-ckwc-resource-tags.php
+++ b/includes/class-ckwc-resource-tags.php
@@ -28,11 +28,4 @@ class CKWC_Resource_Tags extends CKWC_Resource {
 	 */
 	public $type = 'tags';
 
-	/**
-	 * Holds the tags from the ConvertKit API
-	 *
-	 * @var     array
-	 */
-	public $resources = array();
-
 }

--- a/includes/class-ckwc-resource.php
+++ b/includes/class-ckwc-resource.php
@@ -170,7 +170,7 @@ class CKWC_Resource {
 
 		// Bail if the API Key and Secret hasn't been defined in the Plugin Settings.
 		if ( ! WP_CKWC_Integration()->is_enabled() ) {
-			return;
+			return false;
 		}
 
 		// Setup the API.

--- a/tests/wpunit/ResourceCustomFieldsTest.php
+++ b/tests/wpunit/ResourceCustomFieldsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the key name that stores settings for this Plugin.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	string
+	 */
+	private $settings_key = 'woocommerce_ckwc_settings';
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	ConvertKit_Resource_Custom_Fields
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Enable integration, storing API Key and Secret in Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'yes' );
+		WP_CKWC_Integration()->update_option( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
+		WP_CKWC_Integration()->update_option( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Initialize the resource class we want to test.
+		$this->resource = new CKWC_Resource_Custom_Fields();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Disable integration, removing API Key and Secret from Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'no' );
+		WP_CKWC_Integration()->update_option( 'api_key', '' );
+		WP_CKWC_Integration()->update_option( 'api_secret', '' );
+
+		// Delete Settings and Resources from options table.
+		delete_option($this->settings_key);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, true);
+	}
+}

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the key name that stores settings for this Plugin.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	string
+	 */
+	private $settings_key = 'woocommerce_ckwc_settings';
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	ConvertKit_Resource_Forms
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Enable integration, storing API Key and Secret in Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'yes' );
+		WP_CKWC_Integration()->update_option( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
+		WP_CKWC_Integration()->update_option( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Initialize the resource class we want to test.
+		$this->resource = new CKWC_Resource_Forms();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Disable integration, removing API Key and Secret from Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'no' );
+		WP_CKWC_Integration()->update_option( 'api_key', '' );
+		WP_CKWC_Integration()->update_option( 'api_secret', '' );
+
+		// Delete Settings and Resources from options table.
+		delete_option($this->settings_key);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, true);
+	}
+}

--- a/tests/wpunit/ResourceSequencesTest.php
+++ b/tests/wpunit/ResourceSequencesTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the key name that stores settings for this Plugin.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	string
+	 */
+	private $settings_key = 'woocommerce_ckwc_settings';
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	ConvertKit_Resource_Sequences
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Enable integration, storing API Key and Secret in Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'yes' );
+		WP_CKWC_Integration()->update_option( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
+		WP_CKWC_Integration()->update_option( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Initialize the resource class we want to test.
+		$this->resource = new CKWC_Resource_Sequences();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Disable integration, removing API Key and Secret from Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'no' );
+		WP_CKWC_Integration()->update_option( 'api_key', '' );
+		WP_CKWC_Integration()->update_option( 'api_secret', '' );
+
+		// Delete Settings and Resources from options table.
+		delete_option($this->settings_key);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, true);
+	}
+}

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
+{
+	/**
+	 * @var \WpunitTester
+	 */
+	protected $tester;
+
+	/**
+	 * Holds the key name that stores settings for this Plugin.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	string
+	 */
+	private $settings_key = 'woocommerce_ckwc_settings';
+
+	/**
+	 * Holds the ConvertKit Resource class.
+	 * 
+	 * @since 	1.4.7
+	 * 
+	 * @var 	ConvertKit_Resource_Tags
+	 */
+	private $resource;
+
+	/**
+	 * Performs actions before each test.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		// Enable integration, storing API Key and Secret in Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'yes' );
+		WP_CKWC_Integration()->update_option( 'api_key', $_ENV['CONVERTKIT_API_KEY'] );
+		WP_CKWC_Integration()->update_option( 'api_secret', $_ENV['CONVERTKIT_API_SECRET'] );
+
+		// Initialize the resource class we want to test.
+		$this->resource = new CKWC_Resource_Tags();
+		$this->assertNotInstanceOf(WP_Error::class, $this->resource->resources);
+	}
+
+	/**
+	 * Performs actions after each test.
+	 * 
+	 * @since 	1.9.6.9
+	 */
+	public function tearDown(): void
+	{
+		// Disable integration, removing API Key and Secret from Plugin's settings.
+		WP_CKWC_Integration()->update_option( 'enabled', 'no' );
+		WP_CKWC_Integration()->update_option( 'api_key', '' );
+		WP_CKWC_Integration()->update_option( 'api_secret', '' );
+
+		// Delete Settings and Resources from options table.
+		delete_option($this->settings_key);
+		delete_option($this->resource->settings_name);
+		delete_option($this->resource->settings_name . '_last_queried');
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that the refresh() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testRefresh()
+	{
+		// Confirm that the data is stored in the options table and includes some expected keys.
+		$result = $this->resource->refresh();
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the expiry timestamp is set and returns the expected value.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExpiry()
+	{
+		// Define the expected expiry date based on the resource class' $cache_duration setting.
+		$expectedExpiryDate = date('Y-m-d', time() + $this->resource->cache_duration);
+
+		// Fetch the actual expiry date set when the resource class was initialized.
+		$expiryDate = date('Y-m-d', $this->resource->last_queried + $this->resource->cache_duration);
+
+		// Confirm both dates match.
+		$this->assertEquals($expectedExpiryDate, $expiryDate);
+	}
+
+	/**
+	 * Test that the get() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testGet()
+	{
+		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		$result = $this->resource->get();
+		$this->assertNotInstanceOf(WP_Error::class, $result);
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+	}
+
+	/**
+	 * Test that the exist() function performs as expected, storing data in the options table.
+	 * 
+	 * @since 	1.4.7
+	 */
+	public function testExist()
+	{
+		// Confirm that the function returns true, because resources exist.
+		$result = $this->resource->exist();
+		$this->assertSame($result, true);
+	}
+}

--- a/views/backend/custom-field-dropdown-field.php
+++ b/views/backend/custom-field-dropdown-field.php
@@ -14,7 +14,7 @@
 	</option>
 
 	<?php
-	if ( ! is_wp_error( $custom_field['custom_fields']->get() ) ) {
+	if ( $custom_field['custom_fields']->exist() ) {
 		foreach ( $custom_field['custom_fields']->get() as $api_custom_field ) {
 			?>
 			<option value="<?php echo esc_attr( $api_custom_field['key'] ); ?>"<?php selected( esc_attr( $api_custom_field['key'] ), $custom_field['value'] ); ?>><?php echo esc_html( $api_custom_field['label'] ); ?></option>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -7,14 +7,13 @@
  */
 
 ?>
-
 <select class="<?php echo esc_attr( $subscription['class'] ); ?>" id="<?php echo esc_attr( $subscription['id'] ); ?>" name="<?php echo esc_attr( $subscription['name'] ); ?>">
 	<option <?php selected( '', $subscription['value'] ); ?> value="">
 		<?php esc_html_e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?>
 	</option>
 
 	<?php
-	if ( ! is_wp_error( $subscription['sequences']->get() ) ) {
+	if ( $subscription['sequences']->exist() ) {
 		?>
 		<optgroup label="<?php esc_attr_e( 'Sequences', 'woocommerce-convertkit' ); ?>">
 			<?php
@@ -29,7 +28,7 @@
 		<?php
 	}
 
-	if ( ! is_wp_error( $subscription['forms']->get() ) ) {
+	if ( $subscription['forms']->exist() ) {
 		?>
 		<optgroup label="<?php esc_attr_e( 'Forms', 'woocommerce-convertkit' ); ?>">
 			<?php
@@ -43,7 +42,7 @@
 		<?php
 	}
 
-	if ( ! is_wp_error( $subscription['tags']->get() ) ) {
+	if ( $subscription['tags']->exist() ) {
 		?>
 		<optgroup label="<?php esc_attr_e( 'Tags', 'woocommerce-convertkit' ); ?>">
 			<?php


### PR DESCRIPTION
## Summary

Implements cached resource expiration, as we do in the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/302).

## Testing

- `WPUnit` tests updated to confirm resource cache expiration is honored

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)