### PR TITLE
Updated PHPStan configuration to support PHPStan 1.7

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,6 +28,4 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Constant WPINC not found.#'
         - '#Constant WP_PLUGIN_DIR not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -145,7 +145,11 @@ class WooCommerce extends \Codeception\Module
 			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send or map)');
 		}
 
+		// Save.
 		$I->click('Save changes');
+
+		// Wait until the settings page reloads, to avoid a browser alert later that navigating away will lose unsaved changes.
+		$I->waitForElement('#woocommerce_ckwc_enabled');
 		
 		// Create Product
 		switch ($productType) {


### PR DESCRIPTION
## Summary

PHPStan 1.7 better detects some WordPress constants and fixes some false positives, which can be safely removed from the `phpstan.neon.dist` configuration, similar to the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/316).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)