### PR TITLE
PHPStan for WordPress 1.1.5 compatbility

### DIFF
--- a/admin/class-ckwc-admin-bulk-edit.php
+++ b/admin/class-ckwc-admin-bulk-edit.php
@@ -55,7 +55,7 @@ class CKWC_Admin_Bulk_Edit {
 		wp_enqueue_script( 'ckwc-bulk-edit', CKWC_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
 
 		// Output Bulk Edit fields in the footer of the Administration screen.
-		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10, 2 );
+		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );
 
 	}
 

--- a/admin/class-ckwc-admin-quick-edit.php
+++ b/admin/class-ckwc-admin-quick-edit.php
@@ -90,7 +90,7 @@ class CKWC_Admin_Quick_Edit {
 		}
 
 		// Output Quick Edit fields in the footer of the Administration screen.
-		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10, 2 );
+		add_action( 'in_admin_footer', array( $this, 'quick_edit_fields' ), 10 );
 
 	}
 

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -88,7 +88,7 @@ class CKWC_Integration extends WC_Integration {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
 			// Takes the form data and saves it to WooCommerce's settings.
-			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) );
+			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) ); // @phpstan-ignore-line
 
 			// Sanitizes and tests specific setting fields to ensure they're valid.
 			add_filter( "woocommerce_settings_api_sanitized_fields_{$this->id}", array( $this, 'sanitize_settings' ) );

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -77,7 +77,7 @@ class CKWC_Order {
 
 		// Send Purchase Data.
 		if ( $this->integration->get_option_bool( 'send_purchases' ) ) {
-			add_action( 'woocommerce_order_status_changed', array( $this, 'send_purchase_data' ), 99999, 3 );
+			add_action( 'woocommerce_order_status_changed', array( $this, 'send_purchase_data' ), 99999, 3 ); // @phpstan-ignore-line
 		}
 
 	}

--- a/includes/class-ckwc-wc-subscriptions.php
+++ b/includes/class-ckwc-wc-subscriptions.php
@@ -58,8 +58,6 @@ class CKWC_WC_Subscriptions {
 	 */
 	public function __construct() {
 
-		add_action( 'admin_init', array( $this, 'is_plugin_active' ) );
-
 		// Check if the Order should opt in the Customer.
 		add_filter( 'convertkit_for_woocommerce_order_should_opt_in_customer', array( $this, 'order_should_opt_in_customer' ), 10, 2 );
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -74,8 +74,10 @@ class Plugin extends \Codeception\Module
 	public function deactivateWooCommerceAndConvertKitPlugins($I)
 	{
 		$I->deactivateThirdPartyPlugin($I, 'convertkit-for-woocommerce');
-		$I->deactivateThirdPartyPlugin($I, 'woocommerce');
+
+		// Deactivate WooCommerce Stripe Gateway before WooCommerce, to prevent WooCommerce throwing a fatal error.
 		$I->deactivateThirdPartyPlugin($I, 'woocommerce-gateway-stripe');
+		$I->deactivateThirdPartyPlugin($I, 'woocommerce');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes failing static analysis tests due to improvements in static analysis in PHPStan for WordPress 1.1.5.

Fixes an issue with tests when deactivating WooCommerce Stripe Gateway after WooCommerce would result in a fatal error, due to WooCommerce.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)