### PR TITLE
Tests: Apply Coding Standards

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -116,10 +116,15 @@ jobs:
         working-directory: ${{ env.PLUGIN_DIR }}
         run: composer dump-autoload
 
-      # Run WordPress Coding Standards tests.
-      - name: Run WordPress Coding Standards Tests
+      # Run Coding Standards on Tests.
+      - name: Run Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
-        run: php vendor/bin/phpcs ./ -v -s
+        run: php vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -v -s
+
+      # Run WordPress Coding Standards on Plugin.
+      - name: Run WordPress Coding Standards
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/phpcs ./ --standard=phpcs.xml -v -s
 
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <description>Coding Standards for Tests</description>
+
+    <!-- Check that code meets WordPress-Extra standards. -->
+    <rule ref="WordPress-Extra">
+        <!-- Don't use yoda conditions -->
+        <exclude name="WordPress.PHP.YodaConditions" />
+
+        <!-- File and variable naming conventions in Codeception differ from WordPress -->
+        <exclude name="WordPress.NamingConventions" />
+        <exclude name="WordPress.Files.FileName" />
+
+        <!-- Class and function braces and spacing in Codeceptoin differs from WordPress -->
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
+        <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
+        <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
+        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+
+        <!-- _before() and _passed() must use underscores in Codeception -->
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
+
+        <!-- Permit [] instead of array() -->
+        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+        
+        <!-- We might use some datetime functions for tests -->
+        <exclude name="WordPress.DateTime.RestrictedFunctions" />
+
+        <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
+        <exclude name="WordPress.WP.EnqueuedResources" />
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
+        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+    </rule>
+
+    <!-- Check that code is documented to WordPress Standards. -->
+    <rule ref="WordPress-Docs">
+        <!-- File document level comments are useless for tests; we know what a test suite does -->
+        <exclude name="Squiz.Commenting.FileComment.Missing" />
+    </rule>
+
+    <!-- Add in some extra rules from other standards. -->
+    <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+    <rule ref="Generic.Commenting.Todo"/>
+</ruleset>

--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class AcceptanceTester extends \Codeception\Actor
 {
 	use _generated\AcceptanceTesterActions;

--- a/tests/_support/FunctionalTester.php
+++ b/tests/_support/FunctionalTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class FunctionalTester extends \Codeception\Actor
 {
 	use _generated\FunctionalTesterActions;

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -9,18 +9,22 @@ class ConvertKitAPI extends \Codeception\Module
 {
 	/**
 	 * Check the given email address exists as a subscriber on ConvertKit.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 * @param 	mixed 			$firstName 		Name (false = don't check name matches)
-	 * @return 	array 							Subscriber
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   string           $emailAddress   Email Address
+	 * @param   mixed            $firstName      Name (false = don't check name matches)
+	 * @return  array                           Subscriber
+	 */
 	public function apiCheckSubscriberExists($I, $emailAddress, $firstName = false)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check at least one subscriber was returned and it matches the email address.
 		$I->assertGreaterThan(0, $results['total_subscribers']);
@@ -36,16 +40,20 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given email address does not exists as a subscriber.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckSubscriberDoesNotExist($I, $emailAddress)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check no subscribers are returned by this request.
 		$I->assertEquals(0, $results['total_subscribers']);
@@ -53,17 +61,21 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given email address and name exists as a subscriber on ConvertKit.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	string 			$emailAddress 	Email Address
-	 * @param 	string 			$name 			Name
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   string           $emailAddress   Email Address
+	 * @param   string           $name           Name
+	 */
 	public function apiCheckSubscriberEmailAndNameExists($I, $emailAddress, $name)
 	{
 		// Run request.
-		$results = $this->apiRequest('subscribers', 'GET', [
-			'email_address' => $emailAddress,
-		]);
+		$results = $this->apiRequest(
+			'subscribers',
+			'GET',
+			[
+				'email_address' => $emailAddress,
+			]
+		);
 
 		// Check at least one subscriber was returned and it matches the email address.
 		$I->assertGreaterThan(0, $results['total_subscribers']);
@@ -75,12 +87,12 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given order ID exists as a purchase on ConvertKit.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	int 			$orderID 		Order ID
-	 * @param 	string 			$emailAddress 	Email Address
-	 * @param 	int 			$productID 		Product ID
-	 */ 
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   int              $orderID        Order ID
+	 * @param   string           $emailAddress   Email Address
+	 * @param   int              $productID      Product ID
+	 */
 	public function apiCheckPurchaseExists($I, $orderID, $emailAddress, $productID)
 	{
 		// Run request.
@@ -106,11 +118,11 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the given order ID does not exist as a purchase on ConvertKit.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	int 			$orderID 		Order ID
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   int              $orderID        Order ID
+	 * @param   string           $emailAddress   Email Address
+	 */
 	public function apiCheckPurchaseDoesNotExist($I, $orderID, $emailAddress)
 	{
 		// Run request.
@@ -125,21 +137,21 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Returns a Purchase from the /purchases API endpoint based on the given Order ID (transaction_id).
-	 * 
+	 *
 	 * We cannot use /purchases/{id} as {id} is the ConvertKit ID, not the WooCommerce Order ID (which
 	 * is stored in the transaction_id).
-	 * 
-	 * @param 	array 	$purchases 	Purchases Data
-	 * @param 	int 	$orderID 	Order ID
-	 * @return 	array
+	 *
+	 * @param   array $purchases  Purchases Data
+	 * @param   int   $orderID    Order ID
+	 * @return  array
 	 */
 	private function apiExtractPurchaseFromPurchases($purchases, $orderID)
 	{
 		// Bail if no purchases exist.
-		if (!isset($purchases)) {
+		if ( ! isset($purchases)) {
 			return [
-				'id' => 0,
-				'order_id' => 0,
+				'id'            => 0,
+				'order_id'      => 0,
 				'email_address' => 'no',
 			];
 		}
@@ -156,22 +168,22 @@ class ConvertKitAPI extends \Codeception\Module
 
 		// No purchase exists with the given order ID. Return a blank array.
 		return [
-			'id' => 0,
-			'order_id' => 0,
+			'id'            => 0,
+			'order_id'      => 0,
 			'email_address' => 'no2',
 		];
 	}
 
 	/**
 	 * Returns all purchases from the API.
-	 * 
-	 * @return 	array
+	 *
+	 * @return  array
 	 */
 	public function apiGetPurchases()
 	{
 		// Get first page of purchases.
-		$purchases = $this->apiRequest('purchases', 'GET');
-		$data = $purchases['purchases'];
+		$purchases  = $this->apiRequest('purchases', 'GET');
+		$data       = $purchases['purchases'];
 		$totalPages = $purchases['total_pages'];
 
 		if ($totalPages == 1) {
@@ -180,9 +192,13 @@ class ConvertKitAPI extends \Codeception\Module
 
 		// Get additional pages of purchases.
 		for ($page = 2; $page <= $totalPages; $page++) {
-			$purchases = $this->apiRequest('purchases', 'GET', [
-				'page' => $page,
-			]);
+			$purchases = $this->apiRequest(
+				'purchases',
+				'GET',
+				[
+					'page' => $page,
+				]
+			);
 
 			$data = array_merge($data, $purchases['purchases']);
 		}
@@ -193,23 +209,27 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Unsubscribes the given email address. Useful for clearing the API
 	 * between tests.
-	 * 
-	 * @param 	string 			$emailAddress 	Email Address
-	 */ 	
+	 *
+	 * @param   string $emailAddress   Email Address
+	 */
 	public function apiUnsubscribe($emailAddress)
 	{
 		// Run request.
-		$this->apiRequest('unsubscribe', 'PUT', [
-			'email' => $emailAddress,
-		]);
+		$this->apiRequest(
+			'unsubscribe',
+			'PUT',
+			[
+				'email' => $emailAddress,
+			]
+		);
 	}
 
 	/**
 	 * Check the subscriber array's custom field data is valid.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	array 			$subscriber 	Subscriber from API
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   array            $subscriber     Subscriber from API
+	 */
 	public function apiCustomFieldDataIsValid($I, $subscriber)
 	{
 		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
@@ -221,10 +241,10 @@ class ConvertKitAPI extends \Codeception\Module
 
 	/**
 	 * Check the subscriber array's custom field data is empty.
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	array 			$subscriber 	Subscriber from API
-	 */ 	
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   array            $subscriber     Subscriber from API
+	 */
 	public function apiCustomFieldDataIsEmpty($I, $subscriber)
 	{
 		$I->assertEquals($subscriber['fields']['phone_number'], '');
@@ -237,32 +257,39 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Sends a request to the ConvertKit API, typically used to read an endpoint to confirm
 	 * that data in an Acceptance Test was added/edited/deleted successfully.
-	 * 
-	 * @param 	string 	$endpoint 	Endpoint
-	 * @param 	string 	$method 	Method (GET|POST|PUT)
-	 * @param 	array 	$params 	Endpoint Parameters
+	 *
+	 * @param   string $endpoint   Endpoint
+	 * @param   string $method     Method (GET|POST|PUT)
+	 * @param   array  $params     Endpoint Parameters
 	 */
 	public function apiRequest($endpoint, $method = 'GET', $params = array())
 	{
 		// Build query parameters.
-		$params = array_merge($params, [
-			'api_key' => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-		]);
+		$params = array_merge(
+			$params,
+			[
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+			]
+		);
 
 		// Send request.
 		try {
 			$client = new \GuzzleHttp\Client();
-			$result = $client->request($method, 'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params), [
-				'headers' => [
-					'Accept-Encoding' => 'gzip',
-					'timeout'         => 5,
-				],
-			]);
+			$result = $client->request(
+				$method,
+				'https://api.convertkit.com/v3/' . $endpoint . '?' . http_build_query($params),
+				[
+					'headers' => [
+						'Accept-Encoding' => 'gzip',
+						'timeout'         => 5,
+					],
+				]
+			);
 
 			// Return JSON decoded response.
 			return json_decode($result->getBody()->getContents(), true);
-		} catch(\GuzzleHttp\Exception\ClientException $e) {
+		} catch (\GuzzleHttp\Exception\ClientException $e) {
 			return [];
 		}
 	}

--- a/tests/_support/Helper/Acceptance/Email.php
+++ b/tests/_support/Helper/Acceptance/Email.php
@@ -10,16 +10,16 @@ class Email extends \Codeception\Module
 	/**
 	 * Generates a unique email address for use in a test, comprising of a prefix,
 	 * date + time and PHP version number.
-	 * 
+	 *
 	 * This ensures that if tests are run in parallel, the same email address
 	 * isn't used for two tests across parallel testing runs.
-	 * 
-	 * @since 	1.9.6.7
+	 *
+	 * @since   1.9.6.7
 	 */
 	public function generateEmailAddress()
 	{
 		// Include uniqid() as there's a possibility that tests run in parallel on the same PHP version
 		// could request an email address on the same second.
-		return 'wordpress-'.uniqid().'-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
+		return 'wordpress-' . uniqid() . '-' . date( 'Y-m-d-H-i-s' ) . '-php-' . PHP_VERSION_ID . '@convertkit.com';
 	}
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -10,8 +10,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to activate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function activateConvertKitPlugin($I)
 	{
@@ -21,8 +21,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to deactivate the ConvertKit Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function deactivateConvertKitPlugin($I)
 	{
@@ -34,8 +34,8 @@ class Plugin extends \Codeception\Module
 	 * - WooCommerce
 	 * - WooCommerce Stripe Gateway
 	 * - ConvertKit for WooCommerce
-	 * 
-	 * @since 	1.0.0
+	 *
+	 * @since   1.0.0
 	 */
 	public function activateWooCommerceAndConvertKitPlugins($I)
 	{
@@ -58,8 +58,8 @@ class Plugin extends \Codeception\Module
 	 * - WooCommerce
 	 * - WooCommerce Stripe Gateway
 	 * - ConvertKit for WooCommerce
-	 * 
-	 * @since 	1.0.0
+	 *
+	 * @since   1.0.0
 	 */
 	public function deactivateWooCommerceAndConvertKitPlugins($I)
 	{
@@ -70,17 +70,17 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to setup the Plugin's API Key and Secret.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	mixed 	$apiKey 	API Key (if specified, used instead of CONVERTKIT_API_KEY)
-	 * @param 	mixed 	$apiSecret 	API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   mixed $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY)
+	 * @param   mixed $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET)
 	 */
 	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
 	{
 		// Determine API Key and Secret to use.
-		$convertKitAPIKey = ($apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY']);
-		$convertKitAPISecret = ($apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET']);
+		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
+		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -99,15 +99,15 @@ class Plugin extends \Codeception\Module
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the value of the fields match the inputs provided.
-		$I->seeCheckboxIsChecked('#woocommerce_ckwc_enabled');	
+		$I->seeCheckboxIsChecked('#woocommerce_ckwc_enabled');
 		$I->seeInField('woocommerce_ckwc_api_key', $convertKitAPIKey);
 		$I->seeInField('woocommerce_ckwc_api_secret', $convertKitAPISecret);
 	}
 
 	/**
 	 * Helper method to reset the ConvertKit Plugin settings, as if it's a clean installation.
-	 * 
-	 * @since 	1.9.6.7
+	 *
+	 * @since   1.9.6.7
 	 */
 	public function resetConvertKitPlugin($I)
 	{
@@ -128,8 +128,8 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to delete option table rows for review requests.
 	 * Useful for resetting the review state between tests.
-	 * 
-	 * @since 	1.4.3
+	 *
+	 * @since   1.4.3
 	 */
 	public function deleteConvertKitReviewRequestOptions($I)
 	{
@@ -139,8 +139,8 @@ class Plugin extends \Codeception\Module
 
 	/**
 	 * Helper method to load the WooCommerce > Settings > Integration > ConvertKit screen.
-	 * 
-	 * @since 	1.0.0
+	 *
+	 * @since   1.0.0
 	 */
 	public function loadConvertKitSettingsScreen($I)
 	{

--- a/tests/_support/Helper/Acceptance/Select2.php
+++ b/tests/_support/Helper/Acceptance/Select2.php
@@ -9,19 +9,19 @@ class Select2 extends \Codeception\Module
 {
 	/**
 	 * Helper method to enter text into a jQuery Select2 Field, selecting the option that appears.
-	 * 
-	 * @since 	1.9.6.4
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	string 				$container 	Field CSS Class / ID
-	 * @param 	string 				$value 		Field Value
-	 * @param 	string 				$ariaAttributeName 	Aria Attribute Name (aria-controls|aria-owns)
+	 *
+	 * @since   1.9.6.4
+	 *
+	 * @param   AcceptanceTester $I
+	 * @param   string           $container  Field CSS Class / ID
+	 * @param   string           $value      Field Value
+	 * @param   string           $ariaAttributeName  Aria Attribute Name (aria-controls|aria-owns)
 	 */
 	public function fillSelect2Field($I, $container, $value, $ariaAttributeName = 'aria-controls')
 	{
-		$fieldID = $I->grabAttributeFrom($container, 'id');
+		$fieldID   = $I->grabAttributeFrom($container, 'id');
 		$fieldName = str_replace('-container', '', str_replace('select2-', '', $fieldID));
-		$I->click('#'.$fieldID);
+		$I->click('#' . $fieldID);
 		$I->waitForElementVisible('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]');
 		$I->fillField('.select2-search__field[' . $ariaAttributeName . '="select2-' . $fieldName . '-results"]', $value);
 		$I->waitForElementVisible('ul#select2-' . $fieldName . '-results li.select2-results__option--highlighted');

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -10,10 +10,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
@@ -36,10 +36,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	/**
 	 * Helper method to activate a third party Plugin, checking
 	 * it activated and no errors were output.
-	 * 
-	 * @since 	1.9.6.7
-	 * 
-	 * @param 	string 	$name 	Plugin Slug.
+	 *
+	 * @since   1.9.6.7
+	 *
+	 * @param   string $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -9,13 +9,13 @@ class WPBulkEdit extends \Codeception\Module
 {
 	/**
 	 * Bulk Edits the given Post IDs, changing form field values and saving.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   array                                    $postIDs        Post IDs.
+	 * @param   array                                    $configuration  Configuration (field => value key/value array).
 	 */
 	public function bulkEdit($I, $postType, $postIDs, $configuration)
 	{
@@ -23,10 +23,10 @@ class WPBulkEdit extends \Codeception\Module
 		$I->openBulkEdit($I, $postType, $postIDs);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Check that the field exists.
 			$I->seeElementInDOM('#ckwc-bulk-edit #' . $field);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
@@ -48,26 +48,26 @@ class WPBulkEdit extends \Codeception\Module
 		$I->waitForElementVisible('div.updated.notice.is-dismissible');
 
 		// Confirm that Bulk Editing saved with no errors.
-		$I->seeInSource(count($postIDs).' '.$postType.'s updated');
+		$I->seeInSource(count($postIDs) . ' ' . $postType . 's updated');
 	}
 
 	/**
 	 * Opens the Bulk Edit form for the given Post ID.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	array 	$postIDs 		Post IDs.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   array                                    $postIDs        Post IDs.
 	 */
 	public function openBulkEdit($I, $postType, $postIDs)
 	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+		$I->amOnAdminPage('edit.php?post_type=' . $postType);
 
 		// Check boxes for Post IDs.
-		foreach($postIDs as $postID) {
-			$I->checkOption('#cb-select-'.$postID);
+		foreach ($postIDs as $postID) {
+			$I->checkOption('#cb-select-' . $postID);
 		}
 
 		// Select Edit from the Bulk actions dropdown.

--- a/tests/_support/Helper/Acceptance/WPClassicEditor.php
+++ b/tests/_support/Helper/Acceptance/WPClassicEditor.php
@@ -9,10 +9,10 @@ class WPClassicEditor extends \Codeception\Module
 {
 	/**
 	 * Add a Page, Post or Custom Post Type using the Classic Editor in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function addClassicEditorPage($I, $postType = 'page', $title)
 	{
@@ -20,7 +20,7 @@ class WPClassicEditor extends \Codeception\Module
 		$I->activateThirdPartyPlugin($I, 'classic-editor');
 
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
 		// Define the Title.
 		$I->fillField('#title', $title);
@@ -29,16 +29,16 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Visual Editor (TinyMCE).
-	 * 
+	 *
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                          Acceptance Tester.
+	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
+	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
 	 */
 	public function addVisualEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false)
 	{
@@ -46,24 +46,24 @@ class WPClassicEditor extends \Codeception\Module
 		$I->click('button#content-tmce');
 
 		// Click the TinyMCE Button for this shortcode.
-		$I->click('div.mce-container div[aria-label="'.$shortcodeName.'"] button');
+		$I->click('div.mce-container div[aria-label="' . $shortcodeName . '"] button');
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-modal-body input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
+			foreach ($shortcodeConfiguration as $field => $attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
 
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
-						$I->selectOption('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+						$I->selectOption('#convertkit-modal-body-body ' . $fieldID, $attributes[1]);
 						break;
 					default:
-						$I->fillField('#convertkit-modal-body-body '.$fieldID, $attributes[1]);
+						$I->fillField('#convertkit-modal-body-body ' . $fieldID, $attributes[1]);
 						break;
 				}
 			}
@@ -83,16 +83,16 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Add the given shortcode when adding or editing a Page, Post or Custom Post Type
 	 * in the Text Editor.
-	 * 
+	 *
 	 * If a shortcode configuration is specified, applies it to the newly added shortcode.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 							Acceptance Tester.
-	 * @param 	string 				$shortcodeName 				Shortcode Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$shortcodeProgrammaticName 	Programmatic Shortcode Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$shortcodeConfiguration 	Shortcode Configuration (field => value key/value array).
-	 * @param 	bool|string 		$expectedShortcodeOutput 	Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                          Acceptance Tester.
+	 * @param   string           $shortcodeName              Shortcode Name (e.g. 'ConvertKit Form').
+	 * @param   string           $shortcodeProgrammaticName  Programmatic Shortcode Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $shortcodeConfiguration     Shortcode Configuration (field => value key/value array).
+	 * @param   bool|string      $expectedShortcodeOutput    Expected Shortcode Output (e.g. [convertkit_form form="12345"]).
 	 */
 	public function addTextEditorShortcode($I, $shortcodeName, $shortcodeProgrammaticName, $shortcodeConfiguration = false, $expectedShortcodeOutput = false)
 	{
@@ -100,17 +100,17 @@ class WPClassicEditor extends \Codeception\Module
 		$I->click('button#content-html');
 
 		// Click the QuickTags Button for this shortcode.
-		$I->click('input#qt_content_'.$shortcodeProgrammaticName);
+		$I->click('input#qt_content_' . $shortcodeProgrammaticName);
 
 		// Wait for the modal's contents to load.
 		$I->waitForElementVisible('#convertkit-quicktags-modal input.button-primary');
 
 		// If a shortcode configuration is specified, apply it to the shortcode's modal window now.
 		if ($shortcodeConfiguration) {
-			foreach ($shortcodeConfiguration as $field=>$attributes) {
+			foreach ($shortcodeConfiguration as $field => $attributes) {
 				// Field ID will be the attribute name, prefixed with tinymce_modal
 				$fieldID = '#tinymce_modal_' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -135,10 +135,10 @@ class WPClassicEditor extends \Codeception\Module
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addClassicEditorPage() function,
 	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function publishAndViewClassicEditorPage($I)
 	{
@@ -147,7 +147,7 @@ class WPClassicEditor extends \Codeception\Module
 
 		// Wait for notice to display.
 		$I->waitForElementVisible('.notice-success');
-		
+
 		// Load the Page on the frontend site.
 		$I->click('.notice-success a');
 

--- a/tests/_support/Helper/Acceptance/WPGutenberg.php
+++ b/tests/_support/Helper/Acceptance/WPGutenberg.php
@@ -11,30 +11,34 @@ class WPGutenberg extends \Codeception\Module
 	 * Helper method to close the Gutenberg "Welcome to the block editor" dialog, which
 	 * might show for each Page/Post test performed due to there being no persistence
 	 * remembering that the user dismissed the dialog.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function maybeCloseGutenbergWelcomeModal($I)
 	{
 		try {
-			$I->performOn('.components-modal__screen-overlay', [
-				'click' => '.components-modal__screen-overlay .components-modal__header button.components-button'
-			], 3);
+			$I->performOn(
+				'.components-modal__screen-overlay',
+				[
+					'click' => '.components-modal__screen-overlay .components-modal__header button.components-button',
+				],
+				3
+			);
 		} catch ( \Facebook\WebDriver\Exception\TimeoutException $e ) {
 		}
 	}
 
 	/**
 	 * Add a Page, Post or Custom Post Type using Gutenberg in WordPress.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function addGutenbergPage($I, $postType = 'page', $title)
 	{
 		// Navigate to Post Type (e.g. Pages / Posts) > Add New
-		$I->amOnAdminPage('post-new.php?post_type='.$postType);
+		$I->amOnAdminPage('post-new.php?post_type=' . $postType);
 
 		// Close the Gutenberg "Welcome to the block editor" dialog if it's displayed
 		$I->maybeCloseGutenbergWelcomeModal($I);
@@ -46,15 +50,15 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Add the given block when adding or editing a Page, Post or Custom Post Type
 	 * in Gutenberg.
-	 * 
+	 *
 	 * If a block configuration is specified, applies it to the newly added block.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form').
-	 * @param 	string 				$blockProgrammaticName 	Programmatic Block Name (e.g. 'convertkit-form').
-	 * @param 	bool|array 			$blockConfiguration 	Block Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form').
+	 * @param   string           $blockProgrammaticName  Programmatic Block Name (e.g. 'convertkit-form').
+	 * @param   bool|array       $blockConfiguration     Block Configuration (field => value key/value array).
 	 */
 	public function addGutenbergBlock($I, $blockName, $blockProgrammaticName, $blockConfiguration = false)
 	{
@@ -70,11 +74,11 @@ class WPGutenberg extends \Codeception\Module
 		// If a Block configuration is specified, apply it to the Block now.
 		if ($blockConfiguration) {
 			$I->waitForElementVisible('.interface-interface-skeleton__sidebar[aria-label="Editor settings"]');
-			foreach ($blockConfiguration as $field=>$attributes) {
+			foreach ($blockConfiguration as $field => $attributes) {
 				// Field ID will be block's programmatic name with underscores instead of hyphens,
 				// followed by the attribute name.
 				$fieldID = '#' . str_replace('-', '_', $blockProgrammaticName) . '_' . $field;
-				
+
 				// Depending on the field's type, define its value.
 				switch ($attributes[0]) {
 					case 'select':
@@ -91,11 +95,11 @@ class WPGutenberg extends \Codeception\Module
 	/**
 	 * Check that the given block did not output any errors when rendered in the
 	 * Gutenberg editor.
-	 * 
-	 * @since 	1.9.7.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
-	 * @param 	string 				$blockName 				Block Name (e.g. 'ConvertKit Form')
+	 *
+	 * @since   1.9.7.4
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   string           $blockName              Block Name (e.g. 'ConvertKit Form')
 	 */
 	public function checkGutenbergBlockHasNoErrors($I, $blockName)
 	{
@@ -104,26 +108,29 @@ class WPGutenberg extends \Codeception\Module
 		sleep(2);
 
 		// Check that the "This block has encountered an error and cannot be previewed." element doesn't exist.
-		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="'.$blockName.'"] .block-editor-block-list__block-crash-warning');
+		$I->dontSeeElementInDOM('.block-editor-block-list__layout div[data-title="' . $blockName . '"] .block-editor-block-list__block-crash-warning');
 	}
 
 	/**
 	 * Publish a Page, Post or Custom Post Type initiated by the addGutenbergPage() function,
 	 * loading it on the frontend web site.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 						Acceptance Tester.
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
 	 */
 	public function publishAndViewGutenbergPage($I)
 	{
 		// Click the Publish button.
 		$I->click('.editor-post-publish-button__button');
-		
+
 		// When the pre-publish panel displays, click Publish again.
-		$I->performOn('.editor-post-publish-panel__prepublish', function($I) {
-			$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');	
-		});
+		$I->performOn(
+			'.editor-post-publish-panel__prepublish',
+			function($I) {
+				$I->click('.editor-post-publish-panel__header-publish-button .editor-post-publish-button__button');
+			}
+		);
 
 		// Wait for confirmation that the Page published.
 		$I->waitForElementVisible('.post-publish-panel__postpublish-buttons a.components-button');

--- a/tests/_support/Helper/Acceptance/WPMetabox.php
+++ b/tests/_support/Helper/Acceptance/WPMetabox.php
@@ -9,12 +9,12 @@ class WPMetabox extends \Codeception\Module
 {
 	/**
 	 * Configure a given metabox's fields with the given values.
-	 * 
-	 * @since 	1.9.7.5
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$metabox 		Programmatic Metabox Name.
-	 * @param 	array 	$coniguration 	Metabox Configuration (field => value key/value array).
+	 *
+	 * @since   1.9.7.5
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $metabox        Programmatic Metabox Name.
+	 * @param   array                                    $coniguration   Metabox Configuration (field => value key/value array).
 	 */
 	public function configureMetaboxSettings($I, $metabox, $configuration)
 	{
@@ -22,13 +22,13 @@ class WPMetabox extends \Codeception\Module
 		$I->seeElementInDOM('#' . $metabox);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Field ID will be prefixed with wp-convertkit- in the metabox.
 			$fieldID = 'wp-convertkit-' . $field;
 
 			// Check that the field exists.
 			$I->seeElementInDOM('#' . $fieldID);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select2':

--- a/tests/_support/Helper/Acceptance/WPQuickEdit.php
+++ b/tests/_support/Helper/Acceptance/WPQuickEdit.php
@@ -9,13 +9,13 @@ class WPQuickEdit extends \Codeception\Module
 {
 	/**
 	 * Quick Edits the given Post ID, changing form field values and saving.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
-	 * @param 	array 	$configuration 	Configuration (field => value key/value array).
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   int                                      $postID         Post ID.
+	 * @param   array                                    $configuration  Configuration (field => value key/value array).
 	 */
 	public function quickEdit($I, $postType, $postID, $configuration)
 	{
@@ -23,10 +23,10 @@ class WPQuickEdit extends \Codeception\Module
 		$I->openQuickEdit($I, $postType, $postID);
 
 		// Apply configuration.
-		foreach ($configuration as $field=>$attributes) {
+		foreach ($configuration as $field => $attributes) {
 			// Check that the field exists.
 			$I->seeElementInDOM('#ckwc-quick-edit #' . $field);
-			
+
 			// Depending on the field's type, define its value.
 			switch ($attributes[0]) {
 				case 'select':
@@ -44,25 +44,25 @@ class WPQuickEdit extends \Codeception\Module
 
 	/**
 	 * Opens the Quick Edit form for the given Post ID.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	$I 	AcceptanceHelper 	Acceptance Helper.
-	 * @param 	string 	$postType 		Programmatic Post Type.
-	 * @param 	int 	$postID 		Post ID.
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   $I  AcceptanceHelper    Acceptance Helper.
+	 * @param   string                                   $postType       Programmatic Post Type.
+	 * @param   int                                      $postID         Post ID.
 	 */
 	public function openQuickEdit($I, $postType, $postID)
 	{
 		// Navigate to Post Type's WP_List_Table.
-		$I->amOnAdminPage('edit.php?post_type='.$postType);
+		$I->amOnAdminPage('edit.php?post_type=' . $postType);
 
 		// Hover mouse over Post's table row.
-		$I->moveMouseOver('tr#post-'.$postID);
+		$I->moveMouseOver('tr#post-' . $postID);
 
 		// Wait for Quick edit link to be visible.
-		$I->waitForElementVisible('tr#post-'.$postID.' button.editinline');
-		
+		$I->waitForElementVisible('tr#post-' . $postID . ' button.editinline');
+
 		// Click Quick Edit link.
-		$I->click('tr#post-'.$postID.' button.editinline');
+		$I->click('tr#post-' . $postID . ' button.editinline');
 	}
 }

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -9,59 +9,65 @@ class WooCommerce extends \Codeception\Module
 {
 	/**
 	 * Helper method to setup the WooCommerce Plugin.
-	 * 
-	 * @since 	1.0.0
+	 *
+	 * @since   1.0.0
 	 */
 	public function setupWooCommercePlugin($I)
 	{
 		// Setup Cash on Delivery as Payment Method.
-		$I->haveOptionInDatabase('woocommerce_cod_settings', [
-			'enabled' => 'yes',
-			'title' => 'Cash on delivery',
-			'description' => 'Pay with cash upon delivery',
-			'instructions' => 'Pay with cash upon delivery',
-			'enable_for_methods' => [],
-			'enable_for_virtual' => 'yes',
-		]);
+		$I->haveOptionInDatabase(
+			'woocommerce_cod_settings',
+			[
+				'enabled'            => 'yes',
+				'title'              => 'Cash on delivery',
+				'description'        => 'Pay with cash upon delivery',
+				'instructions'       => 'Pay with cash upon delivery',
+				'enable_for_methods' => [],
+				'enable_for_virtual' => 'yes',
+			]
+		);
 
 		// Setup Stripe as Payment Method, as it's required for subscription products.
-		$I->haveOptionInDatabase('woocommerce_stripe_settings', [
-			'enabled' => 'yes',
-			'title' => 'Credit Card (Stripe)',
-			'description' => 'Pay with your credit card via Stripe.',
-			'api_credentials' => '',
-			'testmode' => 'yes',
-			'test_publishable_key' => $_ENV['STRIPE_TEST_PUBLISHABLE_KEY'],
-			'test_secret_key' => $_ENV['STRIPE_TEST_SECRET_KEY'],
-			'publishable_key' => '',
-			'secret_key' => '',
-			'webhook' => '',
-			'test_webhook_secret' => '',
-			'webhook_secret' => '',
-			'inline_cc_form' => 'yes', // Required so one iframe is output by Stripe, instead of 3.
-			'statement_descriptor' => '',
-			'capture' => 'yes',
-			'payment_request' => 'no',
-			'payment_request_button_type' => 'buy',
-			'payment_request_button_theme' => 'dark',
-			'payment_request_button_locations' => [
-				'checkout',
-			],
-			'payment_request_button_size' => 'default',
-			'saved_cards' => 'no',
-			'logging' => 'no',
-			'upe_checkout_experience_enabled' => 'disabled',
-			'title_upe' => '',
-			'is_short_statement_descriptor_enabled' => 'no',
-			'upe_checkout_experience_accepted_payments' => [],
-			'short_statement_descriptor' => 'CK',
-		]);
+		$I->haveOptionInDatabase(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                               => 'yes',
+				'title'                                 => 'Credit Card (Stripe)',
+				'description'                           => 'Pay with your credit card via Stripe.',
+				'api_credentials'                       => '',
+				'testmode'                              => 'yes',
+				'test_publishable_key'                  => $_ENV['STRIPE_TEST_PUBLISHABLE_KEY'],
+				'test_secret_key'                       => $_ENV['STRIPE_TEST_SECRET_KEY'],
+				'publishable_key'                       => '',
+				'secret_key'                            => '',
+				'webhook'                               => '',
+				'test_webhook_secret'                   => '',
+				'webhook_secret'                        => '',
+				'inline_cc_form'                        => 'yes', // Required so one iframe is output by Stripe, instead of 3.
+				'statement_descriptor'                  => '',
+				'capture'                               => 'yes',
+				'payment_request'                       => 'no',
+				'payment_request_button_type'           => 'buy',
+				'payment_request_button_theme'          => 'dark',
+				'payment_request_button_locations'      => [
+					'checkout',
+				],
+				'payment_request_button_size'           => 'default',
+				'saved_cards'                           => 'no',
+				'logging'                               => 'no',
+				'upe_checkout_experience_enabled'       => 'disabled',
+				'title_upe'                             => '',
+				'is_short_statement_descriptor_enabled' => 'no',
+				'upe_checkout_experience_accepted_payments' => [],
+				'short_statement_descriptor'            => 'CK',
+			]
+		);
 	}
 
 	/**
 	 * Helper method to setup the Custom Order Numbers Plugin.
-	 * 
-	 * @since 	1.0.0
+	 *
+	 * @since   1.0.0
 	 */
 	public function setupCustomOrderNumbersPlugin($I)
 	{
@@ -76,11 +82,11 @@ class WooCommerce extends \Codeception\Module
 	 * - log out as the WordPress Administrator
 	 * - add the WooCommerce Product to the cart
 	 * - complete checkout
-	 * 
+	 *
 	 * This is quite a monolithic function, however this flow is used across 20+ tests,
 	 * so it's better to have the code here than in every single test.
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function wooCommerceCreateProductAndCheckoutWithConfig(
 		$I,
@@ -96,14 +102,14 @@ class WooCommerce extends \Codeception\Module
 	{
 		// Define Opt In setting.
 		if ($displayOptIn) {
-			$I->checkOption('#woocommerce_ckwc_display_opt_in');	
+			$I->checkOption('#woocommerce_ckwc_display_opt_in');
 		} else {
 			$I->uncheckOption('#woocommerce_ckwc_display_opt_in');
 		}
 
 		// Define Subscription Event setting.
 		if ($subscriptionEvent) {
-			$I->selectOption('#woocommerce_ckwc_event', $subscriptionEvent);	
+			$I->selectOption('#woocommerce_ckwc_event', $subscriptionEvent);
 		}
 
 		// Define Send Purchase Data setting.
@@ -112,16 +118,16 @@ class WooCommerce extends \Codeception\Module
 
 			// If sendPurchaseData is true, set send purchase data event to processing.
 			// Otherwise set to the string value of sendPurchaseData i.e. completed.
-			$sendPurchaseDataEvent = (($sendPurchaseData === true) ? 'processing' : $sendPurchaseData);
+			$sendPurchaseDataEvent = ( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData );
 			$I->selectOption('#woocommerce_ckwc_send_purchases_event', $sendPurchaseDataEvent);
 		} else {
 			$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 		}
-		
+
 		// Save.
 		$I->click('Save changes');
 
-		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are 
+		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are
 		// saved and the Forms, Tags and Sequences are listed.
 		if ($pluginFormTagSequence) {
 			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
@@ -129,7 +135,7 @@ class WooCommerce extends \Codeception\Module
 			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
 		}
 
-		// Define Order to Custom Field mappings, now that the API credentials are 
+		// Define Order to Custom Field mappings, now that the API credentials are
 		// saved and the Forms, Tags and Sequences are listed.
 		if ($customFields) {
 			$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
@@ -150,31 +156,31 @@ class WooCommerce extends \Codeception\Module
 
 		// Wait until the settings page reloads, to avoid a browser alert later that navigating away will lose unsaved changes.
 		$I->waitForElement('#woocommerce_ckwc_enabled');
-		
+
 		// Create Product
 		switch ($productType) {
 			case 'zero':
-				$productName = 'Zero Value Product';
+				$productName   = 'Zero Value Product';
 				$paymentMethod = 'cod';
-				$productID = $I->wooCommerceCreateZeroValueProduct($I, $productFormTagSequence);
+				$productID     = $I->wooCommerceCreateZeroValueProduct($I, $productFormTagSequence);
 				break;
 
 			case 'virtual':
-				$productName = 'Virtual Product';
+				$productName   = 'Virtual Product';
 				$paymentMethod = 'cod';
-				$productID = $I->wooCommerceCreateVirtualProduct($I, $productFormTagSequence);
+				$productID     = $I->wooCommerceCreateVirtualProduct($I, $productFormTagSequence);
 				break;
 
 			case 'subscription':
-				$productName = 'Subscription Product';
+				$productName   = 'Subscription Product';
 				$paymentMethod = 'stripe';
-				$productID = $I->wooCommerceCreateSubscriptionProduct($I, $productFormTagSequence);
+				$productID     = $I->wooCommerceCreateSubscriptionProduct($I, $productFormTagSequence);
 				break;
 
 			case 'simple':
-				$productName = 'Simple Product';
+				$productName   = 'Simple Product';
 				$paymentMethod = 'cod';
-				$productID = $I->wooCommerceCreateSimpleProduct($I, $productFormTagSequence);
+				$productID     = $I->wooCommerceCreateSimpleProduct($I, $productFormTagSequence);
 				break;
 		}
 
@@ -195,18 +201,18 @@ class WooCommerce extends \Codeception\Module
 			if ($checkOptIn) {
 				$I->checkOption('#ckwc_opt_in');
 			} else {
-				$I->uncheckOption('#ckwc_opt_in');	
+				$I->uncheckOption('#ckwc_opt_in');
 			}
 		} else {
 			$I->dontSeeElement('#ckwc_opt_in');
 		}
-		
+
 		// Click Place order button.
 		$I->click('#place_order');
 
 		// Wait until JS completes and redirects.
 		$I->waitForElement('.woocommerce-order-received', 30);
-		
+
 		// Confirm order received is displayed.
 		// WooCommerce changed the default wording between 5.x and 6.x, so perform
 		// a few checks to be certain.
@@ -217,21 +223,21 @@ class WooCommerce extends \Codeception\Module
 
 		// Return data
 		return [
-			'email_address' => $emailAddress,
-			'product_id' => $productID,
-			'order_id' => $I->grabTextFrom('.woocommerce-order-overview__order strong'),
+			'email_address'   => $emailAddress,
+			'product_id'      => $productID,
+			'order_id'        => $I->grabTextFrom('.woocommerce-order-overview__order strong'),
 			'subscription_id' => ( ( $productType == 'subscription' ) ? (int) filter_var($I->grabTextFrom('.woocommerce-orders-table__cell-order-number a'), FILTER_SANITIZE_NUMBER_INT) : 0 ),
 		];
 	}
 
 	/**
 	 * Changes the order status for the given Order ID to the given Order Status.
-	 * 
-	 * @since 	1.9.6
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	int 				$orderID 		WooCommerce Order ID
-	 * @param 	string 				$orderStatus 	Order Status
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   AcceptanceTester $I
+	 * @param   int              $orderID        WooCommerce Order ID
+	 * @param   string           $orderStatus    Order Status
 	 */
 	public function wooCommerceChangeOrderStatus($I, $orderID, $orderStatus)
 	{
@@ -242,196 +248,207 @@ class WooCommerce extends \Codeception\Module
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
 			$orderIDParts = explode('-', $orderID);
-			$orderID = $orderIDParts[count($orderIDParts)-1];
+			$orderID      = $orderIDParts[ count($orderIDParts) - 1 ];
 		}
-		
+
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
-		$I->submitForm('form#post', [
-			'order_status' => $orderStatus,
-		]);
+		$I->submitForm(
+			'form#post',
+			[
+				'order_status' => $orderStatus,
+			]
+		);
 	}
 
 	/**
 	 * Creates a 'Simple product' in WooCommerce that can be used for tests.
-	 * 
-	 * @since 	1.0.0
-	 * 
-	 * @return 	int 	Product ID
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return  int     Product ID
 	 */
 	public function wooCommerceCreateSimpleProduct($I, $productFormTagSequence = false)
 	{
-		return $I->havePostInDatabase([
-			'post_type'		=> 'product',
-			'post_status'	=> 'publish',
-			'post_name' 	=> 'simple-product',
-			'post_title'	=> 'Simple Product',
-			'post_content'	=> 'Simple Product Content',
-			'meta_input' => [
-				'_backorders' => 'no',
-				'_download_expiry' => -1,
-				'_download_limit' => -1,
-				'_downloadable' => 'no',
-				'_manage_stock' => 'no',
-				'_price' => 10,
-				'_product_version' => '6.3.0',
-				'_regular_price' => 10,
-				'_sold_individually' => 'no',
-				'_stock' => null,
-				'_stock_status' => 'instock',
-				'_tax_class' => '',
-				'_tax_status' => 'taxable',
-				'_virtual' => 'no',
-				'_wc_average_rating' => 0,
-				'_wc_review_count' => 0,
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_name'    => 'simple-product',
+				'post_title'   => 'Simple Product',
+				'post_content' => 'Simple Product Content',
+				'meta_input'   => [
+					'_backorders'        => 'no',
+					'_download_expiry'   => -1,
+					'_download_limit'    => -1,
+					'_downloadable'      => 'no',
+					'_manage_stock'      => 'no',
+					'_price'             => 10,
+					'_product_version'   => '6.3.0',
+					'_regular_price'     => 10,
+					'_sold_individually' => 'no',
+					'_stock'             => null,
+					'_stock_status'      => 'instock',
+					'_tax_class'         => '',
+					'_tax_status'        => 'taxable',
+					'_virtual'           => 'no',
+					'_wc_average_rating' => 0,
+					'_wc_review_count'   => 0,
 
-				// ConvertKit Integration Form/Tag/Sequence
-				'ckwc_subscription' => ( $productFormTagSequence ? $productFormTagSequence : '' ),
-			],
-		]);
+					// ConvertKit Integration Form/Tag/Sequence
+					'ckwc_subscription'  => ( $productFormTagSequence ? $productFormTagSequence : '' ),
+				],
+			]
+		);
 	}
 
 	/**
 	 * Creates a 'Simple product' in WooCommerce that is set to be 'Virtual', that can be used for tests.
-	 * 
-	 * @since 	1.0.0
-	 * 
-	 * @return 	int 	Product ID
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return  int     Product ID
 	 */
 	public function wooCommerceCreateVirtualProduct($I, $productFormTagSequence = false)
 	{
-		return $I->havePostInDatabase([
-			'post_type'		=> 'product',
-			'post_status'	=> 'publish',
-			'post_name' 	=> 'virtual-product',
-			'post_title'	=> 'Virtual Product',
-			'post_content'	=> 'Virtual Product Content',
-			'meta_input' => [
-				'_backorders' => 'no',
-				'_download_expiry' => -1,
-				'_download_limit' => -1,
-				'_downloadable' => 'no',
-				'_manage_stock' => 'no',
-				'_price' => 10,
-				'_product_version' => '6.3.0',
-				'_regular_price' => 10,
-				'_sold_individually' => 'no',
-				'_stock' => null,
-				'_stock_status' => 'instock',
-				'_tax_class' => '',
-				'_tax_status' => 'taxable',
-				'_virtual' => 'yes',
-				'_wc_average_rating' => 0,
-				'_wc_review_count' => 0,
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_name'    => 'virtual-product',
+				'post_title'   => 'Virtual Product',
+				'post_content' => 'Virtual Product Content',
+				'meta_input'   => [
+					'_backorders'        => 'no',
+					'_download_expiry'   => -1,
+					'_download_limit'    => -1,
+					'_downloadable'      => 'no',
+					'_manage_stock'      => 'no',
+					'_price'             => 10,
+					'_product_version'   => '6.3.0',
+					'_regular_price'     => 10,
+					'_sold_individually' => 'no',
+					'_stock'             => null,
+					'_stock_status'      => 'instock',
+					'_tax_class'         => '',
+					'_tax_status'        => 'taxable',
+					'_virtual'           => 'yes',
+					'_wc_average_rating' => 0,
+					'_wc_review_count'   => 0,
 
-				// ConvertKit Integration Form/Tag/Sequence
-				'ckwc_subscription' => ( $productFormTagSequence ? $productFormTagSequence : '' ),
-			],
-		]);
+					// ConvertKit Integration Form/Tag/Sequence
+					'ckwc_subscription'  => ( $productFormTagSequence ? $productFormTagSequence : '' ),
+				],
+			]
+		);
 	}
 
 	/**
 	 * Creates a 'Subscription product' in WooCommerce that can be used for tests, which
 	 * is set to renew daily.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @return 	int 	Product ID
+	 *
+	 * @since   1.4.4
+	 *
+	 * @return  int     Product ID
 	 */
 	public function wooCommerceCreateSubscriptionProduct($I, $productFormTagSequence = false)
 	{
-		return $I->havePostInDatabase([
-			'post_type'		=> 'product',
-			'post_status'	=> 'publish',
-			'post_name' 	=> 'subscription-product',
-			'post_title'	=> 'Subscription Product',
-			'post_content'	=> 'Subscription Product Content',
-			'meta_input' => [
-				'_backorders' => 'no',
-				'_download_expiry' => -1,
-				'_download_limit' => -1,
-				'_downloadable' => 'yes',
-				'_manage_stock' => 'no',
-				'_price' => 10,
-				'_product_version' => '6.2.0',
-				'_regular_price' => 10,
-				'_sold_individually' => 'no',
-				'_stock' => null,
-				'_stock_status' => 'instock',
-				'_subscription_length' => 0,
-				'_subscription_limit' => 'no',
-				'_subscription_one_time_shipping' => 'no',
-				'_subscription_payment_sync_date' => 0,
-				'_subscription_period' => 'day',
-				'_subscription_period_interval' => 1,
-				'_subscription_price' => 10,
-				'_subscription_sign_up_fee' => 0,
-				'_subscription_trial_length' => 0,
-				'_subscription_trial_period' => 'day',
-				'_tax_class' => '',
-				'_tax_status' => 'taxable',
-				'_virtual' => 'yes',
-				'_wc_average_rating' => 0,
-				'_wc_review_count' => 0,
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_name'    => 'subscription-product',
+				'post_title'   => 'Subscription Product',
+				'post_content' => 'Subscription Product Content',
+				'meta_input'   => [
+					'_backorders'                     => 'no',
+					'_download_expiry'                => -1,
+					'_download_limit'                 => -1,
+					'_downloadable'                   => 'yes',
+					'_manage_stock'                   => 'no',
+					'_price'                          => 10,
+					'_product_version'                => '6.2.0',
+					'_regular_price'                  => 10,
+					'_sold_individually'              => 'no',
+					'_stock'                          => null,
+					'_stock_status'                   => 'instock',
+					'_subscription_length'            => 0,
+					'_subscription_limit'             => 'no',
+					'_subscription_one_time_shipping' => 'no',
+					'_subscription_payment_sync_date' => 0,
+					'_subscription_period'            => 'day',
+					'_subscription_period_interval'   => 1,
+					'_subscription_price'             => 10,
+					'_subscription_sign_up_fee'       => 0,
+					'_subscription_trial_length'      => 0,
+					'_subscription_trial_period'      => 'day',
+					'_tax_class'                      => '',
+					'_tax_status'                     => 'taxable',
+					'_virtual'                        => 'yes',
+					'_wc_average_rating'              => 0,
+					'_wc_review_count'                => 0,
 
-				// ConvertKit Integration Form/Tag/Sequence.
-				'ckwc_subscription' => ( $productFormTagSequence ? $productFormTagSequence : '' ),
-			],
-			'tax_input' => [
-				[ 'product_type' => 'subscription' ],
-			],
-		]);
+					// ConvertKit Integration Form/Tag/Sequence.
+					'ckwc_subscription'               => ( $productFormTagSequence ? $productFormTagSequence : '' ),
+				],
+				'tax_input'    => [
+					[ 'product_type' => 'subscription' ],
+				],
+			]
+		);
 	}
 
 	/**
 	 * Creates a zero value 'Simple product' in WooCommerce that can be used for tests.
-	 * 
-	 * @since 	1.0.0
-	 * 
-	 * @return 	int 	Product ID
+	 *
+	 * @since   1.0.0
+	 *
+	 * @return  int     Product ID
 	 */
 	public function wooCommerceCreateZeroValueProduct($I, $productFormTagSequence = false)
 	{
-		return $I->havePostInDatabase([
-			'post_type'		=> 'product',
-			'post_status'	=> 'publish',
-			'post_name' 	=> 'zero-value-product',
-			'post_title'	=> 'Zero Value Product',
-			'post_content'	=> 'Zero Value Product Content',
-			'meta_input' => [
-				'_backorders' => 'no',
-				'_download_expiry' => -1,
-				'_download_limit' => -1,
-				'_downloadable' => 'no',
-				'_manage_stock' => 'no',
-				'_price' => 0,
-				'_product_version' => '6.3.0',
-				'_regular_price' => 0,
-				'_sold_individually' => 'no',
-				'_stock' => null,
-				'_stock_status' => 'instock',
-				'_tax_class' => '',
-				'_tax_status' => 'taxable',
-				'_virtual' => 'no',
-				'_wc_average_rating' => 0,
-				'_wc_review_count' => 0,
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'product',
+				'post_status'  => 'publish',
+				'post_name'    => 'zero-value-product',
+				'post_title'   => 'Zero Value Product',
+				'post_content' => 'Zero Value Product Content',
+				'meta_input'   => [
+					'_backorders'        => 'no',
+					'_download_expiry'   => -1,
+					'_download_limit'    => -1,
+					'_downloadable'      => 'no',
+					'_manage_stock'      => 'no',
+					'_price'             => 0,
+					'_product_version'   => '6.3.0',
+					'_regular_price'     => 0,
+					'_sold_individually' => 'no',
+					'_stock'             => null,
+					'_stock_status'      => 'instock',
+					'_tax_class'         => '',
+					'_tax_status'        => 'taxable',
+					'_virtual'           => 'no',
+					'_wc_average_rating' => 0,
+					'_wc_review_count'   => 0,
 
-				// ConvertKit Integration Form/Tag/Sequence
-				'ckwc_subscription' => ( $productFormTagSequence ? $productFormTagSequence : '' ),
-			],
-		]);
+					// ConvertKit Integration Form/Tag/Sequence
+					'ckwc_subscription'  => ( $productFormTagSequence ? $productFormTagSequence : '' ),
+				],
+			]
+		);
 	}
 
 	/**
 	 * Adds the given Product ID to the Cart, loading the Checkout screen
 	 * and prefilling the standard WooCommerce Billing Fields.
-	 * 
-	 * @since 	1.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I 	 			AcceptanceTester.
-	 * @param 	string  			$productID 		Product ID.
-	 * @param 	string  			$productName	Product Name.
-	 * @param 	string  			$emailAddress 	Email Address (wordpress@convertkit.com).
-	 * @param 	string  			$paymentMethod 	Payment Method (cod|stripe).
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 * @param   string           $productID      Product ID.
+	 * @param   string           $productName    Product Name.
+	 * @param   string           $emailAddress   Email Address (wordpress@convertkit.com).
+	 * @param   string           $paymentMethod  Payment Method (cod|stripe).
 	 */
 	public function wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress = 'wordpress@convertkit.com', $paymentMethod = 'cod')
 	{
@@ -496,15 +513,15 @@ class WooCommerce extends \Codeception\Module
 	/**
 	 * Creates an Order as if the user were creating an Order through the WordPress Administration
 	 * interface.
-	 * 
-	 * @since 	1.0.0
-	 * 
-	 * @param 	AcceptanceTester 	$I
-	 * @param 	int 				$productID 		Product ID
-	 * @param 	string 				$productName 	Product Name
-	 * @param 	string 				$orderStatus 	Order Status
-	 * @param 	string 				$paymentMethod 	Payment Method
-	 * @return 	int 								Order ID
+	 *
+	 * @since   1.0.0
+	 *
+	 * @param   AcceptanceTester $I
+	 * @param   int              $productID      Product ID
+	 * @param   string           $productName    Product Name
+	 * @param   string           $orderStatus    Order Status
+	 * @param   string           $paymentMethod  Payment Method
+	 * @return  int                                 Order ID
 	 */
 	public function wooCommerceCreateManualOrder($I, $productID, $productName, $orderStatus, $paymentMethod)
 	{
@@ -515,9 +532,13 @@ class WooCommerce extends \Codeception\Module
 		$emailAddress = $I->generateEmailAddress();
 
 		// Create User for this Manual Order.
-		$userID = $I->haveUserInDatabase('test', 'subscriber', [
-			'user_email' => $emailAddress,
-		]);
+		$userID = $I->haveUserInDatabase(
+			'test',
+			'subscriber',
+			[
+				'user_email' => $emailAddress,
+			]
+		);
 
 		// Load New Order screen.
 		$I->amOnAdminPage('post-new.php?post_type=shop_order');
@@ -554,32 +575,32 @@ class WooCommerce extends \Codeception\Module
 		// Return.
 		return [
 			'email_address' => $emailAddress,
-			'product_id' => $productID,
-			'order_id' => $orderID,
+			'product_id'    => $productID,
+			'order_id'      => $orderID,
 		];
 	}
 
 	/**
 	 * Check the given Order ID contains an Order Note with the given text.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	int 			 $orderID 		Order ID
-	 * @param 	string 			 $noteText		Order Note Text
-	 */ 	
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   int              $orderID       Order ID
+	 * @param   string           $noteText      Order Note Text
+	 */
 	public function wooCommerceOrderNoteExists($I, $orderID, $noteText)
 	{
 		// Logout.
 		$I->logOut();
-		
+
 		// Login as Administrator.
 		$I->loginAsAdmin();
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
 			$orderIDParts = explode('-', $orderID);
-			$orderID = $orderIDParts[count($orderIDParts)-1];
+			$orderID      = $orderIDParts[ count($orderIDParts) - 1 ];
 		}
 
 		// Load Edit Order screen.
@@ -591,13 +612,13 @@ class WooCommerce extends \Codeception\Module
 
 	/**
 	 * Check the given Order ID does not contain an Order Note with the given text.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester $I 			AcceptanceTester
-	 * @param 	int 			 $orderID 		Order ID
-	 * @param 	string 			 $noteText		Order Note Text
-	 */ 	
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester
+	 * @param   int              $orderID       Order ID
+	 * @param   string           $noteText      Order Note Text
+	 */
 	public function wooCommerceOrderNoteDoesNotExist($I, $orderID, $noteText)
 	{
 		// Login as Administrator.
@@ -606,7 +627,7 @@ class WooCommerce extends \Codeception\Module
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
 			$orderIDParts = explode('-', $orderID);
-			$orderID = $orderIDParts[count($orderIDParts)-1];
+			$orderID      = $orderIDParts[ count($orderIDParts) - 1 ];
 		}
 
 		// Load Edit Order screen.

--- a/tests/_support/Helper/Acceptance/Xdebug.php
+++ b/tests/_support/Helper/Acceptance/Xdebug.php
@@ -9,8 +9,8 @@ class Xdebug extends \Codeception\Module
 {
 	/**
 	 * Helper method to assert that there are non PHP errors, warnings or notices output
-	 * 
-	 * @since 	1.9.6
+	 *
+	 * @since   1.9.6
 	 */
 	public function checkNoWarningsAndNoticesOnScreen($I)
 	{

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class UnitTester extends \Codeception\Actor
 {
 	use _generated\UnitTesterActions;

--- a/tests/_support/WpunitTester.php
+++ b/tests/_support/WpunitTester.php
@@ -3,6 +3,7 @@
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)
@@ -15,7 +16,7 @@
  * @method void pause()
  *
  * @SuppressWarnings(PHPMD)
-*/
+ */
 class WpunitTester extends \Codeception\Actor
 {
 	use _generated\WpunitTesterActions;

--- a/tests/acceptance/general/ActivateDeactivatePluginCest.php
+++ b/tests/acceptance/general/ActivateDeactivatePluginCest.php
@@ -5,10 +5,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Activate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testPluginActivation(AcceptanceTester $I)
 	{
@@ -18,10 +18,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Activate the Plugin without the WooCommerce Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testPluginActivationWithoutWooCommerce(AcceptanceTester $I)
 	{
@@ -31,10 +31,10 @@ class ActivateDeactivatePluginCest
 	/**
 	 * Deactivate the Plugin and confirm a success notification
 	 * is displayed with no errors.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testPluginDeactivation(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
+++ b/tests/acceptance/general/AnyErrorsOnBlankInstallCest.php
@@ -5,10 +5,10 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no PHP errors or notices are displayed at WooCommerce > Settings > Integration > ConvertKit, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSettingsScreen(AcceptanceTester $I)
 	{
@@ -22,16 +22,16 @@ class AnyErrorsOnBlankInstallCest
 	/**
 	 * Check that no errors are displayed on Products > Add New, when the Plugin is activated
 	 * and not configured.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testAddNewProduct(AcceptanceTester $I)
 	{
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
-		
+
 		// Navigate to Products > Add New
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
@@ -43,10 +43,10 @@ class AnyErrorsOnBlankInstallCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests that the ConvertKit Form / Tag / Sequence selection works on
  * a WooCommerce Product.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class ProductCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -27,10 +27,10 @@ class ProductCest
 	 * Test that the meta box displayed when adding/editing a Product does not
 	 * output a field, and instead tells the user to configure the integration,
 	 * when the integration is disabled.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testProductFieldsWithIntegrationDisabled(AcceptanceTester $I)
 	{
@@ -56,10 +56,10 @@ class ProductCest
 	/**
 	 * Test that the meta box displayed when adding/editing a Product outputs
 	 * a <select> field for choosing a Form, Tag or Sequence.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testProductFieldsWithIntegrationEnabled(AcceptanceTester $I)
 	{
@@ -95,10 +95,10 @@ class ProductCest
 	 * Test that the meta box displayed when adding/editing a Product does not
 	 * output a field, and instead tells the user to configure the integration,
 	 * when the integration is enabled but no API Key is specified.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testProductFieldsWithIntegrationEnabledAndNoAPIKey(AcceptanceTester $I)
 	{
@@ -137,10 +137,10 @@ class ProductCest
 	/**
 	 * Test that the meta box displayed when adding/editing a Product does not
 	 * output PHP errors when the integration is enabled with an invalid API Key.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testProductFieldsWithIntegrationEnabledAndInvalidAPIKey(AcceptanceTester $I)
 	{
@@ -173,10 +173,10 @@ class ProductCest
 	/**
 	 * Test that the defined resource (Form, Tag, Sequence) is saved when chosen via
 	 * WordPress' Quick Edit functionality.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testQuickEditUsingDefinedResource(AcceptanceTester $I)
 	{
@@ -184,46 +184,59 @@ class ProductCest
 		$I->setupConvertKitPlugin($I);
 
 		// Programmatically create a Product.
-		$productID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Resource: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
-		]);
+		$productID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Resource: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Quick Edit',
+			]
+		);
 
 		// Quick Edit the Product in the Products WP_List_Table.
-		$I->quickEdit($I, 'product', $productID, [
-			'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->quickEdit(
+			$I,
+			'product',
+			$productID,
+			[
+				'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Reload the Products admin screen.
 		$I->amOnAdminPage('edit.php?post_type=product');
 
 		// Confirm that the chosen Resource is the selected option.
-		$I->seePostMetaInDatabase([
-			'post_id' 	=> $productID,
-			'meta_key' 	=> 'ckwc_subscription',
-			'meta_value'=> 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-		]);
+		$I->seePostMetaInDatabase(
+			[
+				'post_id'    => $productID,
+				'meta_key'   => 'ckwc_subscription',
+				'meta_value' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+			]
+		);
 	}
 
 	/**
 	 * Test that the no Bulk Edit fields are displayed when the integration is not setup.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testBulkEditWithIntegrationDisabled(AcceptanceTester $I)
 	{
 		// Programmatically create two Products.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Open Bulk Edit.
@@ -236,10 +249,10 @@ class ProductCest
 	/**
 	 * Test that the defined form displays when chosen via
 	 * WordPress' Bulk Edit functionality.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
 	{
@@ -248,38 +261,49 @@ class ProductCest
 
 		// Programmatically create two PRoducts.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit #2',
+				]
+			),
 		);
 
 		// Bulk Edit the Products in the Pages WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			[
+				'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
+			]
+		);
 
 		// Iterate through Products to observe expected changes were made to the settings in the database.
-		foreach($productIDs as $productID) {
-			$I->seePostMetaInDatabase([
-				'post_id' 	=> $productID,
-				'meta_key' 	=> 'ckwc_subscription',
-				'meta_value'=> 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-			]);
+		foreach ($productIDs as $productID) {
+			$I->seePostMetaInDatabase(
+				[
+					'post_id'    => $productID,
+					'meta_key'   => 'ckwc_subscription',
+					'meta_value' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				]
+			);
 		}
 	}
 
 	/**
 	 * Test that the existing settings are honored and not changed
 	 * when the Bulk Edit options are set to 'No Change'.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testBulkEditWithNoChanges(AcceptanceTester $I)
 	{
@@ -288,44 +312,55 @@ class ProductCest
 
 		// Programmatically create two Products with a defined form.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
-				'meta_input'	=> [
-					'ckwc_subscription' => 'form:'.$_ENV['CONVERTKIT_API_FORM_ID'],
-				],
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
-				'meta_input'	=> [
-					'ckwc_subscription' => 'form:'.$_ENV['CONVERTKIT_API_FORM_ID'],
-				],
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #1',
+					'meta_input' => [
+						'ckwc_subscription' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+					],
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Page: Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ': Bulk Edit with No Change #2',
+					'meta_input' => [
+						'ckwc_subscription' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+					],
+				]
+			),
 		);
 
 		// Bulk Edit the Products in the Products WP_List_Table.
-		$I->bulkEdit($I, 'product', $productIDs, [
-			'ckwc_subscription' => [ 'select', '— No Change —' ],
-		]);
+		$I->bulkEdit(
+			$I,
+			'product',
+			$productIDs,
+			[
+				'ckwc_subscription' => [ 'select', '— No Change —' ],
+			]
+		);
 
 		// Iterate through Products to observe no changes were made to the settings in the database.
-		foreach($productIDs as $productID) {
-			$I->seePostMetaInDatabase([
-				'post_id' 	=> $productID,
-				'meta_key' 	=> 'ckwc_subscription',
-				'meta_value'=> 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-			]);
+		foreach ($productIDs as $productID) {
+			$I->seePostMetaInDatabase(
+				[
+					'post_id'    => $productID,
+					'meta_key'   => 'ckwc_subscription',
+					'meta_value' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				]
+			);
 		}
 	}
 
 	/**
 	 * Test that the Bulk Edit fields do not display when a search on a WP_List_Table
 	 * returns no results.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testBulkEditFieldsHiddenWhenNoProductsFound(AcceptanceTester $I)
 	{
@@ -343,10 +378,10 @@ class ProductCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests the Refresh Resource button, which are displayed next to settings fields
  * when editing a WooCommerce Product.
- * 
- * @since 	1.4.8
+ *
+ * @since   1.4.8
  */
 class RefreshResourcesButtonCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -23,20 +23,23 @@ class RefreshResourcesButtonCest
 		// Change API keys in database to ones that have ConvertKit Resources.
 		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
 		// until a refresh button is clicked.
-		$I->haveOptionInDatabase('woocommerce_ckwc_settings', [
-			'enabled'	 => 'yes',
-			'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-			'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-			'debug'      => 'yes',
-		]);
+		$I->haveOptionInDatabase(
+			'woocommerce_ckwc_settings',
+			[
+				'enabled'    => 'yes',
+				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
+				'debug'      => 'yes',
+			]
+		);
 	}
 
 	/**
 	 * Test that the refresh button for works when adding a new Product.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testRefreshResourcesOnProduct(AcceptanceTester $I)
 	{
@@ -56,23 +59,27 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh buttons for Forms, Sequences and Tags works when Bulk Editing WooCommerce Products.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testRefreshResourcesOnBulkEdit(AcceptanceTester $I)
 	{
 		// Programmatically create two Pages.
 		$productIDs = array(
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Bulk Edit #1',
-			]),
-			$I->havePostInDatabase([
-				'post_type' 	=> 'product',
-				'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Bulk Edit #2',
-			])
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Refresh Resources: Bulk Edit #1',
+				]
+			),
+			$I->havePostInDatabase(
+				[
+					'post_type'  => 'product',
+					'post_title' => 'ConvertKit: Product: Refresh Resources: Bulk Edit #2',
+				]
+			),
 		);
 
 		// Open Bulk Edit form for the Products in the WooCommerce Products WP_List_Table.
@@ -93,18 +100,20 @@ class RefreshResourcesButtonCest
 
 	/**
 	 * Test that the refresh buttons for Forms, Sequences and Tags works when Quick Editing a WooCommerce Product.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testRefreshResourcesOnQuickEdit(AcceptanceTester $I)
 	{
 		// Programmatically create a Product.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Refresh Resources: Quick Edit',
+			]
+		);
 
 		// Open Quick Edit form for the Product in the WooCommerce Products WP_List_Table.
 		$I->openQuickEdit($I, 'product', $pageID);
@@ -124,26 +133,31 @@ class RefreshResourcesButtonCest
 	/**
 	 * Test that the refresh button triggers an error message when the AJAX request fails,
 	 * or the ConvertKit API returns an error.
-	 * 
-	 * @since 	1.4.9
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.9
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testRefreshResourcesErrorNotice(AcceptanceTester $I)
 	{
 		// Specify invalid API credentials, so that the AJAX request returns an error.
-		$I->haveOptionInDatabase('woocommerce_ckwc_settings', [
-			'enabled'	 => 'yes',
-			'api_key'    => 'fakeApiKey',
-			'api_secret' => 'fakeApiSecret',
-			'debug'      => 'yes',
-		]);
+		$I->haveOptionInDatabase(
+			'woocommerce_ckwc_settings',
+			[
+				'enabled'    => 'yes',
+				'api_key'    => 'fakeApiKey',
+				'api_secret' => 'fakeApiSecret',
+				'debug'      => 'yes',
+			]
+		);
 
 		// Programmatically create a Product.
-		$pageID = $I->havePostInDatabase([
-			'post_type' 	=> 'product',
-			'post_title' 	=> 'ConvertKit: Product: Refresh Resources: Quick Edit',
-		]);
+		$pageID = $I->havePostInDatabase(
+			[
+				'post_type'  => 'product',
+				'post_title' => 'ConvertKit: Product: Refresh Resources: Quick Edit',
+			]
+		);
 
 		// Open Quick Edit form for the Product in the WooCommerce Products WP_List_Table.
 		$I->openQuickEdit($I, 'product', $pageID);
@@ -168,10 +182,10 @@ class RefreshResourcesButtonCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.8
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.8
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests the ConvertKit Review Notification.
- * 
- * @since 	1.4.3
+ *
+ * @since   1.4.3
  */
 class ReviewRequestCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -28,10 +28,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is set in the options table when a WooCommerce
 	 * Checkout is completed successfully.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestOnCheckoutWithOptInEnabled(AcceptanceTester $I)
 	{
@@ -59,10 +59,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is not set in the options table when a WooCommerce
 	 * Checkout is completed successfully but the customer does not opt in.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestOnCheckoutWithOptInDisabled(AcceptanceTester $I)
 	{
@@ -90,10 +90,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is set in the options table when a WooCommerce
 	 * Checkout is completed successfully.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestOnCheckoutWithPurchaseDataEnabled(AcceptanceTester $I)
 	{
@@ -121,10 +121,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is displayed when the options table entries
 	 * have the required values to display the review request notification.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
 	{
@@ -149,10 +149,10 @@ class ReviewRequestCest
 	/**
 	 * Test that the review request is dismissed and does not reappear
 	 * on a subsequent page load.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
 	{
@@ -183,10 +183,10 @@ class ReviewRequestCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -3,17 +3,17 @@
  * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form,
  * Tag or Sequence on the Order Completed event when an order is placed through WooCommerce
  * Subscriptions.
- * 
- * @since 	1.4.4
+ *
+ * @since   1.4.4
  */
 class WooCommerceSubscriptionsSubscribeEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -38,10 +38,10 @@ class WooCommerceSubscriptionsSubscribeEventCest
 	 * - The Customer purchases a 'Subscription' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
 	 * - The Customer is not resubscribed when the WooCommerce Subscription is renewed.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSubscriptionProduct(AcceptanceTester $I)
 	{
@@ -68,11 +68,11 @@ class WooCommerceSubscriptionsSubscribeEventCest
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	
-		// Trigger a renewal of the subscription, as if the recurring payment was made, by visiting WooCommerce > Status > 
+
+		// Trigger a renewal of the subscription, as if the recurring payment was made, by visiting WooCommerce > Status >
 		// Scheduled Actions and searching for the Subscription ID.
 		// https://woocommerce.com/document/testing-subscription-renewal-payments/
-		$I->amOnAdminPage('admin.php?page=wc-status&tab=action-scheduler&s='.$result['subscription_id'].'&action=-1&paged=1&action2=-1&status=pending');
+		$I->amOnAdminPage('admin.php?page=wc-status&tab=action-scheduler&s=' . $result['subscription_id'] . '&action=-1&paged=1&action2=-1&status=pending');
 		$I->moveMouseOver('tbody tr td.column-hook');
 		$I->click('span.run a');
 
@@ -90,10 +90,10 @@ class WooCommerceSubscriptionsSubscribeEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' non-subscription WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndNonSubscriptionProduct(AcceptanceTester $I)
 	{
@@ -125,10 +125,10 @@ class WooCommerceSubscriptionsSubscribeEventCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests that Purchase Data does (or does not) get sent to ConvertKit based on the integration
  * settings.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class PurchaseDataCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -38,10 +38,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithSimpleProductCheckout(AcceptanceTester $I)
 	{
@@ -68,10 +68,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is disabled in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithSimpleProductCheckout(AcceptanceTester $I)
 	{
@@ -98,10 +98,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
 	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithVirtualProductCheckout(AcceptanceTester $I)
 	{
@@ -128,10 +128,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is disabled in the integration Settings, and
 	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithVirtualProductCheckout(AcceptanceTester $I)
 	{
@@ -158,10 +158,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
 	 * - The Customer purchases a WooCommerce Product with zero value, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithZeroValueProductCheckout(AcceptanceTester $I)
 	{
@@ -188,10 +188,10 @@ class PurchaseDataCest
 	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
 	 * - The Customer purchases a WooCommerce Product with zero value, and
 	 * - The Order is created via the frontend checkout.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithZeroValueProductCheckout(AcceptanceTester $I)
 	{
@@ -219,10 +219,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Simple' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithSimpleProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -230,7 +230,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -260,10 +260,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Simple' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithSimpleProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -271,7 +271,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -301,10 +301,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Virtual' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithVirtualProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -312,7 +312,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -342,10 +342,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Virtual' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithVirtualProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -353,7 +353,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -383,10 +383,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Zero Value' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithZeroValueProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -394,7 +394,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -424,10 +424,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Zero Value' WooCommerce Product, and
 	 * - The Order's payment method is blank (N/A), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithZeroValueProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
@@ -435,7 +435,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -465,10 +465,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Simple' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithSimpleProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -476,7 +476,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -506,10 +506,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Simple' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithSimpleProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -517,7 +517,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -547,10 +547,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Virtual' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithVirtualProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -558,7 +558,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -588,10 +588,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Virtual' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithVirtualProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -599,7 +599,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -629,10 +629,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Zero Value' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataWithZeroValueProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -640,7 +640,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');	
+		$I->checkOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -670,10 +670,10 @@ class PurchaseDataCest
 	 * - The Order contains a 'Zero Value' WooCommerce Product, and
 	 * - The Order's payment method is Cash on Delivery (COD), and
 	 * - The Order is created via the WordPress Administration interface.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataWithZeroValueProductCODManualOrder(AcceptanceTester $I)
 	{
@@ -681,7 +681,7 @@ class PurchaseDataCest
 		$I->loadConvertKitSettingsScreen($I);
 
 		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');	
+		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
 
 		// Save.
 		$I->click('Save changes');
@@ -712,10 +712,10 @@ class PurchaseDataCest
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout, and
 	 * - The Order's status is changed from processing to completed.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataOnOrderCompletedWithSimpleProductCheckout(AcceptanceTester $I)
 	{
@@ -753,10 +753,10 @@ class PurchaseDataCest
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Order is created via the frontend checkout, and
 	 * - The Order's status is changed from processing to cancelled.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDontSendPurchaseDataOnOrderCancelledWithSimpleProductCheckout(AcceptanceTester $I)
 	{
@@ -791,10 +791,10 @@ class PurchaseDataCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
+++ b/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests various setting combinations for the "Display Opt-In Checkbox" and associated
  * options.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingAPIKeyAndSecretCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -22,10 +22,10 @@ class SettingAPIKeyAndSecretCest
 	/**
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen when the Save Changes
 	 * button is pressed and no settings are specified at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
@@ -46,10 +46,10 @@ class SettingAPIKeyAndSecretCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and a warning is displayed that the user needs to enter API credentials, when
 	 * enabling the integration at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveBlankSettingsWithIntegrationEnabled(AcceptanceTester $I)
 	{
@@ -77,10 +77,10 @@ class SettingAPIKeyAndSecretCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and no warning is displayed that the supplied API credentials are invalid, when
 	 * saving valid API credentials at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
@@ -101,10 +101,10 @@ class SettingAPIKeyAndSecretCest
 	 * Test that no PHP errors or notices are displayed on the Plugin's Setting screen,
 	 * and a warning is displayed that the supplied API credentials are invalid, when
 	 * saving invalid API credentials at WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
 	{
@@ -136,10 +136,10 @@ class SettingAPIKeyAndSecretCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -5,17 +5,17 @@
  * - Display Opt-In Checkbox
  * - API Keys
  * - Subscription Form
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingCustomFieldsCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,10 +29,10 @@ class SettingCustomFieldsCest
 	/**
 	 * Test that Custom Field options are saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCustomFields(AcceptanceTester $I)
 	{
@@ -61,10 +61,10 @@ class SettingCustomFieldsCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingDebugLogCest.php
+++ b/tests/acceptance/settings/SettingDebugLogCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests various setting combinations for the "Debug" options.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingDebugLogCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -24,10 +24,10 @@ class SettingDebugLogCest
 	/**
 	 * Test that debug logging works when enabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testDebugEnabled(AcceptanceTester $I)
 	{
@@ -54,10 +54,10 @@ class SettingDebugLogCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingEnabledDisabledCest.php
+++ b/tests/acceptance/settings/SettingEnabledDisabledCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for the Enable/Disable option on the WooCommerce Integration.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingEnabledDisabledCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -26,10 +26,10 @@ class SettingEnabledDisabledCest
 	 * Test that the integration doesn't perform any expected actions when disabled at
 	 * WooCommerce > Settings > Integration > ConvertKit, and that WooCommerce Checkout
 	 * works as expected.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testIntegrationWhenDisabled(AcceptanceTester $I)
 	{
@@ -38,7 +38,7 @@ class SettingEnabledDisabledCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Click Place order button.
 		$I->click('Place order');
 
@@ -53,10 +53,10 @@ class SettingEnabledDisabledCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingImportExportCest.php
+++ b/tests/acceptance/settings/SettingImportExportCest.php
@@ -5,17 +5,17 @@
  * - Display Opt-In Checkbox
  * - API Keys
  * - Subscription Form
- * 
- * @since 	1.4.6
+ *
+ * @since   1.4.6
  */
 class SettingImportExportCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.6
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -28,10 +28,10 @@ class SettingImportExportCest
 
 	/**
 	 * Test that the Export Configuration option works.
-	 * 
-	 * @since 	1.4.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.6
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testExportConfiguration(AcceptanceTester $I)
 	{
@@ -45,17 +45,17 @@ class SettingImportExportCest
 		// Check downloaded file exists and contains some expected information.
 		$I->openFile($_ENV['WP_ROOT_FOLDER'] . '/ckwc-export.json');
 		$I->seeInThisFile('{"settings":{"enabled":"yes","api_key":"' . $_ENV['CONVERTKIT_API_KEY'] . '","api_secret":"' . $_ENV['CONVERTKIT_API_SECRET'] . '"');
-	
+
 		// Delete the file.
 		$I->deleteFile($_ENV['WP_ROOT_FOLDER'] . '/ckwc-export.json');
 	}
 
 	/**
 	 * Test that the Import Configuration option works.
-	 * 
-	 * @since 	1.4.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.6
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testImportConfiguration(AcceptanceTester $I)
 	{
@@ -79,10 +79,10 @@ class SettingImportExportCest
 	/**
 	 * Test that the Import Configuration option returns the expected error when an invalid file
 	 * is selected.
-	 * 
-	 * @since 	1.4.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.6
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testImportConfigurationWithInvalidFile(AcceptanceTester $I)
 	{
@@ -102,10 +102,10 @@ class SettingImportExportCest
 	/**
 	 * Test that the Import Configuration option returns the expected error when a file
 	 * that appears to be JSON is selected, but its content are not JSON.
-	 * 
-	 * @since 	1.4.6
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.6
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testImportConfigurationWithFakeJSONFile(AcceptanceTester $I)
 	{
@@ -126,10 +126,10 @@ class SettingImportExportCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingNameFormatCest.php
+++ b/tests/acceptance/settings/SettingNameFormatCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests various setting combinations for the "Name Format" option.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingNameFormatCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,10 +29,10 @@ class SettingNameFormatCest
 	 * Test that the Billing First Name option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit, and honored
 	 * when submitted to ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNameFormatBillingFirstName(AcceptanceTester $I)
 	{
@@ -73,10 +73,10 @@ class SettingNameFormatCest
 	 * Test that the Billing Last Name option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit, and honored
 	 * when submitted to ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNameFormatBillingLastName(AcceptanceTester $I)
 	{
@@ -117,10 +117,10 @@ class SettingNameFormatCest
 	 * Test that the Billing First Name + Billing Last Name option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit, and honored
 	 * when submitted to ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNameFormatBillingFirstNameAndLastName(AcceptanceTester $I)
 	{
@@ -161,10 +161,10 @@ class SettingNameFormatCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingOptInCheckboxCest.php
+++ b/tests/acceptance/settings/SettingOptInCheckboxCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests various setting combinations for the "Display Opt-In Checkbox" and associated
  * options.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingOptInCheckboxCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,10 +29,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the checkbox doesn't display when the Opt-In Checkbox is disabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxDisabled(AcceptanceTester $I)
 	{
@@ -46,14 +46,14 @@ class SettingOptInCheckboxCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the fields honor the changes.
-		$I->dontSeeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');	
+		$I->dontSeeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
 
 		// Create Simple Product.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is not displayed on the Checkout screen.
 		$I->dontSeeElementInDOM('#ckwc_opt_in');
 	}
@@ -61,10 +61,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the checkbox does display when the Opt-In Checkbox is enabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxEnabled(AcceptanceTester $I)
 	{
@@ -78,14 +78,14 @@ class SettingOptInCheckboxCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check the fields remain ticked.
-		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');	
+		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
 
 		// Create Simple Product.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
 
@@ -97,10 +97,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the Opt-In Checkbox Label honors the value defined at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxLabel(AcceptanceTester $I)
 	{
@@ -119,7 +119,7 @@ class SettingOptInCheckboxCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
-		// Check the fields remain ticked.	
+		// Check the fields remain ticked.
 		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
 		$I->seeInField('#woocommerce_ckwc_opt_in_label', $customLabel);
 
@@ -128,7 +128,7 @@ class SettingOptInCheckboxCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
 
@@ -139,10 +139,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the Opt-In Checkbox is checked by default when this behaviour is enabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxDefaultStatusEnabled(AcceptanceTester $I)
 	{
@@ -167,7 +167,7 @@ class SettingOptInCheckboxCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
 
@@ -178,10 +178,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the Opt-In Checkbox is not checked by default when this behaviour is disabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxDefaultStatusDisabled(AcceptanceTester $I)
 	{
@@ -206,7 +206,7 @@ class SettingOptInCheckboxCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
 
@@ -217,10 +217,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the Opt-In Checkbox is displayed in the Billing section of the Checkout when defined at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxDisplayLocationBilling(AcceptanceTester $I)
 	{
@@ -245,7 +245,7 @@ class SettingOptInCheckboxCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed in the Billing section on the Checkout screen.
 		$I->seeElementInDOM('.woocommerce-billing-fields #ckwc_opt_in');
 	}
@@ -253,10 +253,10 @@ class SettingOptInCheckboxCest
 	/**
 	 * Test that the Opt-In Checkbox is displayed in the Order section of the Checkout when defined at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInCheckboxDisplayLocationOrder(AcceptanceTester $I)
 	{
@@ -281,7 +281,7 @@ class SettingOptInCheckboxCest
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
-		
+
 		// Confirm that the Opt-In checkbox is displayed in the Order section on the Checkout screen.
 		$I->seeElementInDOM('.woocommerce-additional-fields #ckwc_opt_in');
 	}
@@ -290,10 +290,10 @@ class SettingOptInCheckboxCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingPurchasesCest.php
+++ b/tests/acceptance/settings/SettingPurchasesCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests various setting combinations for the "Purchases" options.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingPurchasesCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -25,10 +25,10 @@ class SettingPurchasesCest
 	/**
 	 * Test that the Purchase Data option is saved when enabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataEnabled(AcceptanceTester $I)
 	{
@@ -48,10 +48,10 @@ class SettingPurchasesCest
 	/**
 	 * Test that the Purchase Data option is saved when disabled at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataDisabled(AcceptanceTester $I)
 	{
@@ -71,10 +71,10 @@ class SettingPurchasesCest
 	/**
 	 * Test that the Purchase Data Event option is saved when set to Order Processing at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataEventOrderProcessing(AcceptanceTester $I)
 	{
@@ -94,10 +94,10 @@ class SettingPurchasesCest
 	/**
 	 * Test that the Purchase Data Event option is saved when set to Order Completed at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.5
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.5
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSendPurchaseDataEventOrderCompleted(AcceptanceTester $I)
 	{
@@ -118,10 +118,10 @@ class SettingPurchasesCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/settings/SettingSubscribeEventCest.php
+++ b/tests/acceptance/settings/SettingSubscribeEventCest.php
@@ -5,17 +5,17 @@
  * - Display Opt-In Checkbox
  * - API Keys
  * - Subscription Form
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SettingSubscribeEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -29,10 +29,10 @@ class SettingSubscribeEventCest
 	/**
 	 * Test that the Order Pending payment option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOrderPendingPaymentWithoutOptInCheckbox(AcceptanceTester $I)
 	{
@@ -50,15 +50,15 @@ class SettingSubscribeEventCest
 
 		// Confirm the setting saved.
 		$I->seeOptionIsSelected('#woocommerce_ckwc_event', 'Order Pending payment');
-			
+
 	}
 	/**
 	 * Test that the Order Processing option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOrderProcessing(AcceptanceTester $I)
 	{
@@ -78,10 +78,10 @@ class SettingSubscribeEventCest
 	/**
 	 * Test that the Order Completed option is saved when selected at
 	 * WooCommerce > Settings > Integration > ConvertKit.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOrderCompleted(AcceptanceTester $I)
 	{
@@ -102,10 +102,10 @@ class SettingSubscribeEventCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form
  * or Tag on the Order Completed event when an order is placed through WooCommerce.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SubscribeOnOrderCompletedEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -32,10 +32,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -69,10 +69,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -105,10 +105,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is disabled in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -143,10 +143,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -181,10 +181,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -219,10 +219,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -262,10 +262,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -305,10 +305,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -347,10 +347,10 @@ class SubscribeOnOrderCompletedEventCest
 	 * - No Form is selected in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -376,16 +376,16 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
-	}	
+	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -2,17 +2,17 @@
 /**
  * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form
  * or Tag on the Order Pending payment (i.e. Order created) event when an order is placed through WooCommerce.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SubscribeOnOrderPendingPaymentEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -32,10 +32,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -63,10 +63,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -93,10 +93,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is disabled in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -125,10 +125,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -162,10 +162,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -199,10 +199,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -236,10 +236,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -268,10 +268,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -299,10 +299,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - No Form is selected in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -328,10 +328,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -3,17 +3,17 @@
  * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form,
  * Tag or Sequence on the Order Processing event when an order is placed through WooCommerce,
  * and that any Order data is correctly stored e.g. Order Notes.
- * 
- * @since 	1.4.2
+ *
+ * @since   1.4.2
  */
 class SubscribeOnOrderProcessingEventCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -33,10 +33,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -71,10 +71,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -94,7 +94,7 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
-	
+
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
 		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
 	}
@@ -104,10 +104,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is disabled in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -131,7 +131,7 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
-		
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
 	}
@@ -143,10 +143,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -180,10 +180,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -217,10 +217,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -254,10 +254,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -289,10 +289,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenUncheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -323,10 +323,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - No Form is selected in the integration Settings, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInDisabledWithNoFormAndSimpleProduct(AcceptanceTester $I)
 	{
@@ -349,7 +349,7 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
 		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-	
+
 	}
 
 	/**
@@ -359,10 +359,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The 'Simple' WooCommerce Product also defines a Form (separate to the Plugin settings), and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductForm(AcceptanceTester $I)
 	{
@@ -375,7 +375,7 @@ class SubscribeOnOrderProcessingEventCest
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
 			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
 			false, // Don't send purchase data to ConvertKit
-			'form:'.$_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Product level Form to subscribe email address to
+			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Product level Form to subscribe email address to
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -390,11 +390,11 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
 	}
-	
+
 	/**
 	 * Test that the Customer is subscribed to ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
@@ -402,10 +402,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The 'Simple' WooCommerce Product also defines a Tag (separate to the Plugin settings), and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductTag(AcceptanceTester $I)
 	{
@@ -418,7 +418,7 @@ class SubscribeOnOrderProcessingEventCest
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
 			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
 			false, // Don't send purchase data to ConvertKit
-			'tag:'.$_ENV['CONVERTKIT_API_TAG_ID'] // Product level Tag to subscribe email address to
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Product level Tag to subscribe email address to
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -433,7 +433,7 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
 	}
@@ -445,10 +445,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The 'Simple' WooCommerce Product also defines a Sequence (separate to the Plugin settings), and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductSequence(AcceptanceTester $I)
 	{
@@ -461,7 +461,7 @@ class SubscribeOnOrderProcessingEventCest
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to
 			'Order Processing', // Subscribe on WooCommerce "Order Processing" event
 			false, // Don't send purchase data to ConvertKit
-			'course:'.$_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Product level Sequence to subscribe email address to
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Product level Sequence to subscribe email address to
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -473,10 +473,10 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($result['email_address']);
-		
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
-	
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
 	}
@@ -490,10 +490,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The Customer unsubscribes from ConvertKit, and
 	 * - The Order's Status is changed to a non-Processing status, and
 	 * - The Order's Status is changed back to Processing.
-	 * 
-	 * @since 	1.4.2
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testCustomerIsNotResubscribedWhenOrderStatusChanges(AcceptanceTester $I)
 	{
@@ -532,10 +532,10 @@ class SubscribeOnOrderProcessingEventCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -1,17 +1,17 @@
 <?php
 /**
  * Tests for Sync Past Orders functionality.
- * 
- * @since 	1.4.3
+ *
+ * @since   1.4.3
  */
 class SyncPastOrdersCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _before(AcceptanceTester $I)
 	{
@@ -31,15 +31,15 @@ class SyncPastOrdersCest
 	/**
 	 * Test that no button is displayed on the Integration Settings screen
 	 * when the Integration is disabled.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNoButtonDisplayedWhenIntegrationDisabled(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Disable the Integration.
 		$I->loadConvertKitSettingsScreen($I);
@@ -51,7 +51,7 @@ class SyncPastOrdersCest
 
 		// Create Product.
 		$productName = 'Simple Product';
-		$productID = $I->wooCommerceCreateSimpleProduct($I, false);
+		$productID   = $I->wooCommerceCreateSimpleProduct($I, false);
 
 		// Define Email Address for this Test.
 		$emailAddress = 'wordpress-' . date( 'YmdHis' ) . '@convertkit.com';
@@ -70,12 +70,12 @@ class SyncPastOrdersCest
 
 		// Wait until JS completes and redirects.
 		$I->waitForElement('.woocommerce-order-received', 10);
-		
+
 		// Get data.
 		$result = [
 			'email_address' => $emailAddress,
-			'product_id' => $productID,
-			'order_id' => (int) $I->grabTextFrom('.woocommerce-order-overview__order strong'),
+			'product_id'    => $productID,
+			'order_id'      => (int) $I->grabTextFrom('.woocommerce-order-overview__order strong'),
 		];
 
 		// Login as the Administrator
@@ -91,15 +91,15 @@ class SyncPastOrdersCest
 	/**
 	 * Test that no button is displayed on the Integration Settings screen
 	 * when the Integration is enabled, and no API credentials are specified.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNoButtonDisplayedWhenIntegrationEnabledWithNoAPICredentials(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -137,15 +137,15 @@ class SyncPastOrdersCest
 	 * Test that no button is displayed on the Integration Settings screen
 	 * when the Integration is enabled, valid API credentials are specified
 	 * but there are no WooCommerce Orders.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNoButtonDisplayedWhenNoOrders(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -163,15 +163,15 @@ class SyncPastOrdersCest
 	 * - the Integration is enabled,
 	 * - valid API credentials are specified,
 	 * - a WooCommerce Order exists, that has had its Purchase Data sent to ConvertKit.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testNoButtonDisplayedWhenNoPastOrders(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -202,15 +202,15 @@ class SyncPastOrdersCest
 	 * - valid API credentials are specified,
 	 * - a WooCommerce Order exists, that has not had its Purchase Data sent to ConvertKit,
 	 * - clicking the button sends the Order to ConvertKit.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSyncPastOrder(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -248,7 +248,7 @@ class SyncPastOrdersCest
 		// Extract the Post ID from the Order ID, as the Custom Order Numbers Plugin does not prefix
 		// the order ID in the database or log entries.
 		$orderIDParts = explode('-', $result['order_id']);
-		$postID = $orderIDParts[ count($orderIDParts) - 1 ];
+		$postID       = $orderIDParts[ count($orderIDParts) - 1 ];
 
 		// Confirm that the log shows a success message.
 		$I->seeInSource('WooCommerce Order ID #' . $postID . ' added to ConvertKit Purchase Data successfully.');
@@ -266,39 +266,43 @@ class SyncPastOrdersCest
 		$I->seeInSource('Enable ConvertKit integration');
 
 		// Confirm that the Transaction ID is stored in the Order's metdata.
-		$I->seePostMetaInDatabase([
-			'post_id' => $postID,
-			'meta_key' => 'ckwc_purchase_data_sent'
-		]);
-		$I->seePostMetaInDatabase([
-			'post_id' => $postID,
-			'meta_key' => 'ckwc_purchase_data_id',
-		]);
+		$I->seePostMetaInDatabase(
+			[
+				'post_id'  => $postID,
+				'meta_key' => 'ckwc_purchase_data_sent',
+			]
+		);
+		$I->seePostMetaInDatabase(
+			[
+				'post_id'  => $postID,
+				'meta_key' => 'ckwc_purchase_data_id',
+			]
+		);
 	}
 
 	/**
 	 * Tests that a WooCommerce Order, which has had its Purchase Data sent to ConvertKit
 	 * in Plugin version 1.4.2 or older, will be synced in 1.4.5 and higher, to ensure that
 	 * the ConvertKit Purchase / Transaction ID is stored in the Order's metadata.
-	 * 
+	 *
 	 * 1.4.2 and older would mark a WooCommerce Order as sent to ConvertKit by adding the 'ckwc_purchase_data_sent'
 	 * meta key to the Order, with a value of 'yes' - however did not store the ConvertKit Purchase Data API response's
-	 * Transaction ID in the Order, meaning there is no way to potentially map WooCommerce Orders to ConvertKit API data. 
-	 * 
+	 * Transaction ID in the Order, meaning there is no way to potentially map WooCommerce Orders to ConvertKit API data.
+	 *
 	 * 1.4.3 and later performs the same as 1.4.2, but also storing the ConvertKit Transaction ID in the 'ckwc_purchase_data_id',
 	 * allowing for the possibility of future mapping between WooCommerce and ConvertKit.
-	 * 
+	 *
 	 * This test ensures that a 1.4.2 or older Order, which was already sent to ConvertKit, will be sent again so that
 	 * the ConvertKit Purchase Data is overwritten, and the ConvertKit Transaction ID is stored against the WooCommerce Order.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSyncPastOrderCreatedInPreviousPluginVersion(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -318,14 +322,16 @@ class SyncPastOrdersCest
 		// Extract the Post ID from the Order ID, as the Custom Order Numbers Plugin does not prefix
 		// the order ID in the database .
 		$orderIDParts = explode('-', $result['order_id']);
-		$postID = $orderIDParts[ count($orderIDParts) - 1 ];
+		$postID       = $orderIDParts[ count($orderIDParts) - 1 ];
 
 		// Remove the Transaction ID metadata in the Order, as if it were sent
 		// by 1.4.2 or older.
-		$I->dontHavePostMetaInDatabase([
-			'post_id' => $postID,
-			'meta_key' => 'ckwc_purchase_data_id'
-		]);
+		$I->dontHavePostMetaInDatabase(
+			[
+				'post_id'  => $postID,
+				'meta_key' => 'ckwc_purchase_data_id',
+			]
+		);
 
 		// Login as the Administrator
 		$I->loginAsAdmin();
@@ -355,29 +361,33 @@ class SyncPastOrdersCest
 		$I->seeElementInDOM('a.cancel[disabled]');
 
 		// Confirm that the Transaction ID is stored in the Order's metdata.
-		$I->seePostMetaInDatabase([
-			'post_id' => $postID,
-			'meta_key' => 'ckwc_purchase_data_sent'
-		]);
-		$I->seePostMetaInDatabase([
-			'post_id' => $postID,
-			'meta_key' => 'ckwc_purchase_data_id'
-		]);
+		$I->seePostMetaInDatabase(
+			[
+				'post_id'  => $postID,
+				'meta_key' => 'ckwc_purchase_data_sent',
+			]
+		);
+		$I->seePostMetaInDatabase(
+			[
+				'post_id'  => $postID,
+				'meta_key' => 'ckwc_purchase_data_id',
+			]
+		);
 	}
 
 	/**
 	 * Test that a WooCommerce Order, that has not had its Purchase Data sent to ConvertKit,
 	 * is not sent to ConvertKit when the Sync Past Orders button is clicked and the API
 	 * credentials are invalid.
-	 * 
-	 * @since 	1.4.3
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function testSyncPastOrderWithInvalidAPICredentials(AcceptanceTester $I)
 	{
 		// Delete all existing WooCommerce Orders from the database.
-		$I->dontHavePostInDatabase(['post_type' => 'shop_order']);
+		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -439,10 +449,10 @@ class SyncPastOrdersCest
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.
-	 * 
-	 * @since 	1.4.4
-	 * 
-	 * @param 	AcceptanceTester 	$I 	Tester
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester
 	 */
 	public function _passed(AcceptanceTester $I)
 	{

--- a/tests/wpunit/ResourceCustomFieldsNoDataTest.php
+++ b/tests/wpunit/ResourceCustomFieldsNoDataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Custom_Fields class when no data is present in the API.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Custom_Fields
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Custom_Fields
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -114,8 +114,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -125,8 +125,8 @@ class ResourceCustomFieldsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceCustomFieldsTest.php
+++ b/tests/wpunit/ResourceCustomFieldsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Custom_Fields class.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Custom_Fields
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Custom_Fields
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -115,8 +115,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -126,8 +126,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceFormsNoDataTest.php
+++ b/tests/wpunit/ResourceFormsNoDataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Forms class when no data is present in the API.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -114,8 +114,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -125,8 +125,8 @@ class ResourceFormsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Forms class.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Forms
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Forms
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -115,8 +115,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -126,8 +126,8 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceSequencesNoDataTest.php
+++ b/tests/wpunit/ResourceSequencesNoDataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Sequences class when no data is present in the API.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Sequences
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Sequences
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -114,8 +114,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -125,8 +125,8 @@ class ResourceSequencesNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceSequencesTest.php
+++ b/tests/wpunit/ResourceSequencesTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Sequences class.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Sequences
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Sequences
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -115,8 +115,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -126,8 +126,8 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceTagsNoDataTest.php
+++ b/tests/wpunit/ResourceTagsNoDataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Tags class when no data is present in the API.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Tags
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Tags
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -114,8 +114,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -125,8 +125,8 @@ class ResourceTagsNoDataTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Tests for the CKWC_Resource_Tags class.
- * 
- * @since 	1.4.7
+ *
+ * @since   1.4.7
  */
 class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 {
@@ -13,26 +13,26 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Holds the key name that stores settings for this Plugin.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	string
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     string
 	 */
 	private $settings_key = 'woocommerce_ckwc_settings';
 
 	/**
 	 * Holds the ConvertKit Resource class.
-	 * 
-	 * @since 	1.4.7
-	 * 
-	 * @var 	ConvertKit_Resource_Tags
+	 *
+	 * @since   1.4.7
+	 *
+	 * @var     ConvertKit_Resource_Tags
 	 */
 	private $resource;
 
 	/**
 	 * Performs actions before each test.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function setUp(): void
 	{
@@ -50,8 +50,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Performs actions after each test.
-	 * 
-	 * @since 	1.9.6.9
+	 *
+	 * @since   1.9.6.9
 	 */
 	public function tearDown(): void
 	{
@@ -69,8 +69,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the refresh() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testRefresh()
 	{
@@ -83,8 +83,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the expiry timestamp is set and returns the expected value.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExpiry()
 	{
@@ -100,8 +100,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the get() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
@@ -115,8 +115,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the count() function returns the number of resources.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testCount()
 	{
@@ -126,8 +126,8 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 
 	/**
 	 * Test that the exist() function performs as expected.
-	 * 
-	 * @since 	1.4.7
+	 *
+	 * @since   1.4.7
 	 */
 	public function testExist()
 	{


### PR DESCRIPTION
## Summary

Applies coding standards for tests, as we do for the [main ConvertKit Plugin](https://github.com/ConvertKit/convertkit-wordpress/pull/380).

This PR includes whitespace fixes; a separate PR will cover fixes for other coding standards in tests, which means the coding standards GitHub Action will fail at this time.

## Testing

Existing tests are run.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)