### PR TITLE
Improve Test Performance

### DIFF
--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -177,35 +177,14 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
-	 * Returns all purchases from the API.
+	 * Returns the first 50 purchases from the API.
 	 *
 	 * @return  array
 	 */
 	public function apiGetPurchases()
 	{
-		// Get first page of purchases.
 		$purchases  = $this->apiRequest('purchases', 'GET');
-		$data       = $purchases['purchases'];
-		$totalPages = $purchases['total_pages'];
-
-		if ($totalPages === 1) {
-			return $data;
-		}
-
-		// Get additional pages of purchases.
-		for ($page = 2; $page <= $totalPages; $page++) {
-			$purchases = $this->apiRequest(
-				'purchases',
-				'GET',
-				[
-					'page' => $page,
-				]
-			);
-
-			$data = array_merge($data, $purchases['purchases']);
-		}
-
-		return $data;
+		return $purchases['purchases'];
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -183,7 +183,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 */
 	public function apiGetPurchases()
 	{
-		$purchases  = $this->apiRequest('purchases', 'GET');
+		$purchases = $this->apiRequest('purchases', 'GET');
 		return $purchases['purchases'];
 	}
 

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -129,7 +129,7 @@ class Plugin extends \Codeception\Module
 				'display_opt_in' 	   			=> ( $displayOptIn ? 'yes' : 'no' ),
 				'opt_in_label' 	   				=> 'Opt In to Newsletter',
 				'opt_in_status' 	   			=> 'checked',
-				'opt_in_location' 	   			=> $optInLocation,
+				'opt_in_location' 	   			=> ( $displayOptIn ? $displayOptIn : '' ),
 
 				// Purchase Data.
 				'send_purchases'				=> ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
@@ -139,86 +139,6 @@ class Plugin extends \Codeception\Module
 				'debug' 						=> 'yes',
 			]
 		);
-
-		/*
-		// Define Opt In setting.
-		if ($displayOptIn) {
-			$I->checkOption('#woocommerce_ckwc_display_opt_in');
-		} else {
-			$I->uncheckOption('#woocommerce_ckwc_display_opt_in');
-		}
-
-		// Define Subscription Event setting.
-		if ($subscriptionEvent) {
-			$I->selectOption('#woocommerce_ckwc_event', $subscriptionEvent);
-		}
-
-		// Define Send Purchase Data setting.
-		if ($sendPurchaseData) {
-			$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-			// If sendPurchaseData is true, set send purchase data event to processing.
-			// Otherwise set to the string value of sendPurchaseData i.e. completed.
-			$sendPurchaseDataEvent = ( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData );
-			$I->selectOption('#woocommerce_ckwc_send_purchases_event', $sendPurchaseDataEvent);
-		} else {
-			$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-		}
-
-		// Save.
-		$I->click('Save changes');
-
-		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are
-		// saved and the Forms, Tags and Sequences are listed.
-		if ($pluginFormTagSequence) {
-			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
-		} else {
-			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
-		}
-
-		// Define Order to Custom Field mappings, now that the API credentials are
-		// saved and the Forms, Tags and Sequences are listed.
-		if ($customFields) {
-			$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
-			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
-			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
-			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
-			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
-		} else {
-			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send or map)');
-		}
-
-		// Save.
-		$I->click('Save changes');
-
-		// Wait until the settings page reloads, to avoid a browser alert later that navigating away will lose unsaved changes.
-		$I->waitForElement('#woocommerce_ckwc_enabled');
-
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable the Integration.
-		$I->checkOption('#woocommerce_ckwc_enabled');
-
-		// Complete API Fields.
-		$I->fillField('woocommerce_ckwc_api_key', $convertKitAPIKey);
-		$I->fillField('woocommerce_ckwc_api_secret', $convertKitAPISecret);
-
-		// Click the Save Changes button.
-		$I->click('Save changes');
-
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
-
-		// Check the value of the fields match the inputs provided.
-		$I->seeCheckboxIsChecked('#woocommerce_ckwc_enabled');
-		$I->seeInField('woocommerce_ckwc_api_key', $convertKitAPIKey);
-		$I->seeInField('woocommerce_ckwc_api_secret', $convertKitAPISecret);
-		*/
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -85,15 +85,15 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @since   1.6.0
 	 *
-	 * @param   AcceptanceTester $I          			Acceptance Tester.
-	 * @param   bool|string      $apiKey     			API Key (if specified, used instead of CONVERTKIT_API_KEY).
-	 * @param   bool|string      $apiSecret  			API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
-	 * @param 	string 			 $subscriptionEvent 	Subscribe Event.
-	 * @param 	bool|string 	 $subscription 			Form, Tag or Sequence to subscribe customer to.
-	 * @param 	string 			 $nameFormat 			Name Format.
-	 * @param 	bool 			 $mapCustomFields 		Map Order data to Custom Fields.
-	 * @param 	bool 			 $displayOptIn 		 	Display Opt-In Checkbox.
-	 * @param 	bool 			 $sendPurchaseDataEvent Send Purchase Data to ConvertKit on Order Event.
+	 * @param   AcceptanceTester $I                     Acceptance Tester.
+	 * @param   bool|string      $apiKey                API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   bool|string      $apiSecret             API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   string           $subscriptionEvent     Subscribe Event.
+	 * @param   bool|string      $subscription          Form, Tag or Sequence to subscribe customer to.
+	 * @param   string           $nameFormat            Name Format.
+	 * @param   bool             $mapCustomFields       Map Order data to Custom Fields.
+	 * @param   bool             $displayOptIn          Display Opt-In Checkbox.
+	 * @param   bool             $sendPurchaseDataEvent Send Purchase Data to ConvertKit on Order Event.
 	 */
 	public function setupConvertKitPlugin(
 		$I,
@@ -111,32 +111,32 @@ class Plugin extends \Codeception\Module
 		$I->haveOptionInDatabase(
 			'woocommerce_ckwc_settings',
 			[
-				'enabled'	   					=> 'yes',
-				'api_key'      					=> ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
-				'api_secret'   					=> ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
-				'event' 	   					=> $subscriptionEvent,
-				'subscription' 	   				=> ( $subscription ? $subscription : '' ),
-				'name_format' 	   				=> $nameFormat,
+				'enabled'                       => 'yes',
+				'api_key'                       => ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
+				'api_secret'                    => ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
+				'event'                         => $subscriptionEvent,
+				'subscription'                  => ( $subscription ? $subscription : '' ),
+				'name_format'                   => $nameFormat,
 
 				// Custom Field mappings.
-				'custom_field_phone' 	   		=> ( $mapCustomFields ? 'phone_number' : '' ),
-				'custom_field_billing_address' 	=> ( $mapCustomFields ? 'billing_address' : '' ),
+				'custom_field_phone'            => ( $mapCustomFields ? 'phone_number' : '' ),
+				'custom_field_billing_address'  => ( $mapCustomFields ? 'billing_address' : '' ),
 				'custom_field_shipping_address' => ( $mapCustomFields ? 'shipping_address' : '' ),
-				'custom_field_payment_method' 	=> ( $mapCustomFields ? 'payment_method' : '' ),
-				'custom_field_customer_note' 	=> ( $mapCustomFields ? 'notes' : '' ),
+				'custom_field_payment_method'   => ( $mapCustomFields ? 'payment_method' : '' ),
+				'custom_field_customer_note'    => ( $mapCustomFields ? 'notes' : '' ),
 
 				// Opt-In Checkbox.
-				'display_opt_in' 	   			=> ( $displayOptIn ? 'yes' : 'no' ),
-				'opt_in_label' 	   				=> 'I want to subscribe to the newsletter',
-				'opt_in_status' 	   			=> 'checked',
-				'opt_in_location' 	   			=> 'billing',
+				'display_opt_in'                => ( $displayOptIn ? 'yes' : 'no' ),
+				'opt_in_label'                  => 'I want to subscribe to the newsletter',
+				'opt_in_status'                 => 'checked',
+				'opt_in_location'               => 'billing',
 
 				// Purchase Data.
-				'send_purchases'				=> ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
-				'send_purchases_event'			=> ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
+				'send_purchases'                => ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
+				'send_purchases_event'          => ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
 
 				// Debug.
-				'debug' 						=> 'yes',
+				'debug'                         => 'yes',
 			]
 		);
 	}
@@ -166,46 +166,46 @@ class Plugin extends \Codeception\Module
 			'ckwc_custom_fields',
 			[
 				276271 => [
-				    'id' =>  276271,
-				    'name' =>  'ck_field_276271_phone_number',
-				    'key' =>  'phone_number',
-				    'label' =>  'Phone Number'
+					'id'    => 276271,
+					'name'  => 'ck_field_276271_phone_number',
+					'key'   => 'phone_number',
+					'label' => 'Phone Number',
 				],
 				276273 => [
-				    'id' =>  276273,
-				    'name' =>  'ck_field_276273_billing_address',
-				    'key' =>  'billing_address',
-				    'label' =>  'Billing Address'
+					'id'    => 276273,
+					'name'  => 'ck_field_276273_billing_address',
+					'key'   => 'billing_address',
+					'label' => 'Billing Address',
 				],
 				276295 => [
-				    'id' =>  276295,
-				    'name' =>  'ck_field_276295_payment_method',
-				    'key' =>  'payment_method',
-				    'label' =>  'Payment Method'
+					'id'    => 276295,
+					'name'  => 'ck_field_276295_payment_method',
+					'key'   => 'payment_method',
+					'label' => 'Payment Method',
 				],
 				264073 => [
-				    'id' =>  264073,
-				    'name' =>  'ck_field_264073_last_name',
-				    'key' =>  'last_name',
-				    'label' =>  'Last Name'
+					'id'    => 264073,
+					'name'  => 'ck_field_264073_last_name',
+					'key'   => 'last_name',
+					'label' => 'Last Name',
 				],
 				321150 => [
-				    'id' =>  321150,
-				    'name' =>  'ck_field_321150_test',
-				    'key' =>  'test',
-				    'label' =>  'Test'
+					'id'    => 321150,
+					'name'  => 'ck_field_321150_test',
+					'key'   => 'test',
+					'label' => 'Test',
 				],
 				276272 => [
-				    'id' =>  276272,
-				    'name' =>  'ck_field_276272_shipping_address',
-				    'key' =>  'shipping_address',
-				    'label' =>  'Shipping Address'
+					'id'    => 276272,
+					'name'  => 'ck_field_276272_shipping_address',
+					'key'   => 'shipping_address',
+					'label' => 'Shipping Address',
 				],
 				258240 => [
-				    'id' =>  258240,
-				    'name' =>  'ck_field_258240_notes',
-				    'key' =>  'notes',
-				    'label' =>  'Notes'
+					'id'    => 258240,
+					'name'  => 'ck_field_258240_notes',
+					'key'   => 'notes',
+					'label' => 'Notes',
 				],
 			]
 		);
@@ -313,18 +313,18 @@ class Plugin extends \Codeception\Module
 			'ckwc_sequences',
 			[
 				1030824 => [
-				    'id' => 1030824,
-				    'name' => 'WordPress Sequence',
-				    'hold' => false,
-				    'repeat' => false,
-				    'created_at' => '2022-01-04T13:00:15.000Z'
+					'id'         => 1030824,
+					'name'       => 'WordPress Sequence',
+					'hold'       => false,
+					'repeat'     => false,
+					'created_at' => '2022-01-04T13:00:15.000Z',
 				],
 				1341993 => [
-				    'id' => 1341993,
-				    'name' => 'Another Sequence',
-				    'hold' => false,
-				    'repeat' => false,
-				    'created_at' => '2023-01-30T17:25:54.000Z'
+					'id'         => 1341993,
+					'name'       => 'Another Sequence',
+					'hold'       => false,
+					'repeat'     => false,
+					'created_at' => '2023-01-30T17:25:54.000Z',
 				],
 			]
 		);

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -83,7 +83,7 @@ class Plugin extends \Codeception\Module
 	/**
 	 * Helper method to setup the Plugin's API Key and Secret.
 	 *
-	 * @since   1.9.6
+	 * @since   1.6.0
 	 *
 	 * @param   AcceptanceTester $I          			Acceptance Tester.
 	 * @param   bool|string      $apiKey     			API Key (if specified, used instead of CONVERTKIT_API_KEY).
@@ -139,6 +139,265 @@ class Plugin extends \Codeception\Module
 				'debug' 						=> 'yes',
 			]
 		);
+	}
+
+	/**
+	 * Helper method to define cached Resources (Forms, Sequences and Tags),
+	 * directly into the database, instead of querying the API for them via the Resource classes.
+	 *
+	 * This can safely be done for Acceptance tests, as WPUnit tests ensure that
+	 * caching Resources from calls made to the API work and store data in the expected
+	 * structure.
+	 *
+	 * Defining cached Resources here reduces the number of API calls made for each test,
+	 * reducing the likelihood of hitting a rate limit due to running tests in parallel.
+	 *
+	 * Resources are deliberately not in order, to emulate how the data might not always
+	 * be in alphabetical / published order from the API.
+	 *
+	 * @since   1.6.0
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 */
+	public function setupConvertKitPluginResources($I)
+	{
+		// Define Custom Fields.
+		$I->haveOptionInDatabase(
+			'ckwc_custom_fields',
+			[
+				276271 => [
+				    'id' =>  276271,
+				    'name' =>  'ck_field_276271_phone_number',
+				    'key' =>  'phone_number',
+				    'label' =>  'Phone Number'
+				],
+				276273 => [
+				    'id' =>  276273,
+				    'name' =>  'ck_field_276273_billing_address',
+				    'key' =>  'billing_address',
+				    'label' =>  'Billing Address'
+				],
+				276295 => [
+				    'id' =>  276295,
+				    'name' =>  'ck_field_276295_payment_method',
+				    'key' =>  'payment_method',
+				    'label' =>  'Payment Method'
+				],
+				264073 => [
+				    'id' =>  264073,
+				    'name' =>  'ck_field_264073_last_name',
+				    'key' =>  'last_name',
+				    'label' =>  'Last Name'
+				],
+				321150 => [
+				    'id' =>  321150,
+				    'name' =>  'ck_field_321150_test',
+				    'key' =>  'test',
+				    'label' =>  'Test'
+				],
+				276272 => [
+				    'id' =>  276272,
+				    'name' =>  'ck_field_276272_shipping_address',
+				    'key' =>  'shipping_address',
+				    'label' =>  'Shipping Address'
+				],
+				258240 => [
+				    'id' =>  258240,
+				    'name' =>  'ck_field_258240_notes',
+				    'key' =>  'notes',
+				    'label' =>  'Notes'
+				],
+			]
+		);
+
+		// Define Forms.
+		$I->haveOptionInDatabase(
+			'ckwc_forms',
+			[
+				3003590 => [
+					'id'         => 3003590,
+					'name'       => 'Third Party Integrations Form',
+					'created_at' => '2022-02-17T15:05:31.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/71cbcc4042/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/71cbcc4042',
+					'archived'   => false,
+					'uid'        => '71cbcc4042',
+				],
+				2780977 => [
+					'id'         => 2780977,
+					'name'       => 'Modal Form',
+					'created_at' => '2021-11-17T04:22:06.000Z',
+					'type'       => 'embed',
+					'format'     => 'modal',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/397e876257/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/397e876257',
+					'archived'   => false,
+					'uid'        => '397e876257',
+				],
+				2780979 => [
+					'id'         => 2780979,
+					'name'       => 'Slide In Form',
+					'created_at' => '2021-11-17T04:22:24.000Z',
+					'type'       => 'embed',
+					'format'     => 'slide in',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/e0d65bed9d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/e0d65bed9d',
+					'archived'   => false,
+					'uid'        => 'e0d65bed9d',
+				],
+				2765139 => [
+					'id'         => 2765139,
+					'name'       => 'Page Form',
+					'created_at' => '2021-11-11T15:30:40.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/85629c512d/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/85629c512d',
+					'archived'   => false,
+					'uid'        => '85629c512d',
+				],
+				470099  => [
+					'id'                  => 470099,
+					'name'                => 'Legacy Form',
+					'created_at'          => null,
+					'type'                => 'embed',
+					'url'                 => 'https://app.convertkit.com/landing_pages/470099',
+					'embed_js'            => 'https://api.convertkit.com/api/v3/forms/470099.js?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'embed_url'           => 'https://api.convertkit.com/api/v3/forms/470099.html?api_key=' . $_ENV['CONVERTKIT_API_KEY'],
+					'title'               => 'Join the newsletter',
+					'description'         => '<p>Subscribe to get our latest content by email.</p>',
+					'sign_up_button_text' => 'Subscribe',
+					'success_message'     => 'Success! Now check your email to confirm your subscription.',
+					'archived'            => false,
+				],
+				2780980 => [
+					'id'         => 2780980,
+					'name'       => 'Sticky Bar Form',
+					'created_at' => '2021-11-17T04:22:42.000Z',
+					'type'       => 'embed',
+					'format'     => 'sticky bar',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/9f5c601482/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/9f5c601482',
+					'archived'   => false,
+					'uid'        => '9f5c601482',
+				],
+				3437554 => [
+					'id'         => 3437554,
+					'name'       => 'AAA Test',
+					'created_at' => '2022-07-15T15:06:32.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/3bb15822a2/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/3bb15822a2',
+					'archived'   => false,
+					'uid'        => '3bb15822a2',
+				],
+				2765149 => [
+					'id'         => 2765149,
+					'name'       => 'WooCommerce Product Form',
+					'created_at' => '2021-11-11T15:32:54.000Z',
+					'type'       => 'embed',
+					'format'     => 'inline',
+					'embed_js'   => 'https://cheerful-architect-3237.ck.page/7e238f3920/index.js',
+					'embed_url'  => 'https://cheerful-architect-3237.ck.page/7e238f3920',
+					'archived'   => false,
+					'uid'        => '7e238f3920',
+				],
+			]
+		);
+
+		// Define Sequences.
+		$I->haveOptionInDatabase(
+			'ckwc_sequences',
+			[
+				1030824 => [
+				    'id' => 1030824,
+				    'name' => 'WordPress Sequence',
+				    'hold' => false,
+				    'repeat' => false,
+				    'created_at' => '2022-01-04T13:00:15.000Z'
+				],
+				1341993 => [
+				    'id' => 1341993,
+				    'name' => 'Another Sequence',
+				    'hold' => false,
+				    'repeat' => false,
+				    'created_at' => '2023-01-30T17:25:54.000Z'
+				],
+			]
+		);
+
+		// Define Tags.
+		$I->haveOptionInDatabase(
+			'ckwc_tags',
+			[
+				2744672 => [
+					'id'         => 2744672,
+					'name'       => 'wordpress',
+					'created_at' => '2021-11-11T19:30:06.000Z',
+				],
+				2907192 => [
+					'id'         => 2907192,
+					'name'       => 'gravityforms-tag-1',
+					'created_at' => '2022-02-02T14:06:32.000Z',
+				],
+				2907193 => [
+					'id'         => 2907193,
+					'name'       => 'gravityforms-tag-2',
+					'created_at' => '2022-02-02T14:06:38.000Z',
+				],
+			]
+		);
+
+		// Define last queried to now for all resources, so they're not automatically immediately refreshed by the Plugin's logic.
+		$I->haveOptionInDatabase( 'ckwc_custom_fields_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_forms_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_sequences_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_tags_last_queried', strtotime( 'now' ) );
+	}
+
+	/**
+	 * Helper method to define cached Resources (Forms, Landing Pages, Posts, Products and Tags),
+	 * directly into the database, instead of querying the API for them via the Resource classes
+	 * as if the ConvertKit account is new and has no resources defined in ConvertKit.
+	 *
+	 * @since   2.0.7
+	 *
+	 * @param   AcceptanceTester $I              AcceptanceTester.
+	 */
+	public function setupConvertKitPluginResourcesNoData($I)
+	{
+		// Define Custom Fields.
+		$I->haveOptionInDatabase(
+			'ckwc_custom_fields',
+			[]
+		);
+
+		// Define Forms.
+		$I->haveOptionInDatabase(
+			'ckwc_forms',
+			[]
+		);
+
+		// Define Sequences.
+		$I->haveOptionInDatabase(
+			'ckwc_sequences',
+			[]
+		);
+
+		// Define Tags.
+		$I->haveOptionInDatabase(
+			'ckwc_tags',
+			[]
+		);
+
+		// Define last queried to now for all resources, so they're not automatically immediately refreshed by the Plugin's logic.
+		$I->haveOptionInDatabase( 'ckwc_custom_fields_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_forms_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_sequences_last_queried', strtotime( 'now' ) );
+		$I->haveOptionInDatabase( 'ckwc_tags_last_queried', strtotime( 'now' ) );
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -127,9 +127,9 @@ class Plugin extends \Codeception\Module
 
 				// Opt-In Checkbox.
 				'display_opt_in' 	   			=> ( $displayOptIn ? 'yes' : 'no' ),
-				'opt_in_label' 	   				=> 'Opt In to Newsletter',
+				'opt_in_label' 	   				=> 'I want to subscribe to the newsletter',
 				'opt_in_status' 	   			=> 'checked',
-				'opt_in_location' 	   			=> ( $displayOptIn ? $displayOptIn : '' ),
+				'opt_in_location' 	   			=> 'billing',
 
 				// Purchase Data.
 				'send_purchases'				=> ( $sendPurchaseDataEvent ? 'yes' : 'no' ),

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -85,15 +85,118 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6
 	 *
-	 * @param   AcceptanceTester $I          Acceptance Tester.
-	 * @param   mixed            $apiKey     API Key (if specified, used instead of CONVERTKIT_API_KEY).
-	 * @param   mixed            $apiSecret  API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param   AcceptanceTester $I          			Acceptance Tester.
+	 * @param   bool|string      $apiKey     			API Key (if specified, used instead of CONVERTKIT_API_KEY).
+	 * @param   bool|string      $apiSecret  			API Secret (if specified, used instead of CONVERTKIT_API_SECRET).
+	 * @param 	string 			 $subscriptionEvent 	Subscribe Event.
+	 * @param 	bool|string 	 $subscription 			Form, Tag or Sequence to subscribe customer to.
+	 * @param 	string 			 $nameFormat 			Name Format.
+	 * @param 	bool 			 $mapCustomFields 		Map Order data to Custom Fields.
+	 * @param 	bool 			 $displayOptIn 		 	Display Opt-In Checkbox.
+	 * @param 	bool 			 $sendPurchaseDataEvent Send Purchase Data to ConvertKit on Order Event.
 	 */
-	public function setupConvertKitPlugin($I, $apiKey = false, $apiSecret = false)
+	public function setupConvertKitPlugin(
+		$I,
+		$apiKey = false,
+		$apiSecret = false,
+		$subscriptionEvent = 'pending',
+		$subscription = false,
+		$nameFormat = 'first',
+		$mapCustomFields = false,
+		$displayOptIn = false,
+		$sendPurchaseDataEvent = false
+	)
 	{
-		// Determine API Key and Secret to use.
-		$convertKitAPIKey    = ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] );
-		$convertKitAPISecret = ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] );
+		// Define Plugin's settings.
+		$I->haveOptionInDatabase(
+			'woocommerce_ckwc_settings',
+			[
+				'enabled'	   					=> 'yes',
+				'api_key'      					=> ( $apiKey !== false ? $apiKey : $_ENV['CONVERTKIT_API_KEY'] ),
+				'api_secret'   					=> ( $apiSecret !== false ? $apiSecret : $_ENV['CONVERTKIT_API_SECRET'] ),
+				'event' 	   					=> $subscriptionEvent,
+				'subscription' 	   				=> ( $subscription ? $subscription : '' ),
+				'name_format' 	   				=> $nameFormat,
+
+				// Custom Field mappings.
+				'custom_field_phone' 	   		=> ( $mapCustomFields ? 'phone_number' : '' ),
+				'custom_field_billing_address' 	=> ( $mapCustomFields ? 'billing_address' : '' ),
+				'custom_field_shipping_address' => ( $mapCustomFields ? 'shipping_address' : '' ),
+				'custom_field_payment_method' 	=> ( $mapCustomFields ? 'payment_method' : '' ),
+				'custom_field_customer_note' 	=> ( $mapCustomFields ? 'notes' : '' ),
+
+				// Opt-In Checkbox.
+				'display_opt_in' 	   			=> ( $displayOptIn ? 'yes' : 'no' ),
+				'opt_in_label' 	   				=> 'Opt In to Newsletter',
+				'opt_in_status' 	   			=> 'checked',
+				'opt_in_location' 	   			=> $optInLocation,
+
+				// Purchase Data.
+				'send_purchases'				=> ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
+				'send_purchases_event'			=> ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
+
+				// Debug.
+				'debug' 						=> 'yes',
+			]
+		);
+
+		/*
+		// Define Opt In setting.
+		if ($displayOptIn) {
+			$I->checkOption('#woocommerce_ckwc_display_opt_in');
+		} else {
+			$I->uncheckOption('#woocommerce_ckwc_display_opt_in');
+		}
+
+		// Define Subscription Event setting.
+		if ($subscriptionEvent) {
+			$I->selectOption('#woocommerce_ckwc_event', $subscriptionEvent);
+		}
+
+		// Define Send Purchase Data setting.
+		if ($sendPurchaseData) {
+			$I->checkOption('#woocommerce_ckwc_send_purchases');
+
+			// If sendPurchaseData is true, set send purchase data event to processing.
+			// Otherwise set to the string value of sendPurchaseData i.e. completed.
+			$sendPurchaseDataEvent = ( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData );
+			$I->selectOption('#woocommerce_ckwc_send_purchases_event', $sendPurchaseDataEvent);
+		} else {
+			$I->uncheckOption('#woocommerce_ckwc_send_purchases');
+		}
+
+		// Save.
+		$I->click('Save changes');
+
+		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are
+		// saved and the Forms, Tags and Sequences are listed.
+		if ($pluginFormTagSequence) {
+			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
+		} else {
+			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
+		}
+
+		// Define Order to Custom Field mappings, now that the API credentials are
+		// saved and the Forms, Tags and Sequences are listed.
+		if ($customFields) {
+			$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
+			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
+			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
+			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
+		} else {
+			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send or map)');
+			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send or map)');
+		}
+
+		// Save.
+		$I->click('Save changes');
+
+		// Wait until the settings page reloads, to avoid a browser alert later that navigating away will lose unsaved changes.
+		$I->waitForElement('#woocommerce_ckwc_enabled');
 
 		// Go to the Plugin's Settings Screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -115,6 +218,7 @@ class Plugin extends \Codeception\Module
 		$I->seeCheckboxIsChecked('#woocommerce_ckwc_enabled');
 		$I->seeInField('woocommerce_ckwc_api_key', $convertKitAPIKey);
 		$I->seeInField('woocommerce_ckwc_api_secret', $convertKitAPISecret);
+		*/
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -115,9 +115,24 @@ class WooCommerce extends \Codeception\Module
 		$sendPurchaseData = false,
 		$productFormTagSequence = false,
 		$customFields = false,
+		$nameFormat = 'first',
 		$couponFormTagSequence = false
 	)
 	{
+		/*
+		var_dump( 'productType=' . $productType );
+		var_dump( 'displayOptIn=' . $displayOptIn );
+		var_dump( 'checkOptIn=' . $checkOptIn );
+		var_dump( 'pluginFormTagSequence=' . $pluginFormTagSequence );
+		var_dump( 'subscriptionEvent=' . $subscriptionEvent );
+		var_dump( 'sendPurchaseData=' . $sendPurchaseData );
+		var_dump( 'productFormTagSequence=' . $productFormTagSequence );
+		var_dump( 'customFields=' . $customFields );
+		var_dump( 'nameFormat=' . $nameFormat );
+		var_dump( 'couponFormTagSequence=' . $couponFormTagSequence );
+		die();
+		*/
+
 		// Setup ConvertKit for WooCommerce Plugin.
 		$I->setupConvertKitPlugin(
 			$I,
@@ -125,7 +140,7 @@ class WooCommerce extends \Codeception\Module
 			$_ENV['CONVERTKIT_API_SECRET'],
 			$subscriptionEvent,
 			$pluginFormTagSequence,
-			'first',
+			$nameFormat,
 			$customFields,
 			$displayOptIn,
 			( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData )

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -103,6 +103,7 @@ class WooCommerce extends \Codeception\Module
 	 * @param   bool             $sendPurchaseData           Send WooCommerce Order data to ConvertKit Purchase Data API.
 	 * @param   mixed            $productFormTagSequence     Product Setting for Form, Tag or Sequence to subscribe the Customer to.
 	 * @param   bool             $customFields               Map WooCommerce fields to ConvertKit Custom Fields.
+	 * @param   string           $nameFormat                 Name format.
 	 * @param   mixed            $couponFormTagSequence      Coupon Setting for Form, Tag or Sequence to subscribe the Customer to.
 	 */
 	public function wooCommerceCreateProductAndCheckoutWithConfig(

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -118,62 +118,18 @@ class WooCommerce extends \Codeception\Module
 		$couponFormTagSequence = false
 	)
 	{
-		// Define Opt In setting.
-		if ($displayOptIn) {
-			$I->checkOption('#woocommerce_ckwc_display_opt_in');
-		} else {
-			$I->uncheckOption('#woocommerce_ckwc_display_opt_in');
-		}
-
-		// Define Subscription Event setting.
-		if ($subscriptionEvent) {
-			$I->selectOption('#woocommerce_ckwc_event', $subscriptionEvent);
-		}
-
-		// Define Send Purchase Data setting.
-		if ($sendPurchaseData) {
-			$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-			// If sendPurchaseData is true, set send purchase data event to processing.
-			// Otherwise set to the string value of sendPurchaseData i.e. completed.
-			$sendPurchaseDataEvent = ( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData );
-			$I->selectOption('#woocommerce_ckwc_send_purchases_event', $sendPurchaseDataEvent);
-		} else {
-			$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-		}
-
-		// Save.
-		$I->click('Save changes');
-
-		// Define Form, Tag or Sequence to subscribe the Customer to, now that the API credentials are
-		// saved and the Forms, Tags and Sequences are listed.
-		if ($pluginFormTagSequence) {
-			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', $pluginFormTagSequence);
-		} else {
-			$I->fillSelect2Field($I, '#select2-woocommerce_ckwc_subscription-container', 'Select a subscription option...');
-		}
-
-		// Define Order to Custom Field mappings, now that the API credentials are
-		// saved and the Forms, Tags and Sequences are listed.
-		if ($customFields) {
-			$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
-			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
-			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
-			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
-			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
-		} else {
-			$I->selectOption('#woocommerce_ckwc_custom_field_phone', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', '(Don\'t send or map)');
-			$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', '(Don\'t send or map)');
-		}
-
-		// Save.
-		$I->click('Save changes');
-
-		// Wait until the settings page reloads, to avoid a browser alert later that navigating away will lose unsaved changes.
-		$I->waitForElement('#woocommerce_ckwc_enabled');
+		// Setup ConvertKit for WooCommerce Plugin.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			$subscriptionEvent,
+			$pluginFormTagSequence,
+			'first',
+			$customFields,
+			$displayOptIn,
+			( ( $sendPurchaseData === true ) ? 'processing' : $sendPurchaseData )
+		);
 
 		// Create Product.
 		switch ($productType) {

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -119,20 +119,6 @@ class WooCommerce extends \Codeception\Module
 		$couponFormTagSequence = false
 	)
 	{
-		/*
-		var_dump( 'productType=' . $productType );
-		var_dump( 'displayOptIn=' . $displayOptIn );
-		var_dump( 'checkOptIn=' . $checkOptIn );
-		var_dump( 'pluginFormTagSequence=' . $pluginFormTagSequence );
-		var_dump( 'subscriptionEvent=' . $subscriptionEvent );
-		var_dump( 'sendPurchaseData=' . $sendPurchaseData );
-		var_dump( 'productFormTagSequence=' . $productFormTagSequence );
-		var_dump( 'customFields=' . $customFields );
-		var_dump( 'nameFormat=' . $nameFormat );
-		var_dump( 'couponFormTagSequence=' . $couponFormTagSequence );
-		die();
-		*/
-
 		// Setup ConvertKit for WooCommerce Plugin.
 		$I->setupConvertKitPlugin(
 			$I,

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -62,6 +62,6 @@ modules:
             window_size: 1920x1080
             capabilities:
                 chromeOptions:
-                    args: ["--headless", "--disable-gpu"]
+                    args: ["--headless=new", "--disable-gpu"]
                     prefs:
                         download.default_directory: '%WP_ROOT_FOLDER%'

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -62,6 +62,6 @@ modules:
             window_size: 1920x1080
             capabilities:
                 chromeOptions:
-                    args: ["--headless=new", "--disable-gpu"]
+                    args: ["--headless", "--disable-gpu"]
                     prefs:
                         download.default_directory: '%WP_ROOT_FOLDER%'

--- a/tests/acceptance/general/CouponCest.php
+++ b/tests/acceptance/general/CouponCest.php
@@ -66,6 +66,9 @@ class CouponCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Marketing > Coupons > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=shop_coupon');
 
@@ -218,6 +221,9 @@ class CouponCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two Coupons.
 		$couponIDs = array(
 			$I->havePostInDatabase(
@@ -269,6 +275,9 @@ class CouponCest
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Coupons with a defined form.
 		$couponIDs = array(
@@ -327,6 +336,9 @@ class CouponCest
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 
 		// Emulate the user searching for Coupons with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=shop_coupon&s=nothing');

--- a/tests/acceptance/general/CouponCest.php
+++ b/tests/acceptance/general/CouponCest.php
@@ -105,18 +105,18 @@ class CouponCest
 	 */
 	public function testCouponFieldsWithIntegrationEnabledAndNoAPIKey(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable the Integration.
-		$I->checkOption('#woocommerce_ckwc_enabled');
-
-		// Blank the API Fields.
-		$I->fillField('woocommerce_ckwc_api_key', '');
-		$I->fillField('woocommerce_ckwc_api_secret', '');
-
-		// Click the Save Changes button.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			'', // No API Key.
+			'', // No API Secret.
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Navigate to Marketing > Coupons > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=shop_coupon');
@@ -147,18 +147,18 @@ class CouponCest
 	 */
 	public function testCouponFieldsWithIntegrationEnabledAndInvalidAPIKey(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable the Integration.
-		$I->checkOption('#woocommerce_ckwc_enabled');
-
-		// Complete API Fields.
-		$I->fillField('woocommerce_ckwc_api_key', 'fakeApiKey');
-		$I->fillField('woocommerce_ckwc_api_secret', 'fakeApiSecret');
-
-		// Click the Save Changes button.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			'fakeApiKey',
+			'fakeApiSecret',
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Navigate to Marketing > Coupons > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=shop_coupon');

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -105,18 +105,18 @@ class ProductCest
 	 */
 	public function testProductFieldsWithIntegrationEnabledAndNoAPIKey(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable the Integration.
-		$I->checkOption('#woocommerce_ckwc_enabled');
-
-		// Blank the API Fields.
-		$I->fillField('woocommerce_ckwc_api_key', '');
-		$I->fillField('woocommerce_ckwc_api_secret', '');
-
-		// Click the Save Changes button.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			'', // No API Key.
+			'', // No API Secret.
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
@@ -147,18 +147,18 @@ class ProductCest
 	 */
 	public function testProductFieldsWithIntegrationEnabledAndInvalidAPIKey(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable the Integration.
-		$I->checkOption('#woocommerce_ckwc_enabled');
-
-		// Complete API Fields.
-		$I->fillField('woocommerce_ckwc_api_key', 'fakeApiKey');
-		$I->fillField('woocommerce_ckwc_api_secret', 'fakeApiSecret');
-
-		// Click the Save Changes button.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			'fakeApiKey',
+			'fakeApiSecret',
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -66,6 +66,9 @@ class ProductCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+
 		// Navigate to Products > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
@@ -186,6 +189,9 @@ class ProductCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create a Product.
 		$productID = $I->havePostInDatabase(
 			[
@@ -262,6 +268,9 @@ class ProductCest
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
 
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+
 		// Programmatically create two PRoducts.
 		$productIDs = array(
 			$I->havePostInDatabase(
@@ -312,6 +321,9 @@ class ProductCest
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 
 		// Programmatically create two Products with a defined form.
 		$productIDs = array(
@@ -369,6 +381,9 @@ class ProductCest
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 
 		// Emulate the user searching for Products with a query string that yields no results.
 		$I->amOnAdminPage('edit.php?post_type=product&s=nothing');

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -18,20 +18,7 @@ class RefreshResourcesButtonCest
 	{
 		// Activate and Setup ConvertKit plugin using API keys that have no resources (forms, sequences, tags).
 		$I->activateWooCommerceAndConvertKitPlugins($I);
-		$I->setupConvertKitPlugin($I, $_ENV['CONVERTKIT_API_KEY_NO_DATA'], $_ENV['CONVERTKIT_API_SECRET_NO_DATA']);
-
-		// Change API keys in database to ones that have ConvertKit Resources.
-		// We do this directly vs. via the settings screen, so that the Plugin's cached resources remain blank
-		// until a refresh button is clicked.
-		$I->haveOptionInDatabase(
-			'woocommerce_ckwc_settings',
-			[
-				'enabled'    => 'yes',
-				'api_key'    => $_ENV['CONVERTKIT_API_KEY'],
-				'api_secret' => $_ENV['CONVERTKIT_API_SECRET'],
-				'debug'      => 'yes',
-			]
-		);
+		$I->setupConvertKitPlugin($I);
 	}
 
 	/**

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -20,6 +20,9 @@ class ReviewRequestCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -41,9 +44,8 @@ class ReviewRequestCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Check that the options table does have a review request set.
@@ -73,8 +75,7 @@ class ReviewRequestCest
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
 			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Check that the options table does not have a review request set.

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -20,9 +20,6 @@ class ReviewRequestCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**
@@ -120,13 +117,14 @@ class ReviewRequestCest
 
 	/**
 	 * Test that the review request is displayed when the options table entries
-	 * have the required values to display the review request notification.
+	 * have the required values to display the review request notification,
+	 * and that when dismissed, it no longer displays on subsequent requests.
 	 *
 	 * @since   1.4.3
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testReviewRequestNotificationDisplayed(AcceptanceTester $I)
+	public function testReviewRequestNotificationDisplaysAndDismisses(AcceptanceTester $I)
 	{
 		// Clear options table settings for review request.
 		$I->deleteConvertKitReviewRequestOptions($I);
@@ -144,30 +142,6 @@ class ReviewRequestCest
 		// Confirm links are correct.
 		$I->seeInSource('<a href="https://wordpress.org/support/plugin/convertkit-for-woocommerce/reviews/?filter=5#new-post" class="button button-primary" rel="noopener" target="_blank">');
 		$I->seeInSource('<a href="https://convertkit.com/support" class="button" rel="noopener" target="_blank">');
-	}
-
-	/**
-	 * Test that the review request is dismissed and does not reappear
-	 * on a subsequent page load.
-	 *
-	 * @since   1.4.3
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testReviewRequestNotificationDismissed(AcceptanceTester $I)
-	{
-		// Clear options table settings for review request.
-		$I->deleteConvertKitReviewRequestOptions($I);
-
-		// Set review request option with a timestamp in the past, to emulate
-		// the Plugin having set this a few days ago.
-		$I->haveOptionInDatabase('convertkit-for-woocommerce-review-request', time() - 3600 );
-
-		// Navigate to a screen in the WordPress Administration.
-		$I->amOnAdminPage('index.php');
-
-		// Confirm the review displays.
-		$I->seeElementInDOM('div.review-convertkit-for-woocommerce');
 
 		// Dismiss the review request.
 		$I->click('div.review-convertkit-for-woocommerce button.notice-dismiss');

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -44,7 +44,7 @@ class ReviewRequestCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -25,9 +25,6 @@ class WooCommerceSubscriptionsSubscribeEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -48,9 +48,8 @@ class WooCommerceSubscriptionsSubscribeEventCest
 			'subscription', // Subscription Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -100,9 +99,8 @@ class WooCommerceSubscriptionsSubscribeEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -25,6 +25,9 @@ class WooCommerceSubscriptionsSubscribeEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -48,7 +51,7 @@ class WooCommerceSubscriptionsSubscribeEventCest
 			'subscription', // Subscription Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
@@ -99,7 +102,7 @@ class WooCommerceSubscriptionsSubscribeEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -28,6 +28,9 @@ class PurchaseDataCest
 
 		// Setup Custom Order Numbers Plugin.
 		$I->setupCustomOrderNumbersPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -75,12 +75,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -135,12 +130,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'virtual', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'virtual' // Simple Product.
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -195,12 +185,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'zero', // Zero value Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'zero' // Zero value Simple Product.
 		);
 
 		// Confirm that the purchase was added to ConvertKit.
@@ -541,12 +526,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Create Product for this test.
@@ -629,12 +609,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Create Product for this test.
@@ -717,12 +692,7 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Create Product for this test.
@@ -766,7 +736,7 @@ class PurchaseDataCest
 			false, // Don't check Opt-In checkbox on Checkout.
 			false, // Form to subscribe email address to (not used).
 			false, // Subscribe Event.
-			'Order Completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
+			'completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -807,7 +777,7 @@ class PurchaseDataCest
 			false, // Don't check Opt-In checkbox on Checkout.
 			false, // Form to subscribe email address to (not used).
 			false, // Subscribe Event.
-			'Order Completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
+			'completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -28,9 +28,6 @@ class PurchaseDataCest
 
 		// Setup Custom Order Numbers Plugin.
 		$I->setupCustomOrderNumbersPlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**
@@ -226,14 +223,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithSimpleProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
@@ -267,14 +268,18 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithSimpleProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			false // Don't send purchase data.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
@@ -308,14 +313,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithVirtualProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateVirtualProduct($I);
@@ -349,14 +358,18 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithVirtualProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			false // Don't send purchase data.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateVirtualProduct($I);
@@ -390,14 +403,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithZeroValueProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateZeroValueProduct($I);
@@ -431,14 +448,18 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithZeroValueProductNoPaymentMethodManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			false // Don't send purchase data.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateZeroValueProduct($I);
@@ -472,14 +493,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithSimpleProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
@@ -513,14 +538,16 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithSimpleProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			false, // Don't display Opt-In checkbox on Checkout.
+			false, // Don't check Opt-In checkbox on Checkout.
+			false, // Form to subscribe email address to (not used).
+			false, // Subscribe Event.
+			false // Don't send purchase data to ConvertKit.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
@@ -554,14 +581,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithVirtualProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateVirtualProduct($I);
@@ -595,14 +626,16 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithVirtualProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			false, // Don't display Opt-In checkbox on Checkout.
+			false, // Don't check Opt-In checkbox on Checkout.
+			false, // Form to subscribe email address to (not used).
+			false, // Subscribe Event.
+			false // Don't send purchase data to ConvertKit.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateVirtualProduct($I);
@@ -636,14 +669,18 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithZeroValueProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Enable Sending Purchase Data.
-		$I->checkOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Enable Integration and define its API Keys.
+		$I->setupConvertKitPlugin(
+			$I,
+			$_ENV['CONVERTKIT_API_KEY'],
+			$_ENV['CONVERTKIT_API_SECRET'],
+			false, // Don't define a subscribe event.
+			false, // Don't subscribe the customer to anything.
+			'first', // Name format.
+			false, // Don't map custom fields.
+			false, // Don't display an opt in.
+			'processing' // Send purchase data on 'processing' event.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateZeroValueProduct($I);
@@ -677,14 +714,16 @@ class PurchaseDataCest
 	 */
 	public function testDontSendPurchaseDataWithZeroValueProductCODManualOrder(AcceptanceTester $I)
 	{
-		// Go to the Plugin's Settings Screen.
-		$I->loadConvertKitSettingsScreen($I);
-
-		// Disable Sending Purchase Data.
-		$I->uncheckOption('#woocommerce_ckwc_send_purchases');
-
-		// Save.
-		$I->click('Save changes');
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			'simple', // Simple Product.
+			false, // Don't display Opt-In checkbox on Checkout.
+			false, // Don't check Opt-In checkbox on Checkout.
+			false, // Form to subscribe email address to (not used).
+			false, // Subscribe Event.
+			false // Don't send purchase data to ConvertKit.
+		);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateZeroValueProduct($I);

--- a/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
+++ b/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
@@ -84,8 +84,21 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Enable the Integration.
+		$I->checkOption('#woocommerce_ckwc_enabled');
+
+		// Complete API Fields.
+		$I->fillField('woocommerce_ckwc_api_key', $_ENV['CONVERTKIT_API_KEY']);
+		$I->fillField('woocommerce_ckwc_api_secret', $_ENV['CONVERTKIT_API_SECRET']);
+
+		// Click the Save Changes button.
+		$I->click('Save changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm that no message is displayed telling the user that the API Credentials are invalid.
 		$I->dontSeeInSource('Your ConvertKit API Key appears to be invalid. Please double check the value.');

--- a/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
+++ b/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
@@ -17,6 +17,9 @@ class SettingAPIKeyAndSecretCest
 	public function _before(AcceptanceTester $I)
 	{
 		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**
@@ -29,9 +32,6 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
 		// Click the Save Changes button.
 		$I->click('Save changes');
 
@@ -53,9 +53,6 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveBlankSettingsWithIntegrationEnabled(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
 		// Enable the Integration.
 		$I->checkOption('#woocommerce_ckwc_enabled');
 
@@ -84,9 +81,6 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveValidAPICredentials(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
 		// Enable the Integration.
 		$I->checkOption('#woocommerce_ckwc_enabled');
 
@@ -124,9 +118,6 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveInvalidAPICredentials(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
 		// Enable the Integration.
 		$I->checkOption('#woocommerce_ckwc_enabled');
 

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -36,6 +36,9 @@ class SettingCustomFieldsCest
 	 */
 	public function testCustomFields(AcceptanceTester $I)
 	{
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
 		// Confirm Custom Fields are in alphabetical ascending order.
 		$I->checkSelectCustomFieldOptionOrder(
 			$I,

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -24,6 +24,9 @@ class SettingCustomFieldsCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**
@@ -36,9 +39,6 @@ class SettingCustomFieldsCest
 	 */
 	public function testCustomFields(AcceptanceTester $I)
 	{
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
-
 		// Confirm Custom Fields are in alphabetical ascending order.
 		$I->checkSelectCustomFieldOptionOrder(
 			$I,

--- a/tests/acceptance/settings/SettingDebugLogCest.php
+++ b/tests/acceptance/settings/SettingDebugLogCest.php
@@ -19,6 +19,9 @@ class SettingDebugLogCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**
@@ -48,6 +51,29 @@ class SettingDebugLogCest
 
 		// Confirm that a ConvertKit Log File exists in the dropdown selection of logs.
 		$I->seeInSource('<option value="convertkit-' . date('Y-m-d'));
+	}
+
+	/**
+	 * Test that debug logging setting is honored when disabled at
+	 * WooCommerce > Settings > Integration > ConvertKit.
+	 *
+	 * @since   1.6.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDebugDisabled(AcceptanceTester $I)
+	{
+		// Uncheck "Debug" checkbox.
+		$I->uncheckOption('#woocommerce_ckwc_debug');
+
+		// Save.
+		$I->click('Save changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the setting saved.
+		$I->dontSeeCheckboxIsChecked('#woocommerce_ckwc_debug');
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingEnabledDisabledCest.php
+++ b/tests/acceptance/settings/SettingEnabledDisabledCest.php
@@ -17,9 +17,6 @@ class SettingEnabledDisabledCest
 	{
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
-
-		// Setup WooCommerce Plugin.
-		$I->setupWooCommercePlugin($I);
 	}
 
 	/**
@@ -47,6 +44,58 @@ class SettingEnabledDisabledCest
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
+	}
+
+	/**
+	 * Test that the enabled setting is honored when checked at
+	 * WooCommerce > Settings > Integration > ConvertKit.
+	 *
+	 * @since   1.6.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testEnabled(AcceptanceTester $I)
+	{
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Check "Enabled" checkbox.
+		$I->checkOption('#woocommerce_ckwc_enabled');
+
+		// Save.
+		$I->click('Save changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the setting saved.
+		$I->seeCheckboxIsChecked('#woocommerce_ckwc_enabled');
+	}
+
+	/**
+	 * Test that the enabled setting is honored when unchecked at
+	 * WooCommerce > Settings > Integration > ConvertKit.
+	 *
+	 * @since   1.6.0
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDisabled(AcceptanceTester $I)
+	{
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Uncheck "Enabled" checkbox.
+		$I->uncheckOption('#woocommerce_ckwc_enabled');
+
+		// Save.
+		$I->click('Save changes');
+
+		// Check that no PHP warnings or notices were output.
+		$I->checkNoWarningsAndNoticesOnScreen($I);
+
+		// Confirm the setting saved.
+		$I->dontSeeCheckboxIsChecked('#woocommerce_ckwc_enabled');
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingEnabledDisabledCest.php
+++ b/tests/acceptance/settings/SettingEnabledDisabledCest.php
@@ -30,6 +30,9 @@ class SettingEnabledDisabledCest
 	 */
 	public function testIntegrationWhenDisabled(AcceptanceTester $I)
 	{
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
 		// Create Simple Product.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 

--- a/tests/acceptance/settings/SettingImportExportCest.php
+++ b/tests/acceptance/settings/SettingImportExportCest.php
@@ -24,6 +24,9 @@ class SettingImportExportCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingNameFormatCest.php
+++ b/tests/acceptance/settings/SettingNameFormatCest.php
@@ -23,6 +23,9 @@ class SettingNameFormatCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingNameFormatCest.php
+++ b/tests/acceptance/settings/SettingNameFormatCest.php
@@ -57,9 +57,13 @@ class SettingNameFormatCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // Don't define product level form, tag or sequence to subscribe to.
+			false, // Don't map custom fields.
+			'first', // Name format.
+			false // Don't define coupon level form, tag or sequence to subscribe to.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -101,9 +105,13 @@ class SettingNameFormatCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // Don't define product level form, tag or sequence to subscribe to.
+			false, // Don't map custom fields.
+			'last', // Name format.
+			false // Don't define coupon level form, tag or sequence to subscribe to.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -145,9 +153,13 @@ class SettingNameFormatCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
+			false, // Don't send purchase data to ConvertKit.
+			false, // Don't define product level form, tag or sequence to subscribe to.
+			false, // Don't map custom fields.
+			'both', // Name format.
+			false // Don't define coupon level form, tag or sequence to subscribe to.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/settings/SettingOptInCheckboxCest.php
+++ b/tests/acceptance/settings/SettingOptInCheckboxCest.php
@@ -24,6 +24,9 @@ class SettingOptInCheckboxCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingPurchasesCest.php
+++ b/tests/acceptance/settings/SettingPurchasesCest.php
@@ -20,6 +20,9 @@ class SettingPurchasesCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingSubscribeEventCest.php
+++ b/tests/acceptance/settings/SettingSubscribeEventCest.php
@@ -24,6 +24,9 @@ class SettingSubscribeEventCest
 
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**
@@ -36,9 +39,6 @@ class SettingSubscribeEventCest
 	 */
 	public function testOrderPendingPaymentWithoutOptInCheckbox(AcceptanceTester $I)
 	{
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
-
 		// Set Subscribe Event = Order Order Pending payment.
 		$I->selectOption('#woocommerce_ckwc_event', 'Order Pending payment');
 

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -45,7 +45,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
@@ -81,7 +81,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
@@ -116,7 +116,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
@@ -227,7 +227,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -270,7 +270,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
 			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -313,7 +313,7 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
 			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -21,6 +21,9 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -42,9 +45,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -79,9 +81,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -115,9 +116,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -153,9 +153,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -191,9 +190,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -229,8 +227,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -272,8 +270,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Processing" event.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -315,8 +313,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Processing" event.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'completed', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -357,9 +355,8 @@ class SubscribeOnOrderCompletedEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Completed', // Subscribe on WooCommerce "Order Completed" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'completed' // Subscribe on WooCommerce "Order Completed" event.
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -21,9 +21,6 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -21,6 +21,9 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -42,9 +45,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -73,9 +75,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -103,9 +104,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -135,8 +135,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -172,8 +172,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
+			'form:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -209,8 +209,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -246,9 +246,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -278,9 +277,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -309,9 +307,8 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Pending payment', // Subscribe on WooCommerce "Order Pending payment" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -45,7 +45,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
@@ -75,7 +75,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
@@ -104,7 +104,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
 		);
 
@@ -135,7 +135,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -172,7 +172,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
 			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -209,7 +209,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
 			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -21,9 +21,6 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -46,7 +46,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
@@ -83,7 +83,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
@@ -115,7 +115,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
@@ -153,7 +153,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -190,7 +190,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -227,7 +227,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
@@ -366,7 +366,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Product level Form to subscribe email address to.
@@ -409,7 +409,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Product level Tag to subscribe email address to.
@@ -452,7 +452,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Product level Sequence to subscribe email address to.
@@ -495,7 +495,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
@@ -541,7 +541,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
@@ -587,7 +587,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
@@ -635,7 +635,7 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
 			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -22,6 +22,9 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -43,9 +46,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -81,9 +83,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -114,9 +115,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -153,8 +153,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -190,8 +190,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'tag:' . $_ENV['CONVERTKIT_API_TAG_NAME'], // Tag to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -227,8 +227,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'], // Tag to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // Don't define a Product level Form, Tag or Sequence.
 			true // Map Order data to Custom Fields.
@@ -264,9 +264,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -299,9 +298,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -333,9 +331,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			false, // Don't display Opt-In checkbox on Checkout.
 			false, // Don't check Opt-In checkbox on Checkout.
-			'Select a subscription option...', // Don't select a Form to subscribe the email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			false, // Don't select a Form to subscribe the email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -369,8 +366,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Product level Form to subscribe email address to.
 		);
@@ -412,8 +409,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Product level Tag to subscribe email address to.
 		);
@@ -455,8 +452,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Product level Sequence to subscribe email address to.
 		);
@@ -498,11 +495,12 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
 			false, // No Custom Field mapping.
+			'first', // Name format.
 			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Coupon level Form to subscribe email address to.
 		);
 
@@ -543,11 +541,12 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
 			false, // No Custom Field mapping.
+			'first', // Name format.
 			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Coupon level Tag to subscribe email address to.
 		);
 
@@ -588,11 +587,12 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing', // Subscribe on WooCommerce "Order Processing" event.
 			false, // Don't send purchase data to ConvertKit.
 			false, // No Product level Form, Tag or Sequence.
 			false, // No Custom Field mapping.
+			'first', // Name format.
 			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Coupon level Sequence to subscribe email address to.
 		);
 
@@ -635,9 +635,8 @@ class SubscribeOnOrderProcessingEventCest
 			'simple', // Simple Product.
 			true, // Display Opt-In checkbox on Checkout.
 			true, // Check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'Order Processing', // Subscribe on WooCommerce "Order Processing" event.
-			false // Don't send purchase data to ConvertKit.
+			'form:' . $_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
+			'processing' // Subscribe on WooCommerce "Order Processing" event.
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -22,9 +22,6 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 	}
 
 	/**

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -101,9 +101,6 @@ class SyncPastOrdersCest
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
-
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -173,9 +170,6 @@ class SyncPastOrdersCest
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
-
 		// Create Product and Checkout for this test, sending the Order
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
@@ -211,9 +205,6 @@ class SyncPastOrdersCest
 	{
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 
 		// Create Product and Checkout for this test, not sending the Order
 		// to ConvertKit.
@@ -304,9 +295,6 @@ class SyncPastOrdersCest
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
-
 		// Create Product and Checkout for this test, not sending the Order
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
@@ -388,9 +376,6 @@ class SyncPastOrdersCest
 	{
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
-
-		// Enable Integration and define its API Keys.
-		$I->setupConvertKitPlugin($I);
 
 		// Create Product and Checkout for this test, not sending the Order
 		// to ConvertKit.

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -104,12 +104,7 @@ class SyncPastOrdersCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Don't define a subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Login as the Administrator.
@@ -210,12 +205,7 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Don't define a subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Login as the Administrator.
@@ -381,12 +371,7 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Don't define a subscribe Event.
-			false // Don't send purchase data to ConvertKit.
+			'simple' // Simple Product.
 		);
 
 		// Login as the Administrator.

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -41,14 +41,6 @@ class SyncPastOrdersCest
 		// Delete all existing WooCommerce Orders from the database.
 		$I->dontHavePostInDatabase([ 'post_type' => 'shop_order' ]);
 
-		// Disable the Integration.
-		$I->loadConvertKitSettingsScreen($I);
-		$I->checkOption('#woocommerce_ckwc_enabled');
-		$I->fillField('woocommerce_ckwc_api_key', '');
-		$I->fillField('woocommerce_ckwc_api_secret', '');
-		$I->uncheckOption('#woocommerce_ckwc_enabled');
-		$I->click('Save changes');
-
 		// Create Product.
 		$productName = 'Simple Product';
 		$productID   = $I->wooCommerceCreateSimpleProduct($I, false);


### PR DESCRIPTION
## Summary

Improves test performance by performing the following before each test:
- programmatically defining the API Key, Secret and settings,
- writing resources (ConvertKit custom fields, forms, sequences, tags) directly to the database cache, instead of querying the API for them, effectively mocking the API for reading resources
- when querying the API for purchase data, only return the first page of results, instead of all purchases

This improves performance and prevents API rate limits being hit (due to test run in parallel), as the settings screen is only accessed when explicitly required (i.e. for `acceptance/settings` tests).  Previously, this screen would always be accessed for every test, resulting in the API being queried every time to fetch custom fields, forms, sequences and tags.

For performance comparison, see before:
![Screenshot 2023-02-27 at 15 22 52](https://user-images.githubusercontent.com/1462305/221604823-f0bf2295-8ec8-415f-ac93-6ddd470a00f1.png)

![Screenshot 2023-02-27 at 15 55 17](https://user-images.githubusercontent.com/1462305/221613321-828c6ffb-63c7-40a1-8fb7-8ba06c37ab34.png)

After:
![Screenshot 2023-02-27 at 15 24 01](https://user-images.githubusercontent.com/1462305/221605062-6f7e8016-6632-4141-8ceb-81ca2b6297e2.png)

![Screenshot 2023-02-27 at 15 55 14](https://user-images.githubusercontent.com/1462305/221613343-458654ee-6def-4341-a59e-f83ad6bac129.png)

Other API functions are not mocked, and WPUnit test coverage remains, to ensure that resource classes correctly work when querying the API.

## Testing

Tests should pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)