### PR TITLE
Use WordPress Libraries 1.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.2.2"
+        "convertkit/convertkit-wordpress-libraries": "1.2.3"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -86,8 +86,10 @@ class CKWC_API extends ConvertKit_API {
 
 			/* translators: HTTP method */
 			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
-			'request_rate_limit_exceeded'                 => __( 'Rate limit hit.', 'woocommerce-convertkit' ),
-			'response_type_unexpected'                    => __( 'The response from the API is not of the expected type array.', 'woocommerce-convertkit' ),
+			'request_rate_limit_exceeded'                 => __( 'ConvertKit API Error: Rate limit hit.', 'woocommerce-convertkit' ),
+			'request_internal_server_error'               => __( 'ConvertKit API Error: Internal server error.', 'woocommerce-convertkit' ),
+			'request_bad_gateway'                         => __( 'ConvertKit API Error: Bad gateway.', 'woocommerce-convertkit' ),
+			'response_type_unexpected'                    => __( 'ConvertKit API Error: The response is not of the expected type array.', 'woocommerce-convertkit' ),
 		);
 
 	}


### PR DESCRIPTION
## Summary

Updates the Plugin to use the latest version of our ConvertKit WordPress Libraries, [1.2.3](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.2.3), resolving [this issue](https://convertkit.atlassian.net/browse/T3-106).

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)