### PR TITLE
Fix Purchase Data Name Format

### DIFF
--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -431,7 +431,12 @@ class CKWC_Order {
 		$purchase = array(
 			'transaction_id'   => $order->get_order_number(),
 			'email_address'    => $order->get_billing_email(),
-			'first_name'       => $order->get_billing_first_name(),
+
+			// This is deliberate; if the customer has checked the opt in box to subscribe,
+			// their name is overwritten by this first_name parameter when purchase data is
+			// subsequently sent.  Therefore, we use this classes' name() function to ensure
+			// we honor the integration's "Name Format" setting.
+			'first_name'       => $this->name( $order ),
 			'currency'         => $order->get_currency(),
 			'transaction_time' => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
 			'subtotal'         => round( floatval( $order->get_subtotal() ), 2 ),
@@ -702,7 +707,7 @@ class CKWC_Order {
 	 * Returns the customer's name for the given WooCommerce Order, based on the Plugin's
 	 * Name Format setting (First Name, Last Name or First + Last Name),
 	 * immediately before it is sent to ConvertKit when subscribing the Customer
-	 * to a Form, Tag or Sequence.
+	 * to a Form, Tag or Sequence, or sending Purchase Data.
 	 *
 	 * @since   1.0.0
 	 *
@@ -739,7 +744,7 @@ class CKWC_Order {
 		/**
 		 * Returns the customer's name for the given WooCommerce Order,
 		 * immediately before it is sent to ConvertKit when subscribing the Customer
-		 * to a Form, Tag or Sequence.
+		 * to a Form, Tag or Sequence, or sending Purchase Data.
 		 *
 		 * @since   1.0.0
 		 *


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://wordpress.org/support/topic/integration-not-sending-last-name-to-convertkit/), honoring the `Name Format` setting when:
- the customer is opted in (subscribed) to a form, tag or sequence at checkout, **and**
- send purchase data is enabled

This happens because:
- the customer opts in, with an API request sent to ConvertKit to subscribe the customer, honoring the name format (e.g. First + Last Name),
- the purchase data is then sent via the API separately, and after the customer is subscribed. The `first_name` parameter of the purchase data did not honor the Plugin's name format, resulting in the subscriber's name always being overwritten to their first name.

Whilst the field on ConvertKit for a subscriber does specifically state "First name",  we've always supported the Name Format to be one of first name, last name or both with this Plugin.  This PR brings consistency to how this works when purchase data is also sent to ConvertKit; the expectation being that the "Name Format" setting be honored.

Longer term, we may wish to always just send the first name, and possibly look to using a custom field for the surname.

## Testing

- `PurchaseDataCest:testSendPurchaseDataNameFormatHonoredWhenSubscribed`: Confirm that the Name Format setting is honored when the customer subscribes and purchase data is sent to ConvertKit.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)