### PR TITLE
Run tests against PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0' ]
+        php-versions: [ '7.4', '8.0', '8.1' ] #[ '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
@@ -123,12 +123,18 @@ jobs:
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ secrets.CONVERTKIT_PAID_PLUGIN_URLS }}
       
-      # WP_DEBUG = true is required so any WordPress / PHP errors are output and caught by tests.
-      # FS_METHOD = direct is required for WP_Filesystem to operate without suppressed PHP fopen() errors that trip up tests.
+      # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
+      # WP_DEBUG = false for PHP 8.1, otherwise E_DEPRECATED is output due to https://core.trac.wordpress.org/ticket/54504
       - name: Enable WP_DEBUG
+        if: ${{ matrix.php-versions != '8.1' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw
+
+      # FS_METHOD = direct is required for WP_Filesystem to operate without suppressed PHP fopen() errors that trip up tests.
+      - name: Enable FS_METHOD
+        working-directory: ${{ env.ROOT_DIR }}
+        run: |
           wp-cli config set FS_METHOD direct
 
       # This step is deliberately after WordPress installation and configuration, as enabling PHP 8.x before using WP-CLI results


### PR DESCRIPTION
## Summary

Runs tests against PHP 8.1, which is the current (and only) [actively supported version](https://www.php.net/supported-versions.php) provided by PHP.

`WP_DEBUG` is disabled when running tests against PHP 8.1, due to [this WordPress core](https://core.trac.wordpress.org/ticket/54504) issue that requires resolution to prevent `E_DEPRECATED` notices when performing HTTP requests.

Critical PHP errors and warnings will still result in test failure, however we'll need to reintroduce WP_DEBUG once WordPress resolve the above core issue.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)