### PR TITLE
Return Resources in correct order

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-sort-resources-on-refresh"
+        "convertkit/convertkit-wordpress-libraries": "1.3.1"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.0"
+        "convertkit/convertkit-wordpress-libraries": "dev-sort-resources-on-refresh"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-ckwc-resource-custom-fields.php
+++ b/includes/class-ckwc-resource-custom-fields.php
@@ -28,4 +28,13 @@ class CKWC_Resource_Custom_Fields extends CKWC_Resource {
 	 */
 	public $type = 'custom_fields';
 
+	/**
+	 * The key to use when alphabetically sorting resources.
+	 *
+	 * @since   1.5.7
+	 *
+	 * @var     string
+	 */
+	public $order_by = 'label';
+
 }

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -168,4 +168,107 @@ class Plugin extends \Codeception\Module
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 	}
+
+	/**
+	 * Helper method to determine the order of <option> values for the given select element
+	 * and values when <optgroup> is used within a <select>.
+	 *
+	 * @since   1.5.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $selectElement <select> element.
+	 */
+	public function checkSelectWithOptionGroupsOptionOrder($I, $selectElement)
+	{
+		// Define options.
+		$options = [
+			'ckwc-sequences' => [ // <optgroup> ID.
+				'Another Sequence', // First item.
+				'WordPress Sequence', // Last item.
+			],
+			'ckwc-forms'     => [ // <optgroup> ID.
+				'AAA Test', // First item.
+				'WooCommerce Product Form', // Last item.
+			],
+			'ckwc-tags'      => [ // <optgroup> ID.
+				'gravityforms-tag-1', // First item.
+				'wordpress', // Last item.
+			],
+		];
+
+		// Confirm ordering.
+		foreach ( $options as $optgroup => $values ) {
+			foreach ( $values as $i => $value ) {
+				// Define the applicable CSS selector.
+				if ( $i === 0 ) {
+					$nth = 'first-child';
+				} elseif ( $i + 1 === count( $values ) ) {
+					$nth = 'last-child';
+				} else {
+					$nth = 'nth-child(' . ( $i + 1 ) . ')';
+				}
+
+				$I->assertEquals(
+					$I->grabTextFrom('select' . $selectElement . ' optgroup#' . $optgroup . ' option:' . $nth),
+					$value
+				);
+			}
+		}
+	}
+
+	/**
+	 * Helper method to determine that the order of the Form resources in the given
+	 * select element are in the expected alphabetical order.
+	 *
+	 * @since   1.5.7
+	 *
+	 * @param   AcceptanceTester $I                 AcceptanceTester.
+	 * @param   string           $selectElement     <select> element.
+	 * @param   bool|array       $prependOptions    Option elements that should appear before the resources.
+	 */
+	public function checkSelectCustomFieldOptionOrder($I, $selectElement, $prependOptions = false)
+	{
+		// Define options.
+		$options = [
+			'Billing Address', // First item.
+			'Test', // Last item.
+		];
+
+		// Prepend options, such as 'Default' and 'None' to the options, if required.
+		if ( $prependOptions ) {
+			$options = array_merge( $prependOptions, $options );
+		}
+
+		// Check order.
+		$I->checkSelectOptionOrder($I, $selectElement, $options);
+	}
+
+	/**
+	 * Helper method to determine the order of <option> values for the given select element
+	 * and values.
+	 *
+	 * @since   1.5.7
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   string           $selectElement <select> element.
+	 * @param   array            $values        <option> values.
+	 */
+	public function checkSelectOptionOrder($I, $selectElement, $values)
+	{
+		foreach ( $values as $i => $value ) {
+			// Define the applicable CSS selector.
+			if ( $i === 0 ) {
+				$nth = 'first-child';
+			} elseif ( $i + 1 === count( $values ) ) {
+				$nth = 'last-child';
+			} else {
+				$nth = 'nth-child(' . ( $i + 1 ) . ')';
+			}
+
+			$I->assertEquals(
+				$I->grabTextFrom('select' . $selectElement . ' option:' . $nth),
+				$value
+			);
+		}
+	}
 }

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -78,6 +78,9 @@ class ProductCest
 		// Check that the dropdown field to select a Form, Tag or Sequence is displayed.
 		$I->seeElementInDOM('#ckwc_subscription');
 
+		// Check the order of the resource dropdown are alphabetical.
+		$I->checkSelectWithOptionGroupsOptionOrder($I, '#ckwc_subscription');
+
 		// Select Form.
 		$I->fillSelect2Field($I, '#select2-ckwc_subscription-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
 

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -52,6 +52,9 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('button.ckwc-refresh-resources:not(:disabled)');
 
+		// Check the order of the resource dropdown are alphabetical.
+		$I->checkSelectWithOptionGroupsOptionOrder($I, '#ckwc_subscription');
+
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist in the Select2 field, this will fail the test.
 		$I->fillSelect2Field($I, '#select2-ckwc_subscription-container', $_ENV['CONVERTKIT_API_FORM_NAME']);
@@ -93,6 +96,9 @@ class RefreshResourcesButtonCest
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('#ckwc-bulk-edit button.ckwc-refresh-resources:not(:disabled)');
 
+		// Check the order of the resource dropdown are alphabetical.
+		$I->checkSelectWithOptionGroupsOptionOrder($I, '#ckwc_subscription');
+
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.
 		$I->selectOption('#ckwc_subscription', $_ENV['CONVERTKIT_API_FORM_NAME']);
@@ -124,6 +130,9 @@ class RefreshResourcesButtonCest
 
 		// Wait for button to change its state from disabled.
 		$I->waitForElementVisible('#ckwc-quick-edit button.ckwc-refresh-resources:not(:disabled)');
+
+		// Check the order of the resource dropdown are alphabetical.
+		$I->checkSelectWithOptionGroupsOptionOrder($I, '#ckwc_subscription');
 
 		// Change resource to value specified in the .env file, which should now be available.
 		// If the expected dropdown value does not exist, this will fail the test.

--- a/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
+++ b/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
@@ -93,6 +93,9 @@ class SettingAPIKeyAndSecretCest
 		// Confirm that the Subscription dropdown option is displayed.
 		$I->seeElement('#woocommerce_ckwc_subscription');
 
+		// Check the order of the resource dropdown are alphabetical.
+		$I->checkSelectWithOptionGroupsOptionOrder($I, '#woocommerce_ckwc_subscription');
+
 		// Confirm that an expected option can be selected.
 		$I->selectOption('#woocommerce_ckwc_subscription', $_ENV['CONVERTKIT_API_FORM_NAME']);
 	}

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -36,6 +36,15 @@ class SettingCustomFieldsCest
 	 */
 	public function testCustomFields(AcceptanceTester $I)
 	{
+		// Confirm Custom Fields are in alphabetical ascending order.
+		$I->checkSelectCustomFieldOptionOrder(
+			$I,
+			'#woocommerce_ckwc_custom_field_phone',
+			[
+				'(Don\'t send or map)',
+			]
+		);
+
 		// Set Order to Custom Field mappings.
 		$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');

--- a/tests/wpunit/ResourceCustomFieldsTest.php
+++ b/tests/wpunit/ResourceCustomFieldsTest.php
@@ -101,18 +101,97 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected.
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * by default.
 	 *
 	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		// Call resource class' get() function.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+
+		// Assert result is an array.
 		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+		$this->assertArrayHasKey('key', reset($result));
+		$this->assertArrayHasKey('label', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('Billing Address', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Test', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'key';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+		$this->assertArrayHasKey('key', reset($result));
+		$this->assertArrayHasKey('label', reset($result));
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('test', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('billing_address', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+		$this->assertArrayHasKey('key', reset($result));
+		$this->assertArrayHasKey('label', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals('Billing Address', reset($result)['name']);
+		$this->assertEquals('Test', end($result)['name']);
 	}
 
 	/**

--- a/tests/wpunit/ResourceCustomFieldsTest.php
+++ b/tests/wpunit/ResourceCustomFieldsTest.php
@@ -190,8 +190,8 @@ class ResourceCustomFieldsTest extends \Codeception\TestCase\WPTestCase
 		$this->assertArrayHasKey('label', reset($result));
 
 		// Assert order of data has not changed.
-		$this->assertEquals('Billing Address', reset($result)['name']);
-		$this->assertEquals('Test', end($result)['name']);
+		$this->assertEquals('Billing Address', reset($result)['label']);
+		$this->assertEquals('Test', end($result)['label']);
 	}
 
 	/**

--- a/tests/wpunit/ResourceFormsTest.php
+++ b/tests/wpunit/ResourceFormsTest.php
@@ -101,18 +101,91 @@ class ResourceFormsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected.
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * by default.
 	 *
 	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		// Call resource class' get() function.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+
+		// Assert result is an array.
 		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('AAA Test', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('WooCommerce Product Form', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'name';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('WooCommerce Product Form', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('AAA Test', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals('AAA Test', reset($result)['name']);
+		$this->assertEquals('WooCommerce Product Form', end($result)['name']);
 	}
 
 	/**

--- a/tests/wpunit/ResourceSequencesTest.php
+++ b/tests/wpunit/ResourceSequencesTest.php
@@ -101,18 +101,91 @@ class ResourceSequencesTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected.
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * by default.
 	 *
 	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		// Call resource class' get() function.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+
+		// Assert result is an array.
 		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('Another Sequence', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('WordPress Sequence', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'name';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('WordPress Sequence', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('Another Sequence', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals('WordPress Sequence', reset($result)['name']);
+		$this->assertEquals('Another Sequence', end($result)['name']);
 	}
 
 	/**

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -101,18 +101,152 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Test that the get() function performs as expected.
+	 * Tests that the get() function returns resources in alphabetical ascending order
+	 * by default.
 	 *
 	 * @since   1.4.7
 	 */
 	public function testGet()
 	{
-		// Confirm that the data is fetched from the options table when using get(), and includes some expected keys.
+		// Call resource class' get() function.
 		$result = $this->resource->get();
-		$this->assertNotInstanceOf(WP_Error::class, $result);
+
+		// Assert result is an array.
 		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
 		$this->assertArrayHasKey('id', reset($result));
 		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('gravityforms-tag-1', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('wordpress', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'name';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in ascending alphabetical order.
+		$this->assertEquals('wordpress', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('gravityforms-tag-1', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals('wordpress', reset($result)['name']);
+		$this->assertEquals('gravityforms-tag-2', end($result)['name']);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in alphabetical descending order
+	 * when a valid order_by and order properties are defined.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithValidOrderByAndOrder()
+	{
+		// Define order_by and order.
+		$this->resource->order_by = 'name';
+		$this->resource->order    = 'desc';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data is in descending alphabetical order.
+		$this->assertEquals('?', reset($result)[ $this->resource->order_by ]);
+		$this->assertEquals('?', end($result)[ $this->resource->order_by ]);
+	}
+
+	/**
+	 * Tests that the get() function returns resources in their original order
+	 * when populated with Forms and an invalid order_by value is specified.
+	 *
+	 * @since   1.5.7
+	 */
+	public function testGetWithInvalidOrderBy()
+	{
+		// Define order_by with an invalid value (i.e. an array key that does not exist).
+		$this->resource->order_by = 'invalid_key';
+
+		// Call resource class' get() function.
+		$result = $this->resource->get();
+
+		// Assert result is an array.
+		$this->assertIsArray($result);
+
+		// Assert top level array keys are preserved.
+		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
+		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
+
+		// Assert resource within results has expected array keys.
+		$this->assertArrayHasKey('id', reset($result));
+		$this->assertArrayHasKey('name', reset($result));
+
+		// Assert order of data has not changed.
+		$this->assertEquals('?', reset($result)['name']);
+		$this->assertEquals('?', end($result)['name']);
 	}
 
 	/**

--- a/tests/wpunit/ResourceTagsTest.php
+++ b/tests/wpunit/ResourceTagsTest.php
@@ -189,67 +189,6 @@ class ResourceTagsTest extends \Codeception\TestCase\WPTestCase
 	}
 
 	/**
-	 * Tests that the get() function returns resources in alphabetical descending order
-	 * when a valid order_by and order properties are defined.
-	 *
-	 * @since   1.5.7
-	 */
-	public function testGetWithValidOrderByAndOrder()
-	{
-		// Define order_by and order.
-		$this->resource->order_by = 'name';
-		$this->resource->order    = 'desc';
-
-		// Call resource class' get() function.
-		$result = $this->resource->get();
-
-		// Assert result is an array.
-		$this->assertIsArray($result);
-
-		// Assert top level array keys are preserved.
-		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
-		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
-
-		// Assert resource within results has expected array keys.
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-
-		// Assert order of data is in descending alphabetical order.
-		$this->assertEquals('?', reset($result)[ $this->resource->order_by ]);
-		$this->assertEquals('?', end($result)[ $this->resource->order_by ]);
-	}
-
-	/**
-	 * Tests that the get() function returns resources in their original order
-	 * when populated with Forms and an invalid order_by value is specified.
-	 *
-	 * @since   1.5.7
-	 */
-	public function testGetWithInvalidOrderBy()
-	{
-		// Define order_by with an invalid value (i.e. an array key that does not exist).
-		$this->resource->order_by = 'invalid_key';
-
-		// Call resource class' get() function.
-		$result = $this->resource->get();
-
-		// Assert result is an array.
-		$this->assertIsArray($result);
-
-		// Assert top level array keys are preserved.
-		$this->assertArrayHasKey(array_key_first($this->resource->resources), $result);
-		$this->assertArrayHasKey(array_key_last($this->resource->resources), $result);
-
-		// Assert resource within results has expected array keys.
-		$this->assertArrayHasKey('id', reset($result));
-		$this->assertArrayHasKey('name', reset($result));
-
-		// Assert order of data has not changed.
-		$this->assertEquals('?', reset($result)['name']);
-		$this->assertEquals('?', end($result)['name']);
-	}
-
-	/**
 	 * Test that the count() function returns the number of resources.
 	 *
 	 * @since   1.4.7


### PR DESCRIPTION
## Summary

Implements 1.3.1 of the WordPress Libraries, resolving [this issue](https://wordpress.org/support/topic/convertkit-tags-in-woocommerce-not-in-alphabetical-order/), to ensure that Forms, Sequences, Tags and Custom Fields are returned in alphabetical order by name.

## Testing

- Added `checkSelect*Order()` helper functions to test that the order of `<select>` dropdown option are correct
- WPUnit Resource tests to confirm that `order_by` and `order` properties are honored

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)