### PR TITLE
Add subscription logic for WooCommerce Coupons

### DIFF
--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -142,7 +142,7 @@ class CKWC_Order {
 			 * @param   int    $order_id        WooCommerce Order ID.
 			 * @param   string $status_old      Order's Old Status.
 			 * @param   string $status_new      Order's New Status.
-			 * @param   int    $product_id 		Product ID.
+			 * @param   int    $product_id      Product ID.
 			 */
 			$resource_id = apply_filters( 'convertkit_for_woocommerce_order_maybe_subscribe_customer_resource_id', $resource_id, $order_id, $status_old, $status_new, $item['product_id'] );
 
@@ -158,7 +158,7 @@ class CKWC_Order {
 		// Get coupon-specific subscription settings.
 		foreach ( $order->get_coupon_codes() as $coupon_code ) {
 			// Get the WC_Coupon object.
-    		$coupon = new WC_Coupon( $coupon_code );
+			$coupon = new WC_Coupon( $coupon_code );
 
 			// Get the Form, Tag or Sequence for this Coupon.
 			$resource_id = get_post_meta( $coupon->get_id(), 'ckwc_subscription', true );
@@ -172,7 +172,7 @@ class CKWC_Order {
 			 * @param   int    $order_id        WooCommerce Order ID.
 			 * @param   string $status_old      Order's Old Status.
 			 * @param   string $status_new      Order's New Status.
-			 * @param   int    $coupon_id 		Coupon ID.
+			 * @param   int    $coupon_id       Coupon ID.
 			 */
 			$resource_id = apply_filters( 'convertkit_for_woocommerce_order_maybe_subscribe_customer_resource_id_coupon', $resource_id, $order_id, $status_old, $status_new, $coupon->get_id() );
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -122,9 +122,13 @@ class CKWC_Order {
 		// Custom Fields now.
 		$fields = $this->custom_field_data( $order );
 
-		// Build an array of Forms, Tags and Sequences to subscribe the Customer to, based on
-		// the global integration settings and any Product-specific settings.
+		// Build an array of Forms, Tags and Sequences to subscribe the Customer to, based on:
+		// - the global integration's setting,
+		// - any product-specific settings,
+		// - any coupon-specific settings.
 		$subscriptions = array( $this->integration->get_option( 'subscription' ) );
+
+		// Get product-specific subscription settings.
 		foreach ( $order->get_items() as $item ) {
 			// Get the Form, Tag or Sequence for this Product.
 			$resource_id = get_post_meta( $item['product_id'], 'ckwc_subscription', true );
@@ -134,14 +138,45 @@ class CKWC_Order {
 			 *
 			 * @since   1.4.2
 			 *
-			 * @param   mixed   $resource_id    Form, Tag or Sequence ID | empty string.
+			 * @param   mixed  $resource_id     Form, Tag or Sequence ID | empty string.
 			 * @param   int    $order_id        WooCommerce Order ID.
 			 * @param   string $status_old      Order's Old Status.
 			 * @param   string $status_new      Order's New Status.
+			 * @param   int    $product_id 		Product ID.
 			 */
-			$resource_id = apply_filters( 'convertkit_for_woocommerce_order_maybe_subscribe_customer_resource_id', $resource_id, $order_id, $status_old, $status_new );
+			$resource_id = apply_filters( 'convertkit_for_woocommerce_order_maybe_subscribe_customer_resource_id', $resource_id, $order_id, $status_old, $status_new, $item['product_id'] );
 
 			// If no resource is specified for this Product, don't add it to the array.
+			if ( empty( $resource_id ) ) {
+				continue;
+			}
+
+			// Add to array of resources to subscribe the Customer to.
+			$subscriptions[] = $resource_id;
+		}
+
+		// Get coupon-specific subscription settings.
+		foreach ( $order->get_coupon_codes() as $coupon_code ) {
+			// Get the WC_Coupon object.
+    		$coupon = new WC_Coupon( $coupon_code );
+
+			// Get the Form, Tag or Sequence for this Coupon.
+			$resource_id = get_post_meta( $coupon->get_id(), 'ckwc_subscription', true );
+
+			/**
+			 * Define the Form, Tag or Sequence ID to subscribe the Customer to for the given Coupon.
+			 *
+			 * @since   1.5.9
+			 *
+			 * @param   mixed  $resource_id     Form, Tag or Sequence ID | empty string.
+			 * @param   int    $order_id        WooCommerce Order ID.
+			 * @param   string $status_old      Order's Old Status.
+			 * @param   string $status_new      Order's New Status.
+			 * @param   int    $coupon_id 		Coupon ID.
+			 */
+			$resource_id = apply_filters( 'convertkit_for_woocommerce_order_maybe_subscribe_customer_resource_id_coupon', $resource_id, $order_id, $status_old, $status_new, $coupon->get_id() );
+
+			// If no resource is specified for this Coupon, don't add it to the array.
 			if ( empty( $resource_id ) ) {
 				continue;
 			}

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -103,6 +103,7 @@ class WooCommerce extends \Codeception\Module
 	 * @param   bool             $sendPurchaseData           Send WooCommerce Order data to ConvertKit Purchase Data API.
 	 * @param   mixed            $productFormTagSequence     Product Setting for Form, Tag or Sequence to subscribe the Customer to.
 	 * @param   bool             $customFields               Map WooCommerce fields to ConvertKit Custom Fields.
+	 * @param   mixed            $couponFormTagSequence      Coupon Setting for Form, Tag or Sequence to subscribe the Customer to.
 	 */
 	public function wooCommerceCreateProductAndCheckoutWithConfig(
 		$I,
@@ -221,7 +222,7 @@ class WooCommerce extends \Codeception\Module
 		// Apply Coupon Code.
 		if (isset($couponID)) {
 			$I->click('a.showcoupon');
-			$I->waitForElementVisible('input#coupon_code', 5);
+			$I->waitForElementNotVisible('.blockOverlay');
 			$I->fillField('input#coupon_code', '20off');
 			$I->click('Apply coupon');
 			$I->waitForText('Coupon code applied successfully.', 5, '.woocommerce-message');
@@ -239,6 +240,7 @@ class WooCommerce extends \Codeception\Module
 		}
 
 		// Click Place order button.
+		$I->waitForElementNotVisible('.blockOverlay');
 		$I->click('#place_order');
 
 		// Wait until JS completes and redirects.
@@ -483,9 +485,9 @@ class WooCommerce extends \Codeception\Module
 	 * @since   1.5.9
 	 *
 	 * @param   AcceptanceTester $I                      Acceptance Tester.
-	 * @param 	string 			 $couponCode 		     Couponn Code.
+	 * @param   string           $couponCode             Couponn Code.
 	 * @param   mixed            $couponFormTagSequence  Coupon Setting for Form, Tag or Sequence to subscribe the Customer to.
-	 * @return  int                                   	 Coupon ID
+	 * @return  int                                      Coupon ID
 	 */
 	public function wooCommerceCreateCoupon($I, $couponCode, $couponFormTagSequence = false)
 	{
@@ -498,19 +500,19 @@ class WooCommerce extends \Codeception\Module
 				'post_content' => $couponCode,
 				'meta_input'   => [
 					// Create a 20% off coupon. The amount doesn't matter for tests.
-					'discount_type' => 'percent',
-					'coupon_amount' => 20,
-					'individual_use' => 'no',
-					'usage_limit' => 0,
-					'usage_limit_per_user' => 0,
+					'discount_type'          => 'percent',
+					'coupon_amount'          => 20,
+					'individual_use'         => 'no',
+					'usage_limit'            => 0,
+					'usage_limit_per_user'   => 0,
 					'limit_usage_to_x_items' => 0,
-					'usage_count' => 0,
-					'date_expires' => NULL,
-					'free_shipping' => 'no',
-					'exclude_sales_items' => 'no',
+					'usage_count'            => 0,
+					'date_expires'           => null,
+					'free_shipping'          => 'no',
+					'exclude_sales_items'    => 'no',
 
 					// ConvertKit Integration Form/Tag/Sequence.
-					'ckwc_subscription'  => ( $couponFormTagSequence ? $couponFormTagSequence : '' ),
+					'ckwc_subscription'      => ( $couponFormTagSequence ? $couponFormTagSequence : '' ),
 				],
 			]
 		);

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -223,6 +223,7 @@ class WooCommerce extends \Codeception\Module
 		if (isset($couponID)) {
 			$I->click('a.showcoupon');
 			$I->waitForElementNotVisible('.blockOverlay');
+			$I->waitForElementVisible('input#coupon_code');
 			$I->fillField('input#coupon_code', '20off');
 			$I->click('Apply coupon');
 			$I->waitForText('Coupon code applied successfully.', 5, '.woocommerce-message');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -113,7 +113,8 @@ class WooCommerce extends \Codeception\Module
 		$subscriptionEvent = false,
 		$sendPurchaseData = false,
 		$productFormTagSequence = false,
-		$customFields = false
+		$customFields = false,
+		$couponFormTagSequence = false
 	)
 	{
 		// Define Opt In setting.
@@ -200,6 +201,11 @@ class WooCommerce extends \Codeception\Module
 				break;
 		}
 
+		// Create Coupon.
+		if ($couponFormTagSequence) {
+			$couponID = $I->wooCommerceCreateCoupon($I, '20off', $couponFormTagSequence);
+		}
+
 		// Define Email Address for this Test.
 		$emailAddress = $I->generateEmailAddress();
 
@@ -211,6 +217,15 @@ class WooCommerce extends \Codeception\Module
 
 		// Add Product to Cart and load Checkout.
 		$I->wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress, $paymentMethod);
+
+		// Apply Coupon Code.
+		if (isset($couponID)) {
+			$I->click('a.showcoupon');
+			$I->waitForElementVisible('input#coupon_code', 5);
+			$I->fillField('input#coupon_code', '20off');
+			$I->click('Apply coupon');
+			$I->waitForText('Coupon code applied successfully.', 5, '.woocommerce-message');
+		}
 
 		// Handle Opt-In Checkbox.
 		if ($displayOptIn) {
@@ -463,6 +478,45 @@ class WooCommerce extends \Codeception\Module
 	}
 
 	/**
+	 * Creates a Coupon in WooCommerce that can be used for tests.
+	 *
+	 * @since   1.5.9
+	 *
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param 	string 			 $couponCode 		     Couponn Code.
+	 * @param   mixed            $couponFormTagSequence  Coupon Setting for Form, Tag or Sequence to subscribe the Customer to.
+	 * @return  int                                   	 Coupon ID
+	 */
+	public function wooCommerceCreateCoupon($I, $couponCode, $couponFormTagSequence = false)
+	{
+		return $I->havePostInDatabase(
+			[
+				'post_type'    => 'shop_coupon',
+				'post_status'  => 'publish',
+				'post_name'    => $couponCode,
+				'post_title'   => $couponCode,
+				'post_content' => $couponCode,
+				'meta_input'   => [
+					// Create a 20% off coupon. The amount doesn't matter for tests.
+					'discount_type' => 'percent',
+					'coupon_amount' => 20,
+					'individual_use' => 'no',
+					'usage_limit' => 0,
+					'usage_limit_per_user' => 0,
+					'limit_usage_to_x_items' => 0,
+					'usage_count' => 0,
+					'date_expires' => NULL,
+					'free_shipping' => 'no',
+					'exclude_sales_items' => 'no',
+
+					// ConvertKit Integration Form/Tag/Sequence.
+					'ckwc_subscription'  => ( $couponFormTagSequence ? $couponFormTagSequence : '' ),
+				],
+			]
+		);
+	}
+
+	/**
 	 * Adds the given Product ID to the Cart, loading the Checkout screen
 	 * and prefilling the standard WooCommerce Billing Fields.
 	 *
@@ -477,7 +531,7 @@ class WooCommerce extends \Codeception\Module
 	public function wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress = 'wordpress@convertkit.com', $paymentMethod = 'cod')
 	{
 		// Load the Product on the frontend site.
-		$I->amOnPage('/?p=' . $productID );
+		$I->amOnPage('/?p=' . $productID);
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -485,6 +485,96 @@ class SubscribeOnOrderProcessingEventCest
 	 * Test that the Customer is subscribed to ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Form (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponForm(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			true, // Display Opt-In checkbox on Checkout.
+			true, // Check Opt-In checkbox on Checkout.
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // No Product level Form, Tag or Sequence.
+			false, // No Custom Field mapping.
+			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Coupon level Form to subscribe email address to.
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Tag (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponTag(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			true, // Display Opt-In checkbox on Checkout.
+			true, // Check Opt-In checkbox on Checkout.
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // No Product level Form, Tag or Sequence.
+			false, // No Custom Field mapping.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Coupon level Tag to subscribe email address to.
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The WooCommerce Coupon used defines a Sequence (separate to the Plugin settings), and
 	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -482,6 +482,51 @@ class SubscribeOnOrderProcessingEventCest
 	}
 
 	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Sequence (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponSequence(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			true, // Display Opt-In checkbox on Checkout.
+			true, // Check Opt-In checkbox on Checkout.
+			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // No Product level Form, Tag or Sequence.
+			false, // No Custom Field mapping.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Coupon level Sequence to subscribe email address to.
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+	}
+
+	/**
 	 * Test that the Customer is not resubscribed ConvertKit when:
 	 * - The opt in checkbox is enabled in the integration Settings, and
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and


### PR DESCRIPTION
## Summary

Adds subscription logic to subscribe the customer to a form, tag or sequence specified within a WooCommerce Coupon, along with tests.

## Testing

- `SubscribeOnOrderProcessingEventCest:testOptInWhenCheckedWithFormAndSimpleProductWithCouponForm`: Test that defining a ConvertKit Form to subscribe the customer to within a WooCommerce Coupon works when the coupon is applied to the order at checkout.
- `SubscribeOnOrderProcessingEventCest:testOptInWhenCheckedWithFormAndSimpleProductWithCouponTag`: Test that defining a ConvertKit Tag to subscribe the customer to within a WooCommerce Coupon works when the coupon is applied to the order at checkout.
- `SubscribeOnOrderProcessingEventCest:testOptInWhenCheckedWithFormAndSimpleProductWithCouponSequence`: Test that defining a ConvertKit Sequence to subscribe the customer to within a WooCommerce Coupon works when the coupon is applied to the order at checkout.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)