### PR TITLE
Change references from `master` to `main`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,15 +7,15 @@ If it is adding functionality, a use case of why this is needed helps determine 
 ## Testing
 
 Not sure how to perform testing, or perhaps didn't include a test in this PR? Walk through the following in order for a beginner-friendly guide:
-- [Setup](https://github.com/ConvertKit/convertkit-wordpress/blob/master/SETUP.md) - setting up your local environment for development and testing
-- [Development](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md) - best practices for development
-- [Testing](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md) - how to write and run tests
+- [Setup](https://github.com/ConvertKit/convertkit-wordpress/blob/main/SETUP.md) - setting up your local environment for development and testing
+- [Development](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md) - best practices for development
+- [Testing](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md) - how to write and run tests
 
 ## Checklist
 
-* [ ] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#writing-an-acceptance-test) and included it in this PR
-* [ ] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-tests) and they pass
-* [ ] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md#run-php-codesniffer)
-* [ ] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
-* [ ] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
+* [ ] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
+* [ ] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
+* [ ] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
+* [ ] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
+* [ ] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
 * [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
   push:
     branches:
-      - master
+      - main
 
 jobs:
   tests:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ If you are having issues setting up this plugin on your WordPress site, or have 
 ## Developers
 
 For ConvertKit Developers, there are guides in the main ConvertKit Plugin repository covering:
-- [Setup](https://github.com/ConvertKit/convertkit-wordpress/blob/master/SETUP.md) - setting up your local environment for development and testing
-- [Development](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEVELOPMENT.md) - best practices for development
-- [Testing](https://github.com/ConvertKit/convertkit-wordpress/blob/master/TESTING.md) - how to write and run tests
+- [Setup](https://github.com/ConvertKit/convertkit-wordpress/blob/main/SETUP.md) - setting up your local environment for development and testing
+- [Development](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md) - best practices for development
+- [Testing](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md) - how to write and run tests
 - [Actions and Filters](ACTIONS-FILTERS.md) - Actions and Filters available to WordPress Developers looking to extend ConvertKit's functionality
 
 For ConvertKit, there is a separate guide to deploying new versions to wordpress.org:
-- [Deployment](https://github.com/ConvertKit/convertkit-wordpress/blob/master/DEPLOYMENT.md) - how to deploy a new Plugin version to [WordPress.org](https://wordpress.org/plugins/convertkit-for-woocommerce/)
+- [Deployment](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEPLOYMENT.md) - how to deploy a new Plugin version to [WordPress.org](https://wordpress.org/plugins/convertkit-for-woocommerce/)
 
 These guides can be applied to this Plugin; there may be some minor differences in terms of .env.testing configuration.

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ No. You must first have an account on ConvertKit.com, but you do not have to use
 ### 1.4.2 2022-01-28
 * Added: Testing and compatibility for WooCommerce 6.1
 * Added: PHP 8.x compatibility
-* Added: Developers: Action and filter hooks.  See https://github.com/ConvertKit/convertkit-woocommerce/blob/master/ACTIONS-FILTERS.md
+* Added: Developers: Action and filter hooks.  See https://github.com/ConvertKit/convertkit-woocommerce/blob/main/ACTIONS-FILTERS.md
 * Added: Localization and .pot file for translators
 * Fix: Settings: Only show conditional settings if other settings enabled/disabled
 * Fix: Settings: API Key and Secret: Don't need to save settings twice for API Key and Secret to work


### PR DESCRIPTION
## Summary

Updates GitHub Actions for coding standards and tests to run when changes are pushed to the `main` branch since it has been renamed from `master` in GitHub.

Updates links to markdown files to reflect the change of branch name.

## Testing

Existing tests should run on this PR and when this PR is merged.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)