### PR TITLE
Add option to map last name to Custom Field

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -393,7 +393,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Custom Field Mappings.
-			'custom_field_last_name'            => array(
+			'custom_field_last_name'        => array(
 				'title'       => __( 'Send Last Name', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -393,6 +393,15 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Custom Field Mappings.
+			'custom_field_last_name'            => array(
+				'title'       => __( 'Send Last Name', 'woocommerce-convertkit' ),
+				'type'        => 'custom_field',
+				'default'     => '',
+				'description' => __( 'The ConvertKit custom field to store the order\'s last name.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
 			'custom_field_phone'            => array(
 				'title'       => __( 'Send Phone Number', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -838,6 +838,9 @@ class CKWC_Order {
 
 		$fields = array();
 
+		if ( $this->integration->get_option( 'custom_field_last_name' ) ) {
+			$fields[ $this->integration->get_option( 'custom_field_last_name' ) ] = $order->get_billing_last_name();
+		}
 		if ( $this->integration->get_option( 'custom_field_phone' ) ) {
 			$fields[ $this->integration->get_option( 'custom_field_phone' ) ] = $order->get_billing_phone();
 		}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -213,6 +213,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 */
 	public function apiCustomFieldDataIsValid($I, $subscriber)
 	{
+		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
 		$I->assertEquals($subscriber['fields']['billing_address'], 'First Last, Address Line 1, City, CA 12345');
 		$I->assertEquals($subscriber['fields']['shipping_address'], '');
@@ -228,6 +229,7 @@ class ConvertKitAPI extends \Codeception\Module
 	 */
 	public function apiCustomFieldDataIsEmpty($I, $subscriber)
 	{
+		$I->assertEquals($subscriber['fields']['last_name'], '');
 		$I->assertEquals($subscriber['fields']['phone_number'], '');
 		$I->assertEquals($subscriber['fields']['billing_address'], '');
 		$I->assertEquals($subscriber['fields']['shipping_address'], '');

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -119,6 +119,7 @@ class Plugin extends \Codeception\Module
 				'name_format'                   => $nameFormat,
 
 				// Custom Field mappings.
+				'custom_field_last_name'        => ( $mapCustomFields ? 'last_name' : '' ),
 				'custom_field_phone'            => ( $mapCustomFields ? 'phone_number' : '' ),
 				'custom_field_billing_address'  => ( $mapCustomFields ? 'billing_address' : '' ),
 				'custom_field_shipping_address' => ( $mapCustomFields ? 'shipping_address' : '' ),

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -49,6 +49,7 @@ class SettingCustomFieldsCest
 		);
 
 		// Set Order to Custom Field mappings.
+		$I->selectOption('#woocommerce_ckwc_custom_field_last_name', 'Last Name');
 		$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
@@ -62,6 +63,7 @@ class SettingCustomFieldsCest
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Confirm the settings saved.
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_last_name', 'Last Name');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');


### PR DESCRIPTION
## Summary

Adds an option to map the WooCommerce Order's last name to a ConvertKit Custom Field.

<img width="677" alt="Screenshot 2023-04-21 at 17 51 42" src="https://user-images.githubusercontent.com/1462305/233745813-c776b558-9b80-4690-a6c9-e6a69f420486.png">

This opens the possibility of changing the Name Format setting at a later date, given that the name maps to ConvertKit's first name field, and we've provided legacy options to send the first name (which makes sense), last name (which makes less sense) or first and last name (which isn't really what the ConvertKit first name field is for). 

## Testing

- Added Last Name custom field to all custom field tests, to ensure the data is / is not mapped based on the Plugin's configuration

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)