### PR TITLE
Plugin Performance when no Resources exist

### DIFF
--- a/lib/class-convertkit-resource.php
+++ b/lib/class-convertkit-resource.php
@@ -112,12 +112,6 @@ class ConvertKit_Resource {
 			return;
 		}
 
-		// If no resources exist, refresh them now.
-		if ( ! $this->resources ) {
-			$this->refresh();
-			return;
-		}
-
 		// If the resources have expired, refresh them now.
 		if ( time() > ( $this->last_queried + $this->cache_duration ) ) {
 			$this->refresh();


### PR DESCRIPTION
## Summary

As with the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/337), prevents querying the API on every WordPress Administration screen request if a ConvertKit account does not have a particular resource (such as forms or tags).  The frontend site is unaffected, as no API queries are made.

### Detail

If a ConvertKit account has no resources (forms or tags), the plugin's cache for these resources will be empty.
As a result, the plugin would query the API on every WordPress administration screen request, resulting in slow loading times (in this example, approximately ~ 1.4 seconds is added to the load time for an administration screen):
![Screenshot 2022-07-22 at 13 42 15](https://user-images.githubusercontent.com/1462305/180441858-71293613-a6ef-426d-8314-8ba4d213ca55.png)

Whilst the account _should_ have at least one form, tag or sequence (the plugin isn't really useful otherwise), it's wrong for the plugin to presume that at least one form, one tag, one sequence and one custom field will be defined in the ConvertKit account.

If a user subsequently adds forms, tags, sequences or custom fields to their ConvertKit account, they would navigate to `WooCommerce > Settings > Integration > ConvertKit` to force an automatic refresh of resources; this is current plugin behaviour.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)