### PR TITLE
Add Refresh Button to Products

### DIFF
--- a/admin/class-ckwc-admin-refresh-resources.php
+++ b/admin/class-ckwc-admin-refresh-resources.php
@@ -41,7 +41,7 @@ class CKWC_Admin_Refresh_Resources {
 		$resources = array();
 
 		// Fetch forms.
-		$forms   = new CKWC_Resource_Forms();
+		$forms              = new CKWC_Resource_Forms();
 		$resources['forms'] = $forms->refresh();
 
 		// Bail if an error occured.
@@ -50,7 +50,7 @@ class CKWC_Admin_Refresh_Resources {
 		}
 
 		// Fetch sequences.
-		$sequences   = new CKWC_Resource_Sequences();
+		$sequences              = new CKWC_Resource_Sequences();
 		$resources['sequences'] = $sequences->refresh();
 
 		// Bail if an error occured.
@@ -59,7 +59,7 @@ class CKWC_Admin_Refresh_Resources {
 		}
 
 		// Fetch tags.
-		$tags   = new CKWC_Resource_Tags();
+		$tags              = new CKWC_Resource_Tags();
 		$resources['tags'] = $tags->refresh();
 
 		// Bail if an error occured.
@@ -68,10 +68,10 @@ class CKWC_Admin_Refresh_Resources {
 		}
 
 		// Return resources as a zero based sequential array, so that JS retains the order of resources.
-		$resources['forms'] = array_values( $resources['forms'] );
+		$resources['forms']     = array_values( $resources['forms'] );
 		$resources['sequences'] = array_values( $resources['sequences'] );
-		$resources['tags'] = array_values( $resources['tags'] );
-		
+		$resources['tags']      = array_values( $resources['tags'] );
+
 		wp_send_json_success( $resources );
 
 	}

--- a/admin/class-ckwc-admin-refresh-resources.php
+++ b/admin/class-ckwc-admin-refresh-resources.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * ConvertKit Admin Refresh Resources class.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Registers scripts, which run when a Refresh button is clicked, to refresh resources
+ * asynchronously whilst editing a WooCommerce Product.
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+class CKWC_Admin_Refresh_Resources {
+
+	/**
+	 * Registers action and filter hooks.
+	 *
+	 * @since   1.4.8
+	 */
+	public function __construct() {
+
+		add_action( 'wp_ajax_ckwc_admin_refresh_resources', array( $this, 'refresh_resources' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+
+	}
+
+	/**
+	 * Refreshes sequences, forms and tags from the API, returning them as a JSON string.
+	 *
+	 * @since   1.4.8
+	 */
+	public function refresh_resources() {
+
+		// Check nonce.
+		check_ajax_referer( 'ckwc_admin_refresh_resources', 'nonce' );
+
+		// Define an array to store resources in.
+		$resources = array();
+
+		// Fetch forms.
+		$forms   = new CKWC_Resource_Forms();
+		$resources['forms'] = $forms->refresh();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $resources['forms'] ) ) {
+			wp_send_json_error( $resources['forms']->get_error_message() );
+		}
+
+		// Fetch sequences.
+		$sequences   = new CKWC_Resource_Sequences();
+		$resources['sequences'] = $sequences->refresh();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $resources['sequences'] ) ) {
+			wp_send_json_error( $resources['sequences']->get_error_message() );
+		}
+
+		// Fetch tags.
+		$tags   = new CKWC_Resource_Tags();
+		$resources['tags'] = $tags->refresh();
+
+		// Bail if an error occured.
+		if ( is_wp_error( $resources['tags'] ) ) {
+			wp_send_json_error( $resources['tags']->get_error_message() );
+		}
+
+		// Return resources as a zero based sequential array, so that JS retains the order of resources.
+		$resources['forms'] = array_values( $resources['forms'] );
+		$resources['sequences'] = array_values( $resources['sequences'] );
+		$resources['tags'] = array_values( $resources['tags'] );
+		
+		wp_send_json_success( $resources );
+
+	}
+
+	/**
+	 * Enqueue JavaScript when editing a Page, Post, Custom Post Type or Category.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   string $hook   Hook.
+	 */
+	public function enqueue_scripts( $hook ) {
+
+		// Bail if we are not on an Edit Product screen.
+		if ( $hook !== 'edit.php' && $hook !== 'post-new.php' && $hook !== 'post.php' ) {
+			return;
+		}
+
+		// Get integration.
+		$integration = WP_CKWC_Integration();
+
+		// Bail if no API keys are defined.
+		if ( ! $integration->is_enabled() ) {
+			return;
+		}
+
+		// Enqueue JS to perform AJAX request to refresh resources.
+		wp_enqueue_script( 'ckwc-admin-refresh-resources', CKWC_PLUGIN_URL . 'resources/backend/js/refresh-resources.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
+		wp_localize_script(
+			'ckwc-admin-refresh-resources',
+			'ckwc_admin_refresh_resources',
+			array(
+				'action'  => 'ckwc_admin_refresh_resources',
+				'ajaxurl' => admin_url( 'admin-ajax.php' ),
+				'debug'   => $integration->get_option_bool( 'debug' ),
+				'nonce'   => wp_create_nonce( 'ckwc_admin_refresh_resources' ),
+			)
+		);
+
+	}
+
+}

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,9 +99,10 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']    = new CKWC_Admin_AJAX();
-		$this->classes['admin_plugin']  = new CKWC_Admin_Plugin();
-		$this->classes['admin_product'] = new CKWC_Admin_Product();
+		$this->classes['admin_ajax']    			= new CKWC_Admin_AJAX();
+		$this->classes['admin_plugin']  			= new CKWC_Admin_Plugin();
+		$this->classes['admin_product'] 			= new CKWC_Admin_Product();
+		$this->classes['admin_refresh_resources'] 	= new CKWC_Admin_Refresh_Resources();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,10 +99,10 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']    			= new CKWC_Admin_AJAX();
-		$this->classes['admin_plugin']  			= new CKWC_Admin_Plugin();
-		$this->classes['admin_product'] 			= new CKWC_Admin_Product();
-		$this->classes['admin_refresh_resources'] 	= new CKWC_Admin_Refresh_Resources();
+		$this->classes['admin_ajax']              = new CKWC_Admin_AJAX();
+		$this->classes['admin_plugin']            = new CKWC_Admin_Plugin();
+		$this->classes['admin_product']           = new CKWC_Admin_Product();
+		$this->classes['admin_refresh_resources'] = new CKWC_Admin_Refresh_Resources();
 
 		/**
 		 * Initialize integration classes for the WordPress Administration interface.

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -99,11 +99,11 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['admin_ajax']       = new CKWC_Admin_AJAX();
-		$this->classes['admin_bulk_edit']  = new CKWC_Admin_Bulk_Edit();
-		$this->classes['admin_plugin']     = new CKWC_Admin_Plugin();
-		$this->classes['admin_product']    = new CKWC_Admin_Product();
-		$this->classes['admin_quick_edit'] = new CKWC_Admin_Quick_Edit();
+		$this->classes['admin_ajax']              = new CKWC_Admin_AJAX();
+		$this->classes['admin_bulk_edit']         = new CKWC_Admin_Bulk_Edit();
+		$this->classes['admin_plugin']            = new CKWC_Admin_Plugin();
+		$this->classes['admin_product']           = new CKWC_Admin_Product();
+		$this->classes['admin_quick_edit']        = new CKWC_Admin_Quick_Edit();
 		$this->classes['admin_refresh_resources'] = new CKWC_Admin_Refresh_Resources();
 
 		/**

--- a/lib/class-convertkit-resource.php
+++ b/lib/class-convertkit-resource.php
@@ -112,12 +112,6 @@ class ConvertKit_Resource {
 			return;
 		}
 
-		// If no resources exist, refresh them now.
-		if ( ! $this->resources ) {
-			$this->refresh();
-			return;
-		}
-
 		// If the resources have expired, refresh them now.
 		if ( time() > ( $this->last_queried + $this->cache_duration ) ) {
 			$this->refresh();

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -33,8 +33,8 @@ jQuery( document ).ready(
 
 			// Move Plugin's Quick Edit fields container into the inline editor, if they don't yet exist.
 			// This only needs to be done once.
-			if ( $( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child .ckwc-quick-edit' ).length === 0 ) {
-				$( '.ckwc-quick-edit' ).appendTo( '.inline-edit-wrapper fieldset.inline-edit-col-left:first-child' ).show();
+			if ( $( '.quick-edit-row .inline-edit-wrapper fieldset.inline-edit-col-left:first-child #ckwc-quick-edit' ).length === 0 ) {
+				$( '#ckwc-quick-edit' ).appendTo( '.quick-edit-row .inline-edit-wrapper fieldset.inline-edit-col-left:first-child' ).show();
 			}
 
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
@@ -42,7 +42,7 @@ jQuery( document ).ready(
 				function() {
 
 					// Assign the setting's value to the setting's Quick Edit field.
-					$( '.ckwc-quick-edit select[name="' + $( this ).data( 'setting' ) + '"]' ).val( $( this ).data( 'value' ) );
+					$( '#ckwc-quick-edit select[name="' + $( this ).data( 'setting' ) + '"]' ).val( $( this ).data( 'value' ) );
 
 				}
 			);

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -44,7 +44,7 @@ jQuery( document ).ready(
 
 							// Get currently selected option.
 							var selectedOption = $( field ).val();
-
+							
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
 								function() {
@@ -66,12 +66,13 @@ jQuery( document ).ready(
 								// resoruces = array of resources.
 								resources.forEach(
 									function( item ) {
+										var value = $( 'optgroup#ckwc-' + resource, $( field ) ).data( 'option-value-prefix' ) + item.id;
 										$( 'optgroup#ckwc-' + resource, $( field ) ).append(
 											new Option(
 												item.name,
-												$( 'optgroup#ckwc-' + resource, $( field ) ).data( 'option-value-prefix' ) + item.id,
+												value,
 												false,
-												( selectedOption == item.id ? true : false )
+												( selectedOption == value ? true : false )
 											)
 										);
 									}

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -1,0 +1,101 @@
+/**
+ * Refresh Resources
+ *
+ * @package CKWC
+ * @author ConvertKit
+ */
+
+/**
+ * Refreshes sequences, forms and tags when the Refresh button is clicked.
+ *
+ * @since 	1.4.8
+ */
+jQuery( document ).ready(
+	function( $ ) {
+
+		$( 'button.ckwc-refresh-resources' ).on(
+			'click',
+			function( e ) {
+
+				e.preventDefault();
+
+				// Fetch some DOM elements.
+				var button = this,
+				resource   = $( button ).data( 'resource' ),
+				field      = $( button ).data( 'field' );
+
+				// Disable button.
+				$( button ).prop( 'disabled', true );
+
+				// Perform AJAX request to refresh resource.
+				$.ajax(
+					{
+						type: 'POST',
+						data: {
+							action: 'ckwc_admin_refresh_resources',
+							nonce: ckwc_admin_refresh_resources.nonce
+						},
+						url: ckwc_admin_refresh_resources.ajaxurl,
+						success: function ( response ) {
+
+							if ( ckwc_admin_refresh_resources.debug ) {
+								console.log( response );
+							}
+
+							// Get currently selected option.
+							var selectedOption = $( field ).val();
+
+							// Remove existing select options.
+							$( 'option', $( field ) ).each(
+								function() {
+									// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
+									// This will be present on the 'None' and 'Default' options.
+									if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
+										return;
+									}
+
+									// Remove this option.
+									$( this ).remove();
+								}
+							);
+
+							// Populate each resource type with select options from response data into
+							// the application option group.
+							for ( const[ resource, resources ] of Object.entries( response.data ) ) {
+								// resource = forms, sequences, tags.
+								// resoruces = array of resources.
+								resources.forEach(
+									function( item ) {
+										$( 'optgroup#ckwc-' + resource, $( field ) ).append(
+											new Option(
+												item.name,
+												$( 'optgroup#ckwc-' + resource, $( field ) ).data( 'option-value-prefix' ) + item.id,
+												false, 
+												( selectedOption == item.id ? true : false )
+											)
+										);
+									}
+								);
+							}
+
+							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
+							$( field ).trigger( 'change' );
+							
+							// Enable button.
+							$( button ).prop( 'disabled', false );
+
+						}
+					}
+				).fail(
+					function ( response ) {
+						if ( ckwc_admin_refresh_resources.debug ) {
+							console.log( response );
+						}
+					}
+				);
+
+			}
+		);
+
+	}
+);

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -70,7 +70,7 @@ jQuery( document ).ready(
 											new Option(
 												item.name,
 												$( 'optgroup#ckwc-' + resource, $( field ) ).data( 'option-value-prefix' ) + item.id,
-												false, 
+												false,
 												( selectedOption == item.id ? true : false )
 											)
 										);
@@ -80,7 +80,7 @@ jQuery( document ).ready(
 
 							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
 							$( field ).trigger( 'change' );
-							
+
 							// Enable button.
 							$( button ).prop( 'disabled', false );
 

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -44,7 +44,7 @@ jQuery( document ).ready(
 
 							// Get currently selected option.
 							var selectedOption = $( field ).val();
-							
+
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
 								function() {

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -24,19 +24,16 @@ class WPBulkEdit extends \Codeception\Module
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
-			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
-
 			// Check that the field exists.
-			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
+			$I->seeElementInDOM('#ckwc-bulk-edit #' . $field);
 			
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
-					$I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
+					$I->selectOption('#ckwc-bulk-edit #' . $field, $attributes[1]);
 					break;
 				default:
-					$I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
+					$I->fillField('#ckwc-bulk-edit #' . $field, $attributes[1]);
 					break;
 			}
 		}

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -10,7 +10,7 @@ class WPBulkEdit extends \Codeception\Module
 	/**
 	 * Bulk Edits the given Post IDs, changing form field values and saving.
 	 * 
-	 * @since 	1.9.8.0
+	 * @since 	1.4.8
 	 * 
 	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
 	 * @param 	string 	$postType 		Programmatic Post Type.
@@ -24,16 +24,19 @@ class WPBulkEdit extends \Codeception\Module
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
+			// Field ID will be prefixed with wp-convertkit-bulk-edit-.
+			$fieldID = 'wp-convertkit-bulk-edit-' . $field;
+
 			// Check that the field exists.
-			$I->seeElementInDOM('#ckwc-bulk-edit #' . $field);
+			$I->seeElementInDOM('#convertkit-bulk-edit #' . $fieldID);
 			
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
-					$I->selectOption('#ckwc-bulk-edit #' . $field, $attributes[1]);
+					$I->selectOption('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
 					break;
 				default:
-					$I->fillField('#ckwc-bulk-edit #' . $field, $attributes[1]);
+					$I->fillField('#convertkit-bulk-edit #' . $fieldID, $attributes[1]);
 					break;
 			}
 		}
@@ -51,7 +54,7 @@ class WPBulkEdit extends \Codeception\Module
 	/**
 	 * Opens the Bulk Edit form for the given Post ID.
 	 * 
-	 * @since 	1.9.8.1
+	 * @since 	1.4.8
 	 * 
 	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
 	 * @param 	string 	$postType 		Programmatic Post Type.

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -24,19 +24,16 @@ class WPQuickEdit extends \Codeception\Module
 
 		// Apply configuration.
 		foreach ($configuration as $field=>$attributes) {
-			// Field ID will be prefixed with wp-convertkit-quick-edit.
-			$fieldID = 'wp-convertkit-quick-edit-' . $field;
-
 			// Check that the field exists.
-			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
+			$I->seeElementInDOM('#ckwc-quick-edit #' . $field);
 			
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
-					$I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+					$I->selectOption('#ckwc-quick-edit #' . $field, $attributes[1]);
 					break;
 				default:
-					$I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+					$I->fillField('#ckwc-quick-edit #' . $field, $attributes[1]);
 					break;
 			}
 		}

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -19,6 +19,43 @@ class WPQuickEdit extends \Codeception\Module
 	 */
 	public function quickEdit($I, $postType, $postID, $configuration)
 	{
+		// Open Quick Edit form for the Post.
+		$I->openQuickEdit($I, $postType, $postID);
+
+		// Apply configuration.
+		foreach ($configuration as $field=>$attributes) {
+			// Field ID will be prefixed with wp-convertkit-quick-edit.
+			$fieldID = 'wp-convertkit-quick-edit-' . $field;
+
+			// Check that the field exists.
+			$I->seeElementInDOM('#convertkit-quick-edit #' . $fieldID);
+			
+			// Depending on the field's type, define its value.
+			switch ($attributes[0]) {
+				case 'select':
+					$I->selectOption('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+					break;
+				default:
+					$I->fillField('#convertkit-quick-edit #' . $fieldID, $attributes[1]);
+					break;
+			}
+		}
+
+		// Click Update.
+		$I->click('Update');
+	}
+
+	/**
+	 * Opens the Quick Edit form for the given Post ID.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
+	 * @param 	string 	$postType 		Programmatic Post Type.
+	 * @param 	int 	$postID 		Post ID.
+	 */
+	public function openQuickEdit($I, $postType, $postID)
+	{
 		// Navigate to Post Type's WP_List_Table.
 		$I->amOnAdminPage('edit.php?post_type='.$postType);
 
@@ -30,27 +67,5 @@ class WPQuickEdit extends \Codeception\Module
 		
 		// Click Quick Edit link.
 		$I->click('tr#post-'.$postID.' button.editinline');
-
-		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
-			// Check that the field exists.
-			$I->seeElementInDOM('#' . $field);
-			
-			// Depending on the field's type, define its value.
-			switch ($attributes[0]) {
-				case 'select2':
-					$I->fillSelect2Field($I, '#select2-' . $field . '-container', $attributes[1]);
-					break;
-				case 'select':
-					$I->selectOption('#' . $field, $attributes[1]);
-					break;
-				default:
-					$I->fillField('#' . $field, $attributes[1]);
-					break;
-			}
-		}
-
-		// Click Update.
-		$I->click('Update');
 	}
 }

--- a/tests/acceptance/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/RefreshResourcesButtonCest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Tests the Refresh Resource button, which are displayed next to settings fields
+ * when editing a WooCommerce Product.
+ * 
+ * @since 	1.4.8
+ */
+class RefreshResourcesButtonCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, sequences, tags).
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
+
+		// Change API keys in database to ones that have ConvertKit Resources.
+		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
+		// until a refresh button is clicked.
+		$I->haveOptionInDatabase('woocommerce_ckwc_settings', [
+			'enabled'	 => 'yes',
+			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			'debug'      => 'yes',
+		]);
+	}
+
+	/**
+	 * Test that the refresh button for works when adding a new Product.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnProduct(AcceptanceTester $I)
+	{
+		// Navigate to Product > Add New
+		$I->amOnAdminPage('post-new.php?post_type=product');
+
+		// Click the refresh button.
+		$I->click('button.ckwc-refresh-resources');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
+		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateConvertKitPlugin($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/RefreshResourcesButtonCest.php
@@ -55,6 +55,70 @@ class RefreshResourcesButtonCest
 	}
 
 	/**
+	 * Test that the refresh buttons for Forms, Sequences and Tags works when Quick Editing a WooCommerce Product.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
+	{
+		// Programmatically create a Product.
+		$pageID = $I->havePostInDatabase([
+			'post_type' 	=> 'product',
+			'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Quick Edit',
+		]);
+
+		// Open Quick Edit form for the Product in the WooCommerce Products WP_List_Table.
+		$I->openQuickEdit($I, 'product', $pageID);
+
+		// Click the refresh button.
+		$I->click('button.ckwc-refresh-resources');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#ckwc_subscription', $_ENV['CONVERTKIT_API_FORM_NAME']);
+	}
+
+	/**
+	 * Test that the refresh buttons for Forms, Sequences and Tags works when Bulk Editing WooCommerce Products.
+	 * 
+	 * @since 	1.4.8
+	 * 
+	 * @param 	AcceptanceTester 	$I 	Tester
+	 */
+	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
+	{
+		// Programmatically create two Pages.
+		$productIDs = array(
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Bulk Edit #1',
+			]),
+			$I->havePostInDatabase([
+				'post_type' 	=> 'product',
+				'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Bulk Edit #2',
+			])
+		);
+
+		// Open Bulk Edit form for the Products in the WooCommerce Products WP_List_Table.
+		$I->openBulkEdit($I, 'product', $productIDs);
+
+		// Click the refresh button.
+		$I->click('button.ckwc-refresh-resources');
+
+		// Wait for button to change its state from disabled.
+		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
+
+		// Change resource to value specified in the .env file, which should now be available.
+		// If the expected dropdown value does not exist, this will fail the test.
+		$I->selectOption('#ckwc_subscription', $_ENV['CONVERTKIT_API_FORM_NAME']);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/RefreshResourcesButtonCest.php
@@ -51,7 +51,7 @@ class RefreshResourcesButtonCest
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
-		$I->fillSelect2Field($I, '#select2-wp-convertkit-form-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
+		$I->fillSelect2Field($I, '#select2-ckwc_subscription-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}
 
 	/**

--- a/tests/acceptance/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/RefreshResourcesButtonCest.php
@@ -73,10 +73,10 @@ class RefreshResourcesButtonCest
 		$I->openQuickEdit($I, 'product', $pageID);
 
 		// Click the refresh button.
-		$I->click('button.ckwc-refresh-resources');
+		$I->click('#ckwc-quick-edit button.ckwc-refresh-resources');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
+		$I->waitForElementVisible('#ckwc-quick-edit button.ckwc-refresh-resources:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
@@ -108,10 +108,10 @@ class RefreshResourcesButtonCest
 		$I->openBulkEdit($I, 'product', $productIDs);
 
 		// Click the refresh button.
-		$I->click('button.ckwc-refresh-resources');
+		$I->click('#ckwc-bulk-edit button.ckwc-refresh-resources');
 
 		// Wait for button to change its state from disabled.
-		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
+		$I->waitForElementVisible('#ckwc-bulk-edit button.ckwc-refresh-resources:not(:disabled)');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.

--- a/views/backend/product/bulk-edit.php
+++ b/views/backend/product/bulk-edit.php
@@ -13,7 +13,12 @@
 	<?php
 	// Load subscription dropdown field.
 	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+	?>
+	<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+		<span class="dashicons dashicons-update"></span>
+	</button>
 
+	<?php
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
 	?>
 </div>

--- a/views/backend/product/meta-box.php
+++ b/views/backend/product/meta-box.php
@@ -10,7 +10,7 @@
 require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 ?>
 
-<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
 	<span class="dashicons dashicons-update"></span>
 </button>
 

--- a/views/backend/product/meta-box.php
+++ b/views/backend/product/meta-box.php
@@ -10,6 +10,10 @@
 require_once CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
 ?>
 
+<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+	<span class="dashicons dashicons-update"></span>
+</button>
+
 <p class="description">
 	<?php esc_html_e( 'The ConvertKit form, tag or sequence to subscribe customers to who purchase this product.', 'woocommerce-convertkit' ); ?>
 </p>

--- a/views/backend/product/quick-edit.php
+++ b/views/backend/product/quick-edit.php
@@ -7,7 +7,7 @@
  */
 
 ?>
-<div class="ckwc-quick-edit" style="display:none;">
+<div id="ckwc-quick-edit" style="display:none;">
 	<h4><?php esc_html_e( 'ConvertKit for WooCommerce', 'woocommerce-convertkit' ); ?></h4>
 
 	<?php

--- a/views/backend/product/quick-edit.php
+++ b/views/backend/product/quick-edit.php
@@ -13,7 +13,12 @@
 	<?php
 	// Load subscription dropdown field.
 	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+	?>
+	<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+		<span class="dashicons dashicons-update"></span>
+	</button>
 
+	<?php
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );
 	?>
 </div>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -12,7 +12,7 @@
 	// If Bulk Edit is true, add a No Change option and select it.
 	if ( array_key_exists( 'is_bulk_edit', $subscription ) && $subscription['is_bulk_edit'] === true ) {
 		?>
-		<option value="-1"<?php selected( '', $subscription['value'] ); ?>><?php esc_html_e( '— No Change —', 'woocommerce-convertkit' ); ?></option>
+		<option value="-1" data-preserve-on-refresh="1"<?php selected( '', $subscription['value'] ); ?>><?php esc_html_e( '— No Change —', 'woocommerce-convertkit' ); ?></option>
 		<?php
 	}
 	?>

--- a/views/backend/subscription-dropdown-field.php
+++ b/views/backend/subscription-dropdown-field.php
@@ -8,52 +8,44 @@
 
 ?>
 <select class="<?php echo esc_attr( $subscription['class'] ); ?>" id="<?php echo esc_attr( $subscription['id'] ); ?>" name="<?php echo esc_attr( $subscription['name'] ); ?>">
-	<option <?php selected( '', $subscription['value'] ); ?> value="">
+	<option <?php selected( '', $subscription['value'] ); ?> value="" data-preserve-on-refresh="1">
 		<?php esc_html_e( 'Select a subscription option...', 'woocommerce-convertkit' ); ?>
 	</option>
 
-	<?php
-	if ( $subscription['sequences']->exist() ) {
-		?>
-		<optgroup label="<?php esc_attr_e( 'Sequences', 'woocommerce-convertkit' ); ?>">
-			<?php
+	<optgroup label="<?php esc_attr_e( 'Sequences', 'woocommerce-convertkit' ); ?>" id="ckwc-sequences" data-option-value-prefix="course:">
+		<?php
+		if ( $subscription['sequences']->exist() ) {
 			foreach ( $subscription['sequences']->get() as $sequence ) {
 				// 'course:' is deliberate for backward compat. functionality when Sequences used to be called Courses.
 				?>
 				<option value="course:<?php echo esc_attr( $sequence['id'] ); ?>"<?php selected( 'course:' . esc_attr( $sequence['id'] ), $subscription['value'] ); ?>><?php echo esc_html( $sequence['name'] ); ?></option>
 				<?php
 			}
-			?>
-		</optgroup>
-		<?php
-	}
-
-	if ( $subscription['forms']->exist() ) {
+		}
 		?>
-		<optgroup label="<?php esc_attr_e( 'Forms', 'woocommerce-convertkit' ); ?>">
-			<?php
+	</optgroup>
+
+	<optgroup label="<?php esc_attr_e( 'Forms', 'woocommerce-convertkit' ); ?>" id="ckwc-forms" data-option-value-prefix="form:">
+		<?php
+		if ( $subscription['forms']->exist() ) {
 			foreach ( $subscription['forms']->get() as $form ) {
 				?>
 				<option value="form:<?php echo esc_attr( $form['id'] ); ?>"<?php selected( 'form:' . esc_attr( $form['id'] ), $subscription['value'] ); ?>><?php echo esc_html( $form['name'] ); ?></option>
 				<?php
 			}
-			?>
-		</optgroup>
-		<?php
-	}
-
-	if ( $subscription['tags']->exist() ) {
+		}
 		?>
-		<optgroup label="<?php esc_attr_e( 'Tags', 'woocommerce-convertkit' ); ?>">
-			<?php
+	</optgroup>
+
+	<optgroup label="<?php esc_attr_e( 'Tags', 'woocommerce-convertkit' ); ?>" id="ckwc-tags" data-option-value-prefix="tag:">
+		<?php
+		if ( $subscription['tags']->exist() ) {
 			foreach ( $subscription['tags']->get() as $convertkit_tag ) {
 				?>
 				<option value="tag:<?php echo esc_attr( $convertkit_tag['id'] ); ?>"<?php selected( 'tag:' . esc_attr( $convertkit_tag['id'] ), $subscription['value'] ); ?>><?php echo esc_html( $convertkit_tag['name'] ); ?></option>
 				<?php
 			}
-			?>
-		</optgroup>
-		<?php
-	}
-	?>
+		}
+		?>
+	</optgroup>
 </select>

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -59,6 +59,7 @@ if ( is_admin() ) {
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-ajax.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-plugin.php';
 	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-product.php';
+	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-refresh-resources.php';
 }
 
 /**


### PR DESCRIPTION
## Summary

Similar to the [ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/339), adds a refresh button next to the subscription setting on WooCommerce Products, to refresh the cached forms, sequences and tags from the API.

- adding/editing Products
![Screenshot 2022-08-02 at 15 07 44](https://user-images.githubusercontent.com/1462305/182394946-86aaea58-07af-4b15-9eac-daedf34c330e.png)

- quick/bulk editing Products
![Screenshot 2022-08-02 at 15 07 16](https://user-images.githubusercontent.com/1462305/182394920-b420e7c6-b865-4d8c-818b-382aca779dd0.png)

This solves two issues:

1. Currently, only WordPress Administrators have access to forcing a refresh of resources by navigating to the `WooCommerce > Settings > Integrations > ConvertKit` screen.  WordPress Editors and Authors do not have access to this screen, which is standard WordPress behaviour - however, Editors and Authors in WordPress can create/edit Products, and configure the per-Product subscription setting for ConvertKit.

2.  There can be confusion when a ConvertKit user (whether a WordPress Administrator or not) adds/edits/deletes a form, sequence or tag to their ConvertKit account, only to then not know how to reflect that change in WordPress.  See https://wordpress.org/support/topic/tags-not-updating-to-woocommerce-wp-site/ for an example of this.

## Testing

- `RefreshResourcesButtonCest`: Adds tests to confirm that the refresh buttons populates the subscription field with forms, sequences and tags.  To emulate a resource being added to a ConvertKit account, the test switches from API keys for an account with no resources to API keys for an account with resources.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)