### PR TITLE
Bulk Edit

### DIFF
--- a/admin/class-ckwc-admin-bulk-edit.php
+++ b/admin/class-ckwc-admin-bulk-edit.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * ConvertKit Admin Bulk Edit class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Registers settings fields for output when using WordPress' Bulk Edit functionality
+ * in the WooCommerce Product WP_List_Table.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+class CKWC_Admin_Bulk_Edit {
+
+	/**
+	 * Holds the WooCommerce Integration instance for this Plugin.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @var     CKWC_Integration
+	 */
+	private $integration;
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.4.8
+	 */
+	public function __construct() {
+
+		// Fetch integration.
+		$this->integration = WP_CKWC_Integration();
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+		add_action( 'load-edit.php', array( $this, 'bulk_edit_save' ) );
+
+	}
+
+	/**
+	 * Enqueues scripts and CSS for Bulk Edit functionality in the WooCommerce Product WP_List_Table
+	 *
+	 * @since   1.4.8
+	 */
+	public function enqueue_assets() {
+
+		// Bail if we're not on the Products WP_List_Table.
+		if ( ! $this->is_product_wp_list_table_screen() ) {
+			return;
+		}
+
+		// Enqueue JS.
+		wp_enqueue_script( 'ckwc-bulk-edit', CKWC_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
+
+		// Output Bulk Edit fields in the footer of the Administration screen.
+		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10, 2 );
+
+	}
+
+	/**
+	 * Save Bulk Edit data.
+	 *
+	 * Logic used here follows how WordPress handles bulk editing in bulk_edit_posts().
+	 *
+	 * @since   2.0.0
+	 */
+	public function bulk_edit_save() {
+
+		// Bail if the bulk action isn't 'edit'.
+		if ( ! $this->is_bulk_edit_request() ) {
+			return;
+		}
+
+		// Bail if no nonce field exists.
+		if ( ! isset( $_REQUEST['ckwc_nonce'] ) ) {
+			return;
+		}
+
+		// Bail if the nonce verification fails.
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['ckwc_nonce'] ) ), 'ckwc' ) ) {
+			return;
+		}
+
+		// Bail if no Form / Tag option exists in request data.
+		if ( ! isset( $_REQUEST['ckwc_subscription'] ) ) {
+			return;
+		}
+
+		// Bail if the value is -1, as this means don't change the setting.
+		if ( sanitize_text_field( $_REQUEST['ckwc_subscription'] ) === '-1' ) {
+			return;
+		}
+
+		// Get Post Type object.
+		$post_type = get_post_type_object( $_REQUEST['post_type'] );
+
+		// Bail if the logged in user cannot edit Pages/Posts.
+		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+			wp_die(
+				sprintf(
+					/* translators: Post Type name */
+					esc_html__( 'Sorry, you are not allowed to edit %s.', 'woocommerce-convertkit' ),
+					esc_html( $post_type->name )
+				)
+			);
+		}
+
+		// Get Post IDs that are bulk edited.
+		$post_ids = array_map( 'intval', (array) $_REQUEST['post'] );
+
+		// Iterate through each Post, updating its settings.
+		foreach ( $post_ids as $post_id ) {
+			update_post_meta( $post_id, 'ckwc_subscription', sanitize_text_field( wp_unslash( $_REQUEST['ckwc_subscription'] ) ) );
+		}
+
+	}
+
+	/**
+	 * Outputs Bulk Edit settings fields in the footer of the administration screen.
+	 *
+	 * The Bulk Edit JS will then move these hidden fields into the Bulk Edit row
+	 * when the user clicks on a Bulk Edit action in the WP_List_Table.
+	 *
+	 * @since   1.4.8
+	 */
+	public function bulk_edit_fields() {
+
+		// Don't output Bulk Edit fields if the API settings have not been defined.
+		if ( ! $this->integration->is_enabled() ) {
+			return;
+		}
+
+		// Get Forms, Tags and Sequences.
+		$forms     = new CKWC_Resource_Forms();
+		$sequences = new CKWC_Resource_Sequences();
+		$tags      = new CKWC_Resource_Tags();
+
+		// Get current subscription setting and other settings to render the subscription dropdown field.
+		$subscription = array(
+			'id'           => 'ckwc_subscription',
+			'class'        => 'widefat',
+			'name'         => 'ckwc_subscription',
+			'value'        => '-1', // Select 'No Change' option as default.
+			'forms'        => $forms,
+			'tags'         => $tags,
+			'sequences'    => $sequences,
+			'is_bulk_edit' => true,
+		);
+
+		// Output view.
+		require_once CKWC_PLUGIN_PATH . '/views/backend/product/bulk-edit.php';
+
+	}
+
+	/**
+	 * Checks if the request is for viewing the WooCommerce Add / Edit Product screen.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @return  bool
+	 */
+	private function is_product_wp_list_table_screen() {
+
+		// Return false if we cannot reliably determine the current screen that is viewed,
+		// due to WordPress' get_current_screen() function being unavailable.
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+
+		// Get screen.
+		$screen = get_current_screen();
+
+		// Bail if we're not on a Post Type Edit screen.
+		if ( $screen->base !== 'edit' ) {
+			return false;
+		}
+
+		// Return false if we're not on the Product WP_List_Table.
+		if ( $screen->post_type !== 'product' ) {
+			return false;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Determines if the request is for saving values via bulk editing.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @return  bool    Is bulk edit request
+	 */
+	private function is_bulk_edit_request() {
+
+		// Determine the current bulk action, if any.
+		$wp_list_table = _get_list_table( 'WP_Posts_List_Table' );
+		$bulk_action   = $wp_list_table->current_action();
+
+		// Bail if the bulk action isn't edit.
+		if ( $bulk_action !== 'edit' ) {
+			return false;
+		}
+		if ( ! array_key_exists( 'bulk_edit', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			return false;
+		}
+
+		return true;
+
+	}
+
+}

--- a/admin/class-ckwc-admin-product.php
+++ b/admin/class-ckwc-admin-product.php
@@ -143,25 +143,33 @@ class CKWC_Admin_Product {
 			return;
 		}
 
-		$data = stripslashes_deep( $_POST );
-
-		// Bail if nonce is missing.
-		if ( ! isset( $data['ckwc_nonce'] ) ) {
+		// Bail if this is an autosave.
+		if ( wp_is_post_autosave( $post_id ) ) {
 			return;
 		}
 
-		// Bail if nonce verification fails.
-		if ( ! wp_verify_nonce( $data['ckwc_nonce'], 'ckwc' ) ) {
+		// Bail if this is a post revision.
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		// Bail if no nonce field exists.
+		if ( ! isset( $_POST['ckwc_nonce'] ) ) {
+			return;
+		}
+
+		// Bail if the nonce verification fails.
+		if ( ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['ckwc_nonce'] ) ), 'ckwc' ) ) {
 			return;
 		}
 
 		// Bail if no Form / Tag option exists in POST data.
-		if ( ! isset( $data['ckwc_subscription'] ) ) {
+		if ( ! isset( $_POST['ckwc_subscription'] ) ) {
 			return;
 		}
 
-		// Update Post Meta.
-		update_post_meta( $post_id, 'ckwc_subscription', $data['ckwc_subscription'] );
+		// Save Post's settings.
+		update_post_meta( $post_id, 'ckwc_subscription', sanitize_text_field( wp_unslash( $_POST['ckwc_subscription'] ) ) );
 
 	}
 

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,10 +99,10 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']      = new CKWC_Admin_AJAX();
-		$this->classes['admin_bulk_edit'] = new CKWC_Admin_Bulk_Edit();
-		$this->classes['admin_plugin']    = new CKWC_Admin_Plugin();
-		$this->classes['admin_product']   = new CKWC_Admin_Product();
+		$this->classes['admin_ajax']       = new CKWC_Admin_AJAX();
+		$this->classes['admin_bulk_edit']  = new CKWC_Admin_Bulk_Edit();
+		$this->classes['admin_plugin']     = new CKWC_Admin_Plugin();
+		$this->classes['admin_product']    = new CKWC_Admin_Product();
 		$this->classes['admin_quick_edit'] = new CKWC_Admin_Quick_Edit();
 
 		/**

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,9 +99,10 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']    = new CKWC_Admin_AJAX();
-		$this->classes['admin_plugin']  = new CKWC_Admin_Plugin();
-		$this->classes['admin_product'] = new CKWC_Admin_Product();
+		$this->classes['admin_ajax']      = new CKWC_Admin_AJAX();
+		$this->classes['admin_bulk_edit'] = new CKWC_Admin_Bulk_Edit();
+		$this->classes['admin_plugin']    = new CKWC_Admin_Plugin();
+		$this->classes['admin_product']   = new CKWC_Admin_Product();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -1,0 +1,29 @@
+/**
+ * Bulk Edit
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Copies Bulk Edit fields into WordPress' #bulk-edit table row on load.
+ *
+ * WordPress' built in Bulk Edit functionality does not do this automatically
+ * for Plugins that register settings, which is why we have this code here.
+ *
+ * @since 	1.4.8
+ */
+jQuery( document ).ready(
+	function( $ ) {
+
+		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
+		// if a bulk-edit table row exists (it won't exist if searching returns no pages).
+		if ( $( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).length > 0 ) {
+			$( 'tr#bulk-edit .inline-edit-wrapper fieldset.inline-edit-col-right' ).first().append( $( '#ckwc-bulk-edit' ) );
+
+			// Show the Bulk Edit fields, as they are now contained in the inline-edit row which WordPress will show/hide as necessary.
+			$( '#ckwc-bulk-edit' ).show();
+		}
+
+	}
+);

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -1,0 +1,76 @@
+<?php
+namespace Helper\Acceptance;
+
+// Define any custom actions related to WordPress' Bulk Edit functionality that
+// would be used across multiple tests.
+// These are then available in $I->{yourFunctionName}
+
+class WPBulkEdit extends \Codeception\Module
+{
+	/**
+	 * Bulk Edits the given Post IDs, changing form field values and saving.
+	 * 
+	 * @since 	1.9.8.0
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	array 	$postIDs 		Post IDs.
+	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 */
+	public function bulkEdit($I, $postType, $postIDs, $configuration)
+	{
+		// Open Bulk Edit form for the Posts.
+		$I->openBulkEdit($I, $postType, $postIDs);
+
+		// Apply configuration.
+		foreach ($configuration as $field=>$attributes) {
+			// Check that the field exists.
+			$I->seeElementInDOM('#ckwc-bulk-edit #' . $field);
+			
+			// Depending on the field's type, define its value.
+			switch ($attributes[0]) {
+				case 'select':
+					$I->selectOption('#ckwc-bulk-edit #' . $field, $attributes[1]);
+					break;
+				default:
+					$I->fillField('#ckwc-bulk-edit #' . $field, $attributes[1]);
+					break;
+			}
+		}
+
+		// Scroll to Update button.
+		$I->scrollTo('#bulk_edit');
+
+		// Click Update.
+		$I->click('Update');
+
+		// Confirm that Bulk Editing saved with no errors.
+		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
+	}
+
+	/**
+	 * Opens the Bulk Edit form for the given Post ID.
+	 * 
+	 * @since 	1.9.8.1
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	array 	$postIDs 		Post IDs.
+	 */
+	public function openBulkEdit($I, $postType, $postIDs)
+	{
+		// Navigate to Post Type's WP_List_Table.
+		$I->amOnAdminPage('edit.php?post_type='.$postType);
+
+		// Check boxes for Post IDs.
+		foreach($postIDs as $postID) {
+			$I->checkOption('#cb-select-'.$postID);
+		}
+
+		// Select Edit from the Bulk actions dropdown.
+		$I->selectOption('#bulk-action-selector-top', 'Edit');
+
+		// Click Apply button.
+		$I->click('#doaction');
+	}
+}

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -24,6 +24,7 @@ modules:
         - \Helper\Acceptance\Select2
         - \Helper\Acceptance\ThirdPartyPlugin
         - \Helper\Acceptance\WooCommerce
+        - \Helper\Acceptance\WPBulkEdit
         - \Helper\Acceptance\WPClassicEditor
         - \Helper\Acceptance\WPMetabox
         - \Helper\Acceptance\WPGutenberg

--- a/tests/acceptance/SettingImportExportCest.php
+++ b/tests/acceptance/SettingImportExportCest.php
@@ -69,7 +69,6 @@ class SettingImportExportCest
 		$I->click('Save changes');
 
 		// Confirm success message displays.
-		// @TODO.
 		$I->seeInSource('Configuration imported successfully.');
 
 		// Confirm that the fake API Key and Secret are populated.
@@ -97,7 +96,6 @@ class SettingImportExportCest
 		$I->click('Save changes');
 
 		// Confirm error message displays.
-		// @TODO.
 		$I->seeInSource('The uploaded configuration file contains no settings.');
 	}
 
@@ -121,7 +119,6 @@ class SettingImportExportCest
 		$I->click('Save changes');
 
 		// Confirm error message displays.
-		// @TODO.
 		$I->seeInSource('The uploaded configuration file isn\'t valid.');
 	}
 

--- a/views/backend/product/bulk-edit.php
+++ b/views/backend/product/bulk-edit.php
@@ -12,7 +12,7 @@
 
 	<?php
 	// Load subscription dropdown field.
-	require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
 	?>

--- a/views/backend/product/bulk-edit.php
+++ b/views/backend/product/bulk-edit.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Bulk Edit view
+ *
+ * @package ConvertKit
+ * @author ConvertKit
+ */
+
+?>
+<div id="ckwc-bulk-edit" style="display:none;">
+	<h4><?php esc_html_e( 'ConvertKit for WooCommerce', 'woocommerce-convertkit' ); ?></h4>
+
+	<?php
+	// Load subscription dropdown field.
+	require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+
+	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
+	?>
+</div>
+

--- a/views/backend/product/meta-box.php
+++ b/views/backend/product/meta-box.php
@@ -7,7 +7,7 @@
  */
 
 // Load subscription dropdown field.
-require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 ?>
 
 <p class="description">

--- a/views/backend/product/quick-edit.php
+++ b/views/backend/product/quick-edit.php
@@ -12,7 +12,7 @@
 
 	<?php
 	// Load subscription dropdown field.
-	require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
 	?>

--- a/views/backend/settings/subscription.php
+++ b/views/backend/settings/subscription.php
@@ -17,7 +17,7 @@
 			<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
 			<?php
 			// Load subscription dropdown field.
-			require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+			require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 			echo $this->get_description_html( $data ); // phpcs:ignore WordPress.Security.EscapeOutput
 			?>
 		</fieldset>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -8,7 +8,16 @@
 
 ?>
 <select class="<?php echo esc_attr( $subscription['class'] ); ?>" id="<?php echo esc_attr( $subscription['id'] ); ?>" name="<?php echo esc_attr( $subscription['name'] ); ?>">
-	<option <?php selected( '', $subscription['value'] ); ?> value="">
+	<?php
+	// If Bulk Edit is true, add a No Change option and select it.
+	if ( array_key_exists( 'is_bulk_edit', $subscription ) && $subscription['is_bulk_edit'] === true ) {
+		?>
+		<option value="-1"<?php selected( '', $subscription['value'] ); ?>><?php esc_html_e( '— No Change —', 'woocommerce-convertkit' ); ?></option>
+		<?php
+	}
+	?>
+
+	<option value=""<?php selected( '', $subscription['value'] ); ?>>
 		<?php esc_html_e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?>
 	</option>
 

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -57,6 +57,7 @@ require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-wc-subscriptions.php';
 // Load files that are only used in the WordPress Administration interface.
 if ( is_admin() ) {
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-ajax.php';
+	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-bulk-edit.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-plugin.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-product.php';
 }


### PR DESCRIPTION
## Summary

Similar to the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/336), adds options to WordPress' [Bulk Edit](https://wordpress.com/support/pages/edit-pages-screen/#bulk-edit) functionality to change the ConvertKit Form, Tag or Sequence to subscribe the customer to for a given WooCommerce Product.

![Screenshot 2022-07-27 at 14 04 28](https://user-images.githubusercontent.com/1462305/181253949-cb41e430-4a9a-4398-ae34-b78432b7fc64.png)

Video:
https://www.loom.com/share/6741662a2a784221aa9a6019d8872c60

## Testing

- `ProductCest:testBulkEditWithIntegrationDisabled`: Tests that no Bulk Edit field displays when the integration is disabled.
- `ProductCest:testBulkEditUsingDefinedForm`: Tests that using the Bulk Edit functionality on existing WooCommerce Products works when choosing a Form option.
- `ProductCest:testBulkEditWithNoChanges`: Tests that using the Bulk Edit functionality on existing WooCommerce Products retains settings when no changes are made.
- `ProductCest:testBulkEditFieldsHiddenWhenNoProductsFound`: Tests that no Bulk Edit field displays when performing a WooCommerce Product search that returns no products.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)