### PR TITLE
Improve Bulk & Quick Edit UI

### DIFF
--- a/admin/class-ckwc-admin-bulk-edit.php
+++ b/admin/class-ckwc-admin-bulk-edit.php
@@ -54,6 +54,9 @@ class CKWC_Admin_Bulk_Edit {
 		// Enqueue JS.
 		wp_enqueue_script( 'ckwc-bulk-edit', CKWC_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
 
+		// Enqueue CSS.
+		wp_enqueue_style( 'ckwc-bulk-quick-edit', CKWC_PLUGIN_URL . '/resources/backend/css/bulk-quick-edit.css', array(), CKWC_PLUGIN_VERSION );
+
 		// Output Bulk Edit fields in the footer of the Administration screen.
 		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );
 

--- a/resources/backend/css/bulk-quick-edit.css
+++ b/resources/backend/css/bulk-quick-edit.css
@@ -1,0 +1,29 @@
+#ckwc-bulk-edit,
+#ckwc-quick-edit {
+	display: none;
+}
+
+.ckwc-bulk-quick-edit > div {
+	display: grid;
+	grid-template-columns: auto 36px;
+	column-gap: 10px;
+	align-items: end;
+	margin: 0 0 5px 0;
+}
+.ckwc-bulk-quick-edit > div select {
+	width: 100%;
+	max-width: 100%;
+	height: 32px;
+	line-height: 32px;
+}
+.ckwc-bulk-quick-edit > div button {
+	width: 36px;
+	height: 32px;
+}
+
+@media screen and (max-width: 782px) {
+	.ckwc-bulk-quick-edit > div button {
+		width: 40px;
+		height: 40px;
+	}
+}

--- a/views/backend/product/bulk-edit.php
+++ b/views/backend/product/bulk-edit.php
@@ -2,21 +2,23 @@
 /**
  * Bulk Edit view
  *
- * @package ConvertKit
+ * @package CKWC
  * @author ConvertKit
  */
 
 ?>
-<div id="ckwc-bulk-edit" style="display:none;">
+<div id="ckwc-bulk-edit" class="ckwc-bulk-quick-edit">
 	<h4><?php esc_html_e( 'ConvertKit for WooCommerce', 'woocommerce-convertkit' ); ?></h4>
 
-	<?php
-	// Load subscription dropdown field.
-	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
-	?>
-	<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
-		<span class="dashicons dashicons-update"></span>
-	</button>
+	<div>
+		<?php
+		// Load subscription dropdown field.
+		require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+		?>
+		<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+			<span class="dashicons dashicons-update"></span>
+		</button>
+	</div>
 
 	<?php
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );

--- a/views/backend/product/quick-edit.php
+++ b/views/backend/product/quick-edit.php
@@ -7,16 +7,18 @@
  */
 
 ?>
-<div id="ckwc-quick-edit" style="display:none;">
+<div id="ckwc-quick-edit" class="ckwc-bulk-quick-edit">
 	<h4><?php esc_html_e( 'ConvertKit for WooCommerce', 'woocommerce-convertkit' ); ?></h4>
 
-	<?php
-	// Load subscription dropdown field.
-	require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
-	?>
-	<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
-		<span class="dashicons dashicons-update"></span>
-	</button>
+	<div>
+		<?php
+		// Load subscription dropdown field.
+		require CKWC_PLUGIN_PATH . '/views/backend/subscription-dropdown-field.php';
+		?>
+		<button class="ckwc-refresh-resources" class="button button-secondary" title="<?php esc_attr_e( 'Refresh sequences, forms and tags from ConvertKit account', 'woocommerce-convertkit' ); ?>" data-field="#<?php echo esc_attr( $subscription['id'] ); ?>">
+			<span class="dashicons dashicons-update"></span>
+		</button>
+	</div>
 
 	<?php
 	wp_nonce_field( 'ckwc', 'ckwc_nonce' );


### PR DESCRIPTION
## Summary

- Improves layout, spacing and sizing of elements when using the Bulk Edit and Quick Edit functionality in WordPress on varying screen sizes
- Increase size of refresh buttons on smaller screens

### Before

Desktop
![Screenshot 2022-12-02 at 15 30 26](https://user-images.githubusercontent.com/1462305/205329117-e7911969-f8b4-443d-a2c6-37380e05e2f4.png)

Mobile
![Screenshot 2022-12-02 at 15 30 32](https://user-images.githubusercontent.com/1462305/205329118-e1532ccb-eec1-4fa1-afce-1e5aa73601d1.png)

### After

Desktop
![Screenshot 2022-12-02 at 15 31 28](https://user-images.githubusercontent.com/1462305/205329137-75d55f7c-2a2c-4146-8995-ef644c410dd1.png)

Mobile
![Screenshot 2022-12-02 at 15 31 41](https://user-images.githubusercontent.com/1462305/205329138-bd507521-1f28-4ef9-9c2f-12d313ab96a6.png)

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)