### PR TITLE
Run tests against WordPress 6.1 RC5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ '6.1-RC4' ]
+        wp-versions: [ '6.1-RC5' ]
         php-versions: [ '7.4', '8.0' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
     # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
     strategy:
       matrix:
-        wp-versions: [ '6.0.3' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0' ]
+        wp-versions: [ '6.1-RC4' ]
+        php-versions: [ '7.4', '8.0' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [


### PR DESCRIPTION
## Summary

Run tests against WordPress 6.1 RC5, head of WordPress 6.1's formal release on ~ 1st November 2022.

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)