### PR TITLE
Fix iThemes Sync Error

### DIFF
--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -55,14 +55,12 @@ require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-resource-tags.php';
 require_once CKWC_PLUGIN_PATH . '/includes/class-ckwc-wc-subscriptions.php';
 
 // Load files that are only used in the WordPress Administration interface.
-if ( is_admin() ) {
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-ajax.php';
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-bulk-edit.php';
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-plugin.php';
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-product.php';
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-quick-edit.php';
-	require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-refresh-resources.php';
-}
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-ajax.php';
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-bulk-edit.php';
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-plugin.php';
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-product.php';
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-quick-edit.php';
+require_once CKWC_PLUGIN_PATH . '/admin/class-ckwc-admin-refresh-resources.php';
 
 /**
  * Main function to return Plugin instance.


### PR DESCRIPTION
## Summary

Fixes [this reported error](https://convertkit.atlassian.net/browse/T3-81), where attempting to remotely update any WordPress Plugins using [iThemes Sync](https://sync.ithemes.com/) would result in iThemes Sync returning an error, specifically when the ConvertKit for WooCommerce Plugin is active:
[]

This happens during the iThemes Sync remote request due to the following request life cycle:
1. `is_admin()` is false [here](https://github.com/ConvertKit/convertkit-woocommerce/blob/main/woocommerce-convertkit.php#L58), therefore the Plugin does not include WordPress Admin specific PHP files,
2. The iThemes Sync Plugin (which listens for inbound requests from https://sync.ithemes.com/ for e.g. updating a Plugin) determines that this is a WordPress Admin request, changing `is_admin()` to `true`,
3. `is_admin()` is true [here](https://github.com/ConvertKit/convertkit-woocommerce/blob/main/includes/class-wp-ckwc.php#L98), because we deliberately initialize our Plugin classes using the `woocommerce_init` hook, to ensure that WooCommerce is fully loaded.
4. Classes, such as `CKWC_AJAX_Admin` fail to initialize because they weren't loaded in step 1

Including the WordPress Admin specific PHP files won't affect performance, as they are still only conditionally initialized in step 4.

## Testing

iThemes Sync is a remote service that connects WordPress sites that are web accessible and have the iThemes Sync plugin installed and authenticated.  It's not possible to write a test, because GitHub Actions spin up WordPress instances that are not web accessible.

Manual testing was performed, to confirm the change resolves.

Before:
https://www.loom.com/share/595538092aab4ad7810c92fbf888f618

After:
https://www.loom.com/share/b9cc958bea244611bae477f986d62bd4

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)