### PR TITLE
Fix PHPStan Configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,7 +201,7 @@ jobs:
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpstan --memory-limit=512M
+        run: php vendor/bin/phpstan --memory-limit=1024M
 
       # Build Codeception Tests.
       - name: Build Tests

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -210,25 +210,6 @@ class CKWC_Integration extends WC_Integration {
 	}
 
 	/**
-	 * Verifies if the _convertkit_settings_tools_nonce nonce was included in the request,
-	 * and if so whether the nonce action is valid.
-	 *
-	 * @since   1.4.6
-	 *
-	 * @return  bool
-	 */
-	private function verify_nonce() {
-
-		// Bail if nonce verification fails.
-		if ( ! isset( $_REQUEST['_convertkit_settings_tools_nonce'] ) ) {
-			return false;
-		}
-
-		return wp_verify_nonce( $_REQUEST['_convertkit_settings_tools_nonce'], 'convertkit-settings-tools' );
-
-	}
-
-	/**
 	 * Output the Integration settings screen, depending on whether the request
 	 * is for the settings or the Sync Past Orders screen.
 	 *

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,9 +17,9 @@ parameters:
     bootstrapFiles:
         - woocommerce-convertkit.php
 
-    # Location of WordPress installation
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress
+        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-content/plugins
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
@@ -29,3 +29,4 @@ parameters:
     # so they're false positives.
     ignoreErrors:
         - '#Constant WP_PLUGIN_DIR not found.#'
+        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -17,9 +17,9 @@ parameters:
     bootstrapFiles:
         - woocommerce-convertkit.php
 
-    # Location of WordPress installation
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /Users/tim/Local Sites/convertkit-github/app/public
+        - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
@@ -28,6 +28,5 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Constant WPINC not found.#'
         - '#Constant WP_PLUGIN_DIR not found.#'
         - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect

--- a/tests/acceptance/SyncPastOrdersCest.php
+++ b/tests/acceptance/SyncPastOrdersCest.php
@@ -20,6 +20,9 @@ class SyncPastOrdersCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Setup Custom Order Numbers Plugin.
+		$I->setupCustomOrderNumbersPlugin($I);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes PHPStan's configuration for GitHub actions by:
- Changing `scanDirectories` to scan the WordPress Plugins directory to build symbols (function definitions and constants), rather than scanning the entire WordPress installation, because the `includes` configuration already points to phpstan-wordpress' WordPress symbol definitions.  Scanning the entire WordPress installation is slower and results in [false positive errors](https://github.com/ConvertKit/convertkit-woocommerce/runs/6677864876?check_suite_focus=true).
- Changing `ignoreErrors` to ignore some WordPress symbols that aren't yet detected by PHPStan.

## Testing

Existing tests should pass to confirm this PR works.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)