### PR TITLE
Improve reasons to ignore coding standards

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,7 +196,7 @@ jobs:
       # the user sooner.
       - name: Run WordPress Coding Standards Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ -v
+        run: php vendor/bin/phpcs ./ -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/admin/class-ckwc-admin-product.php
+++ b/admin/class-ckwc-admin-product.php
@@ -143,7 +143,7 @@ class CKWC_Admin_Product {
 			return;
 		}
 
-		$data = stripslashes_deep( $_POST ); // phpcs:ignore
+		$data = stripslashes_deep( $_POST );
 
 		// Bail if nonce is missing.
 		if ( ! isset( $data['ckwc_nonce'] ) ) {

--- a/composer.json
+++ b/composer.json
@@ -48,5 +48,10 @@
             "readme.md",
             "tags"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -87,6 +87,7 @@ class CKWC_API extends ConvertKit_API {
 			/* translators: HTTP method */
 			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
 			'request_rate_limit_exceeded'                 => __( 'Rate limit hit.', 'woocommerce-convertkit' ),
+			'response_type_unexpected' 					  => __( 'The response from the API is not of the expected type array.', 'woocommerce-convertkit' ),
 		);
 
 	}

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -87,7 +87,7 @@ class CKWC_API extends ConvertKit_API {
 			/* translators: HTTP method */
 			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
 			'request_rate_limit_exceeded'                 => __( 'Rate limit hit.', 'woocommerce-convertkit' ),
-			'response_type_unexpected' 					  => __( 'The response from the API is not of the expected type array.', 'woocommerce-convertkit' ),
+			'response_type_unexpected'                    => __( 'The response from the API is not of the expected type array.', 'woocommerce-convertkit' ),
 		);
 
 	}

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -111,7 +111,7 @@ class CKWC_Checkout {
 		} else {
 			// Opt in checkbox is displayed at checkout.
 			// Opt in if it is checked.
-			if ( isset( $_POST['ckwc_opt_in'] ) ) { /* phpcs:ignore */
+			if ( isset( $_POST['ckwc_opt_in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 				$opt_in = 'yes';
 			}
 		}

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -108,10 +108,10 @@ class CKWC_Integration extends WC_Integration {
 	private function maybe_export_configuration() {
 
 		// Bail if the action isn't for exporting a configuration file.
-		if ( ! array_key_exists( 'action', $_REQUEST ) ) { // phpcs:ignore
+		if ( ! array_key_exists( 'action', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( $_REQUEST['action'] !== 'ckwc-export' ) { // phpcs:ignore
+		if ( $_REQUEST['action'] !== 'ckwc-export' ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -133,7 +133,7 @@ class CKWC_Integration extends WC_Integration {
 		header( 'Content-Disposition: attachment; filename=ckwc-export.json' );
 		header( 'Pragma: no-cache' );
 		header( 'Expires: 0' );
-		echo $json; /* phpcs:ignore */
+		echo $json; // phpcs:ignore WordPress.Security.EscapeOutput
 		exit();
 
 	}
@@ -838,7 +838,7 @@ class CKWC_Integration extends WC_Integration {
 	 * @param   string $key    Setting Field Key.
 	 * @param   array  $data   Setting Field Configuration.
 	 */
-	public function generate_sync_past_orders_button_html( $key, $data ) { /* phpcs:ignore */
+	public function generate_sync_past_orders_button_html( $key, $data ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 		// Bail if the Integration isn't enabled and doesn't have an API Key and Secret specified.
 		if ( ! $this->is_enabled() ) {
@@ -880,7 +880,7 @@ class CKWC_Integration extends WC_Integration {
 	 * @param   string $key    Setting Field Key.
 	 * @param   array  $data   Setting Field Configuration.
 	 */
-	public function generate_link_button_html( $key, $data ) { /* phpcs:ignore */
+	public function generate_link_button_html( $key, $data ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 		// Return HTML for button.
 		ob_start();
@@ -914,10 +914,10 @@ class CKWC_Integration extends WC_Integration {
 	 * @param   string $api_key    API Key.
 	 * @return  string              API Key
 	 */
-	public function validate_api_key_field( $key, $api_key ) { /* phpcs:ignore */
+	public function validate_api_key_field( $key, $api_key ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
 
 		// If the integration isn't enabled, don't validate the API Key.
-		if ( ! isset( $_POST[ $this->plugin_id . $this->id . '_enabled' ] ) ) { /* phpcs:ignore */
+		if ( ! isset( $_POST[ $this->plugin_id . $this->id . '_enabled' ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$this->resources_delete();
 			return $api_key;
 		}
@@ -1007,38 +1007,42 @@ class CKWC_Integration extends WC_Integration {
 	 */
 	private function get_integration_screen_name() {
 
+		// The settings screen is loaded without a nonce in WooCommerce, so we cannot perform verification.
+		// phpcs:disable WordPress.Security.NonceVerification
+
 		// Return false if no request for a page was made.
-		if ( ! isset( $_REQUEST['page'] ) ) { // phpcs:ignore
+		if ( ! isset( $_REQUEST['page'] ) ) {
 			return false;
 		}
 
 		// Return false if the page request isn't for WooCommerce Settings.
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'wc-settings' ) { // phpcs:ignore
+		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'wc-settings' ) {
 			return false;
 		}
 
 		// Return false if the settings page request isn't for an Integration.
-		if ( ! isset( $_REQUEST['tab'] ) ) { // phpcs:ignore
+		if ( ! isset( $_REQUEST['tab'] ) ) {
 			return false;
 		}
-		if ( sanitize_text_field( $_REQUEST['tab'] ) !== 'integration' ) { // phpcs:ignore
+		if ( sanitize_text_field( $_REQUEST['tab'] ) !== 'integration' ) {
 			return false;
 		}
 
 		// Return false if the Integration request doesn't specify a section.
-		if ( ! isset( $_REQUEST['section'] ) ) { // phpcs:ignore
+		if ( ! isset( $_REQUEST['section'] ) ) {
 			return false;
 		}
 
 		// Return false if the Integration request section isn't for this Plugin.
-		if ( sanitize_text_field( $_REQUEST['section'] ) !== 'ckwc' ) { // phpcs:ignore
+		if ( sanitize_text_field( $_REQUEST['section'] ) !== 'ckwc' ) {
 			return false;
 		}
 
 		// If a sub section is defined, return its name now.
-		if ( isset( $_REQUEST['sub_section'] ) ) { // phpcs:ignore
-			return sanitize_text_field( $_REQUEST['sub_section'] ); // phpcs:ignore
+		if ( isset( $_REQUEST['sub_section'] ) ) {
+			return sanitize_text_field( $_REQUEST['sub_section'] );
 		}
+		// phpcs:enable
 
 		// The request is for the Integration's main settings screen.
 		return 'settings';

--- a/lib/class-convertkit-resource.php
+++ b/lib/class-convertkit-resource.php
@@ -151,7 +151,7 @@ class ConvertKit_Resource {
 
 		foreach ( $this->get() as $resource ) {
 			// If this resource's ID matches the ID we're looking for, return it.
-			if ( $resource['id'] == $id ) { // phpcs:ignore
+			if ( $resource['id'] === $id ) {
 				return $resource;
 			}
 		}

--- a/views/backend/settings/custom-field.php
+++ b/views/backend/settings/custom-field.php
@@ -18,7 +18,7 @@
 			<?php
 			// Load custom field dropdown field.
 			require CKWC_PLUGIN_PATH . '/views/backend/custom-field-dropdown-field.php';
-			echo $this->get_description_html( $data ); // phpcs:ignore
+			echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput
 			?>
 		</fieldset>
 	</td>

--- a/views/backend/settings/link-button.php
+++ b/views/backend/settings/link-button.php
@@ -20,7 +20,7 @@
 				echo esc_html( $data['label'] );
 				?>
 			</a>
-			<?php echo $this->get_description_html( $data ); // phpcs:ignore ?>
+			<?php echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
 		</fieldset>
 	</td>
 </tr>

--- a/views/backend/settings/subscription.php
+++ b/views/backend/settings/subscription.php
@@ -18,7 +18,7 @@
 			<?php
 			// Load subscription dropdown field.
 			require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
-			echo $this->get_description_html( $data ); // phpcs:ignore
+			echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput
 			?>
 		</fieldset>
 	</td>

--- a/views/backend/settings/sync-past-orders-button.php
+++ b/views/backend/settings/sync-past-orders-button.php
@@ -21,7 +21,7 @@
 				);
 				?>
 			</a>
-			<?php echo $this->get_description_html( $data ); // phpcs:ignore ?>
+			<?php echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput ?>
 		</fieldset>
 	</td>
 </tr>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -46,9 +46,9 @@
 		?>
 		<optgroup label="<?php esc_attr_e( 'Tags', 'woocommerce-convertkit' ); ?>">
 			<?php
-			foreach ( $subscription['tags']->get() as $tag ) { // phpcs:ignore
+			foreach ( $subscription['tags']->get() as $convertkit_tag ) {
 				?>
-				<option value="tag:<?php echo esc_attr( $tag['id'] ); ?>"<?php selected( 'tag:' . esc_attr( $tag['id'] ), $subscription['value'] ); ?>><?php echo esc_html( $tag['name'] ); ?></option>
+				<option value="tag:<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag:' . esc_attr( $convertkit_tag['id'] ), $subscription['value'] ); ?>><?php echo esc_html( $convertkit_tag['name'] ); ?></option>
 				<?php
 			}
 			?>

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -66,7 +66,7 @@ if ( is_admin() ) {
  *
  * @since   1.4.2
  */
-function WP_CKWC() { // phpcs:ignore
+function WP_CKWC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 
 	return WP_CKWC::get_instance();
 
@@ -77,7 +77,7 @@ function WP_CKWC() { // phpcs:ignore
  *
  * @since   1.0.0
  */
-function WP_CKWC_Integration() { // phpcs:ignore
+function WP_CKWC_Integration() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 
 	// Bail if WooCommerce isn't active.
 	if ( ! function_exists( 'WC' ) ) {


### PR DESCRIPTION
## Summary

Replaces `phpcs:ignore` comments with the specific rule to ignore, such as `phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter`.

This ensures the coding standard checks for lines containing an ignore directive will still validate the code against other coding standard rules.

## Testing

Existing tests pass to confirm no breaking changes.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)