### PR TITLE
Update Select2 instance on Refresh Resources

### DIFF
--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -93,6 +93,9 @@ jQuery( document ).ready(
 								);
 							}
 
+							// Reload Select2 instances, so that they reflect the changes made.
+							$( '.ckwc-select2' ).select2();
+
 							// Enable button.
 							$( button ).prop( 'disabled', false );
 

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -94,7 +94,8 @@ jQuery( document ).ready(
 							}
 
 							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
-							$( field ).trigger( 'change' );
+							// Reload Select2 instances, so that they reflect the changes made.
+							$( '.ckwc-select2' ).select2();
 
 							// Enable button.
 							$( button ).prop( 'disabled', false );

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -93,10 +93,6 @@ jQuery( document ).ready(
 								);
 							}
 
-							// Trigger a change event on the select field, to allow Select2 instances to repopulate their options.
-							// Reload Select2 instances, so that they reflect the changes made.
-							$( '.ckwc-select2' ).select2();
-
 							// Enable button.
 							$( button ).prop( 'disabled', false );
 


### PR DESCRIPTION
## Summary

Reloads Select2 instances after the refreshing resources process completes, to ensure that the updated resources are displayed in the Select2 dropdown.

The existing method of triggering the `change` event works in tests and the main ConvertKit Plugin, but fails when manually tested in this Plugin (in this example, the Test Sequence does not get added to the list of options, despite being added in ConvertKit):
https://www.loom.com/share/1e6064a2327543f69c594d9d68d9e778

Changing this to reloading the Select2 instance works (in this example, the Test Sequence is added to the list of options when added in ConvertKit):
https://www.loom.com/share/9aa3f6980d9a4367b67d1f24de968f96

WooCommerce ships its own variant of the Select2 library, which may explain this different behaviour, although it's unclear why this isn't caught by our tests, which have always checked that the Select2 options are updated.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)