### PR TITLE
Quick Edit

### DIFF
--- a/admin/class-ckwc-admin-product.php
+++ b/admin/class-ckwc-admin-product.php
@@ -129,8 +129,8 @@ class CKWC_Admin_Product {
 	}
 
 	/**
-	 * Saves the WooCommerce Product's Form or Tag to subscribe the Customer to when a
-	 * Product is edited, overriding the Plugin default's Form / Tag.
+	 * Saves the WooCommerce Product's Form, Sequence or Tag to subscribe the Customer to when
+	 * either editing a Product or using the Quick Edit functionality.
 	 *
 	 * @since   1.0.0
 	 *
@@ -155,7 +155,7 @@ class CKWC_Admin_Product {
 			return;
 		}
 
-		// Bail if no Form / Tag option exists in POST data.
+		// Bail if no Form, Sequence or Tag option exists in POST data.
 		if ( ! isset( $data['ckwc_subscription'] ) ) {
 			return;
 		}

--- a/admin/class-ckwc-admin-quick-edit.php
+++ b/admin/class-ckwc-admin-quick-edit.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * ConvertKit Admin Quick Edit class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Registers settings fields for output when using WordPress' Quick Edit functionality
+ * in the WooCommerce Products WP_List_Table.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+class CKWC_Admin_Quick_Edit {
+
+	/**
+	 * Holds the WooCommerce Integration instance for this Plugin.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @var     CKWC_Integration
+	 */
+	private $integration;
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.4.8
+	 */
+	public function __construct() {
+
+		// Fetch integration.
+		$this->integration = WP_CKWC_Integration();
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'add_inline_data', array( $this, 'quick_edit_inline_data' ) );
+
+	}
+
+	/**
+	 * Enqueues scripts and CSS for Quick Edit functionality in the Post, Page and Custom Post WP_List_Tables
+	 *
+	 * @since   1.4.8
+	 */
+	public function enqueue_assets() {
+
+		// Bail if we're not on the Products WP_List_Table.
+		if ( ! $this->is_product_wp_list_table_screen() ) {
+			return;
+		}
+
+		// Enqueue JS.
+		wp_enqueue_script( 'ckwc-admin-quick-edit', CKWC_PLUGIN_URL . 'resources/backend/js/quick-edit.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
+
+	}
+
+	/**
+	 * Outputs hidden inline data in each Post's Title column, which the Quick Edit
+	 * JS can read when the user clicks the Quick Edit link in a WP_List_Table.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   WP_Post $post               Post.
+	 */
+	public function quick_edit_inline_data( $post ) {
+
+		// Bail if we're not on the Products WP_List_Table.
+		if ( $post->post_type !== 'product' ) {
+			return;
+		}
+
+		// Fetch Product's Settings.
+		$settings = array(
+			'ckwc_subscription' => get_post_meta( $post->ID, 'ckwc_subscription', true ),
+		);
+
+		// Output the Product's ConvertKit settings as hidden data- attributes, which
+		// the Quick Edit JS can read.
+		foreach ( $settings as $key => $value ) {
+			// If the value is blank, set it to zero.
+			// This allows Quick Edit's JS to select the correct <option> value.
+			if ( $value === '' ) {
+				$value = 0;
+			}
+			?>
+			<div class="ckwc" data-setting="<?php echo esc_attr( $key ); ?>" data-value="<?php echo esc_attr( $value ); ?>"><?php echo esc_attr( $value ); ?></div>
+			<?php
+		}
+
+		// Output Quick Edit fields in the footer of the Administration screen.
+		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10, 2 );
+
+	}
+
+	/**
+	 * Outputs Quick Edit settings fields in the footer of the administration screen.
+	 *
+	 * The Quick Edit JS will then move these hidden fields into the Quick Edit row
+	 * when the user clicks on a Quick Edit link in the WP_List_Table.
+	 *
+	 * @since   1.4.8
+	 */
+	public function quick_edit_fields() {
+
+		// Don't output Quick Edit fields if the API settings have not been defined.
+		if ( ! $this->integration->is_enabled() ) {
+			return;
+		}
+
+		// Get Forms, Tags and Sequences.
+		$forms     = new CKWC_Resource_Forms();
+		$sequences = new CKWC_Resource_Sequences();
+		$tags      = new CKWC_Resource_Tags();
+
+		// Get current subscription setting and other settings to render the subscription dropdown field.
+		$subscription = array(
+			'id'        => 'ckwc_subscription',
+			'class'     => 'widefat',
+			'name'      => 'ckwc_subscription',
+			'value'     => '',
+			'forms'     => $forms,
+			'tags'      => $tags,
+			'sequences' => $sequences,
+		);
+
+		// Output view.
+		require_once CKWC_PLUGIN_PATH . '/views/backend/product/quick-edit.php';
+
+	}
+
+	/**
+	 * Checks if the request is for viewing the WooCommerce Add / Edit Product screen.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @return  bool
+	 */
+	private function is_product_wp_list_table_screen() {
+
+		// Return false if we cannot reliably determine the current screen that is viewed,
+		// due to WordPress' get_current_screen() function being unavailable.
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		// Get screen.
+		$screen = get_current_screen();
+
+		// Bail if we're not on a Post Type Edit screen.
+		if ( $screen->base !== 'edit' ) {
+			return false;
+		}
+
+		// Return false if we're not on the Product WP_List_Table.
+		if ( $screen->post_type !== 'product' ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+}

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,9 +99,10 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']    = new CKWC_Admin_AJAX();
-		$this->classes['admin_plugin']  = new CKWC_Admin_Plugin();
-		$this->classes['admin_product'] = new CKWC_Admin_Product();
+		$this->classes['admin_ajax']       = new CKWC_Admin_AJAX();
+		$this->classes['admin_plugin']     = new CKWC_Admin_Plugin();
+		$this->classes['admin_product']    = new CKWC_Admin_Product();
+		$this->classes['admin_quick_edit'] = new CKWC_Admin_Quick_Edit();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -1,0 +1,53 @@
+/**
+ * Quick Edit
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Populates Quick Edit fields for this Plugin with the values output
+ * in the `add_inline_data` WordPress action when the user clicks
+ * a Quick Edit link in a Product WP_List_Table.
+ *
+ * WordPress' built in Quick Edit functionality does not do this automatically
+ * for Plugins that register settings, which is why we have this code here.
+ *
+ * @since 	1.4.8
+ */
+jQuery( document ).ready(
+	function( $ ) {
+
+		var ckwcInlineEditPost = inlineEditPost.edit;
+
+		// Extend WordPress' quick edit function.
+		inlineEditPost.edit = function( id ) {
+
+			// Merge arguments from original function.
+			ckwcInlineEditPost.apply( this, arguments );
+
+			// Get Post ID.
+			if ( typeof( id ) === 'object' ) {
+				id = parseInt( this.getId( id ) );
+			}
+
+			// Move Plugin's Quick Edit fields container into the inline editor, if they don't yet exist.
+			// This only needs to be done once.
+			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child .ckwc-quick-edit' ).length === 0 ) {
+				$( '.ckwc-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child' ).show();
+			}
+
+			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
+			$( '.ckwc', $( '#inline_' + id ) ).each(
+				function() {
+
+					// Assign the setting's value to the setting's Quick Edit field.
+					$( '.ckwc-quick-edit select[name="' + $( this ).data( 'setting' ) + '"]' ).val( $( this ).data( 'value' ) );
+
+				}
+			);
+
+		}
+
+	}
+);

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -1,0 +1,56 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to WordPress' Quick Edit functionality that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class WPQuickEdit extends \Codeception\Module
+{
+	/**
+	 * Quick Edits the given Post ID, changing form field values and saving.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
+	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 */
+	public function quickEdit($I, $postType, $postID, $configuration)
+	{
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
+
+		// Hover mouse over Post's table row.
+		$I->moveMouseOver('tr#post-'.$postID);
+
+		// Wait for Quick edit link to be visible.
+		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
+		
+		// Click Quick Edit link.
+		$I->click('tr#post-'.$postID.' button.editinline');
+
+		// Apply configuration.
+		foreach ($configuration as $field=>$attributes) {
+			// Check that the field exists.
+			$I->seeElementInDOM('#' . $field);
+			
+			// Depending on the field's type, define its value.
+			switch ($attributes[0]) {
+				case 'select2':
+					$I->fillSelect2Field($I, '#select2-' . $field . '-container', $attributes[1]);
+					break;
+				case 'select':
+					$I->selectOption('#' . $field, $attributes[1]);
+					break;
+				default:
+					$I->fillField('#' . $field, $attributes[1]);
+					break;
+			}
+		}
+
+		// Click Update.
+		$I->click('Update');
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -27,6 +27,7 @@ modules:
         - \Helper\Acceptance\WPClassicEditor
         - \Helper\Acceptance\WPMetabox
         - \Helper\Acceptance\WPGutenberg
+        - \Helper\Acceptance\WPQuickEdit
         - \Helper\Acceptance\Xdebug
     config:
         WPDb:

--- a/tests/acceptance/ProductCest.php
+++ b/tests/acceptance/ProductCest.php
@@ -171,6 +171,41 @@ class ProductCest
 	}
 
 	/**
+	 * Test that the defined resource (Form, Tag, Sequence) is saved when chosen via
+	 * WordPress' Quick Edit functionality.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testQuickEditUsingDefinedResource(AcceptanceTester $I)
+	{
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin($I);
+
+		// Programmatically create a Product.
+		$productID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Resource: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+		]);
+
+		// Quick Edit the Product in the Products WP_List_Table.
+		$I->quickEdit($I, 'product', $productID, [
+			'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+		]);
+
+		// Reload the Products admin screen.
+		$I->amOnAdminPage('edit.php?post_type=product');
+
+		// Confirm that the chosen Resource is the selected option.
+		$I->seePostMetaInDatabase([
+			'post_id' 	=> $productID,
+			'meta_key' 	=> 'ckwc_subscription',
+			'meta_value'=> 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+		]);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/views/backend/product/quick-edit.php
+++ b/views/backend/product/quick-edit.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Quick Edit view
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+?>
+<div class="ckwc-quick-edit" style="display:none;">
+	<h4><?php esc_html_e( 'ConvertKit for WooCommerce', 'woocommerce-convertkit' ); ?></h4>
+
+	<?php
+	// Load subscription dropdown field.
+	require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+
+	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
+	?>
+</div>

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -59,6 +59,7 @@ if ( is_admin() ) {
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-ajax.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-plugin.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-product.php';
+	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-quick-edit.php';
 }
 
 /**


### PR DESCRIPTION
## Summary

Similar to the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/335), adds options to WordPress' [Quick Edit](https://wordpress.com/support/pages/edit-pages-screen/#quick-edit) functionality to change the ConvertKit Form, Tag or Sequence to subscribe the customer to for a given WooCommerce Product

![Screenshot 2022-07-26 at 18 03 42](https://user-images.githubusercontent.com/1462305/181067241-6ffa52be-9e63-459d-934b-0ebc142886e9.png)

Video:
https://www.loom.com/share/c941acbdf0a44a6d8c34af518c36d366

## Testing

- `ProductCest:testQuickEditUsingDefinedResource`: Tests that using the Quick Edit functionality on an existing WooCommerce Product works when choosing a specific resource.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)