### PR TITLE
Remove double forwardslash on CSS/JS URLs

### DIFF
--- a/admin/class-ckwc-admin-bulk-edit.php
+++ b/admin/class-ckwc-admin-bulk-edit.php
@@ -55,7 +55,7 @@ class CKWC_Admin_Bulk_Edit {
 		wp_enqueue_script( 'ckwc-bulk-edit', CKWC_PLUGIN_URL . 'resources/backend/js/bulk-edit.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, true );
 
 		// Enqueue CSS.
-		wp_enqueue_style( 'ckwc-bulk-quick-edit', CKWC_PLUGIN_URL . '/resources/backend/css/bulk-quick-edit.css', array(), CKWC_PLUGIN_VERSION );
+		wp_enqueue_style( 'ckwc-bulk-quick-edit', CKWC_PLUGIN_URL . 'resources/backend/css/bulk-quick-edit.css', array(), CKWC_PLUGIN_VERSION );
 
 		// Output Bulk Edit fields in the footer of the Administration screen.
 		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -679,7 +679,7 @@ class CKWC_Integration extends WC_Integration {
 		}
 
 		// CSS to always enqueue.
-		wp_enqueue_style( 'ckwc-settings', CKWC_PLUGIN_URL . '/resources/backend/css/settings.css', array(), CKWC_PLUGIN_VERSION );
+		wp_enqueue_style( 'ckwc-settings', CKWC_PLUGIN_URL . 'resources/backend/css/settings.css', array(), CKWC_PLUGIN_VERSION );
 
 		// Depending on the screen name, enqueue scripts now.
 		switch ( $screen_name ) {
@@ -688,7 +688,7 @@ class CKWC_Integration extends WC_Integration {
 			 * Sync Past Orders Screen.
 			 */
 			case 'sync_past_orders':
-				wp_enqueue_style( 'ckwc-sync-past-orders', CKWC_PLUGIN_URL . '/resources/backend/css/sync-past-orders.css', array(), CKWC_PLUGIN_VERSION );
+				wp_enqueue_style( 'ckwc-sync-past-orders', CKWC_PLUGIN_URL . 'resources/backend/css/sync-past-orders.css', array(), CKWC_PLUGIN_VERSION );
 				break;
 
 			/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -76,7 +76,7 @@ function ckwc_get_api_key_url() {
 function ckwc_select2_enqueue_scripts() {
 
 	wp_enqueue_script( 'ckwc-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js', array( 'jquery' ), CKWC_PLUGIN_VERSION, false );
-	wp_enqueue_script( 'ckwc-admin-select2', CKWC_PLUGIN_URL . '/resources/backend/js/select2.js', array( 'ckwc-select2' ), CKWC_PLUGIN_VERSION, false );
+	wp_enqueue_script( 'ckwc-admin-select2', CKWC_PLUGIN_URL . 'resources/backend/js/select2.js', array( 'ckwc-select2' ), CKWC_PLUGIN_VERSION, false );
 
 }
 
@@ -88,6 +88,6 @@ function ckwc_select2_enqueue_scripts() {
 function ckwc_select2_enqueue_styles() {
 
 	wp_enqueue_style( 'ckwc-select2', 'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css', array(), CKWC_PLUGIN_VERSION );
-	wp_enqueue_style( 'ckwc-admin-select2', CKWC_PLUGIN_URL . '/resources/backend/css/select2.css', array(), CKWC_PLUGIN_VERSION );
+	wp_enqueue_style( 'ckwc-admin-select2', CKWC_PLUGIN_URL . 'resources/backend/css/select2.css', array(), CKWC_PLUGIN_VERSION );
 
 }

--- a/tests/_support/Helper/Acceptance/WPAssets.php
+++ b/tests/_support/Helper/Acceptance/WPAssets.php
@@ -14,13 +14,12 @@ class WPAssets extends \Codeception\Module
 	 *
 	 * @since   1.6.4
 	 *
-	 * @param   AcceptanceHelper $I     Acceptance Helper.
-	 * @param   string           $url 	Script URL, relative to Plugin root folder.
-	 * @param 	string 			 $id 	Script ID.
+	 * @param   AcceptanceHelper $I     	Acceptance Helper.
+	 * @param   string           $url 		Script URL, relative to Plugin root folder.
 	 */
-	public function seeJSEnqueued($I, $url, $id)
+	public function seeJSEnqueued($I, $url)
 	{
-		$I->seeInSource('<script src=\'' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/' . $url );
+		$I->seeInSource('<script src="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/' . $url );
 	}
 
 	/**
@@ -28,9 +27,8 @@ class WPAssets extends \Codeception\Module
 	 *
 	 * @since   1.6.4
 	 *
-	 * @param   AcceptanceHelper $I     Acceptance Helper.
-	 * @param   string           $url 	Script URL, relative to WordPress Plugins folder.
-	 * @param 	string 			 $id 	Script ID.
+	 * @param   AcceptanceHelper $I     	Acceptance Helper.
+	 * @param   string           $url 		CSS URL, relative to Plugin root folder.
 	 */
 	public function seeCSSEnqueued($I, $url, $id)
 	{

--- a/tests/_support/Helper/Acceptance/WPAssets.php
+++ b/tests/_support/Helper/Acceptance/WPAssets.php
@@ -1,0 +1,39 @@
+<?php
+namespace Helper\Acceptance;
+
+/**
+ * Helper methods and actions related to WordPress' Bulk Edit functionality,
+ * which are then available using $I->{yourFunctionName}.
+ *
+ * @since   1.6.4
+ */
+class WPAssets extends \Codeception\Module
+{
+	/**
+	 * Helper method to assert that the given script has been enqueued in WordPress.
+	 *
+	 * @since   1.6.4
+	 *
+	 * @param   AcceptanceHelper $I     Acceptance Helper.
+	 * @param   string           $url 	Script URL, relative to Plugin root folder.
+	 * @param 	string 			 $id 	Script ID.
+	 */
+	public function seeJSEnqueued($I, $url, $id)
+	{
+		$I->seeInSource('<script src=\'' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/' . $url );
+	}
+
+	/**
+	 * Helper method to assert that the given stylesheet has been enqueued in WordPress.
+	 *
+	 * @since   1.6.4
+	 *
+	 * @param   AcceptanceHelper $I     Acceptance Helper.
+	 * @param   string           $url 	Script URL, relative to WordPress Plugins folder.
+	 * @param 	string 			 $id 	Script ID.
+	 */
+	public function seeCSSEnqueued($I, $url, $id)
+	{
+		$I->seeInSource('<link rel="stylesheet" id="' . $id . '" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-content/plugins/' . $url );
+	}
+}

--- a/tests/_support/Helper/Acceptance/WPAssets.php
+++ b/tests/_support/Helper/Acceptance/WPAssets.php
@@ -14,8 +14,8 @@ class WPAssets extends \Codeception\Module
 	 *
 	 * @since   1.6.4
 	 *
-	 * @param   AcceptanceHelper $I     	Acceptance Helper.
-	 * @param   string           $url 		Script URL, relative to Plugin root folder.
+	 * @param   AcceptanceHelper $I         Acceptance Helper.
+	 * @param   string           $url       Script URL, relative to Plugin root folder.
 	 */
 	public function seeJSEnqueued($I, $url)
 	{
@@ -27,8 +27,9 @@ class WPAssets extends \Codeception\Module
 	 *
 	 * @since   1.6.4
 	 *
-	 * @param   AcceptanceHelper $I     	Acceptance Helper.
-	 * @param   string           $url 		CSS URL, relative to Plugin root folder.
+	 * @param   AcceptanceHelper $I         Acceptance Helper.
+	 * @param   string           $url       CSS URL, relative to Plugin root folder.
+	 * @param   string           $id        CSS ID.
 	 */
 	public function seeCSSEnqueued($I, $url, $id)
 	{

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -24,6 +24,7 @@ modules:
         - \Helper\Acceptance\Select2
         - \Helper\Acceptance\ThirdPartyPlugin
         - \Helper\Acceptance\WooCommerce
+        - \Helper\Acceptance\WPAssets
         - \Helper\Acceptance\WPBulkEdit
         - \Helper\Acceptance\WPMetabox
         - \Helper\Acceptance\WPGutenberg

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -78,7 +78,7 @@ class ProductCest
 		// Confirm CSS and JS is output by the Plugin.
 		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/select2.css', 'ckwc-admin-select2-css' );
 		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/select2.js' );
-	
+
 		// Check that the ConvertKit meta box exists.
 		$I->seeElementInDOM('#ckwc');
 

--- a/tests/acceptance/general/ProductCest.php
+++ b/tests/acceptance/general/ProductCest.php
@@ -75,6 +75,10 @@ class ProductCest
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		// Confirm CSS and JS is output by the Plugin.
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/select2.css', 'ckwc-admin-select2-css' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/select2.js' );
+	
 		// Check that the ConvertKit meta box exists.
 		$I->seeElementInDOM('#ckwc');
 
@@ -213,6 +217,10 @@ class ProductCest
 		// Reload the Products admin screen.
 		$I->amOnAdminPage('edit.php?post_type=product');
 
+		// Confirm CSS and JS is output by the Plugin.
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/bulk-quick-edit.css', 'ckwc-bulk-quick-edit-css' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/quick-edit.js' );
+
 		// Confirm that the chosen Resource is the selected option.
 		$I->seePostMetaInDatabase(
 			[
@@ -256,14 +264,14 @@ class ProductCest
 	}
 
 	/**
-	 * Test that the defined form displays when chosen via
+	 * Test that the defined resource (Form, Tag, Sequence) is saved when chosen via
 	 * WordPress' Bulk Edit functionality.
 	 *
 	 * @since   1.4.8
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
-	public function testBulkEditUsingDefinedForm(AcceptanceTester $I)
+	public function testBulkEditUsingDefinedResource(AcceptanceTester $I)
 	{
 		// Enable Integration and define its API Keys.
 		$I->setupConvertKitPlugin($I);
@@ -296,6 +304,13 @@ class ProductCest
 				'ckwc_subscription' => [ 'select', $_ENV['CONVERTKIT_API_FORM_NAME'] ],
 			]
 		);
+
+		// Reload the Products admin screen.
+		$I->amOnAdminPage('edit.php?post_type=product');
+
+		// Confirm CSS and JS is output by the Plugin.
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/bulk-quick-edit.css', 'ckwc-bulk-quick-edit-css' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/bulk-edit.js' );
 
 		// Iterate through Products to observe expected changes were made to the settings in the database.
 		foreach ($productIDs as $productID) {

--- a/tests/acceptance/general/RefreshResourcesButtonCest.php
+++ b/tests/acceptance/general/RefreshResourcesButtonCest.php
@@ -33,6 +33,9 @@ class RefreshResourcesButtonCest
 		// Navigate to Product > Add New.
 		$I->amOnAdminPage('post-new.php?post_type=product');
 
+		// Confirm JS is output by the Plugin.
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/refresh-resources.js' );
+
 		// Click the refresh button.
 		$I->click('button.ckwc-refresh-resources');
 
@@ -75,6 +78,9 @@ class RefreshResourcesButtonCest
 		// Open Bulk Edit form for the Products in the WooCommerce Products WP_List_Table.
 		$I->openBulkEdit($I, 'product', $productIDs);
 
+		// Confirm JS is output by the Plugin.
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/refresh-resources.js' );
+
 		// Click the refresh button.
 		$I->wait(2);
 		$I->scrollTo('select[name="comment_status"]');
@@ -110,6 +116,9 @@ class RefreshResourcesButtonCest
 
 		// Open Quick Edit form for the Product in the WooCommerce Products WP_List_Table.
 		$I->openQuickEdit($I, 'product', $pageID);
+
+		// Confirm JS is output by the Plugin.
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/refresh-resources.js' );
 
 		// Click the refresh button.
 		$I->waitForElementVisible('#ckwc-quick-edit button.ckwc-refresh-resources');

--- a/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
+++ b/tests/acceptance/settings/SettingAPIKeyAndSecretCest.php
@@ -32,6 +32,12 @@ class SettingAPIKeyAndSecretCest
 	 */
 	public function testSaveBlankSettings(AcceptanceTester $I)
 	{
+		// Confirm CSS and JS is output by the Plugin.
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/settings.css', 'ckwc-settings-css' );
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/select2.css', 'ckwc-admin-select2-css' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/select2.js' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/integration.js' );
+
 		// Click the Save Changes button.
 		$I->click('Save changes');
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -215,6 +215,12 @@ class SyncPastOrdersCest
 		// Confirm the popup.
 		$I->acceptPopup();
 
+		// Confirm CSS and JS is output by the Plugin.
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/settings.css', 'ckwc-settings-css' );
+		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/sync-past-orders.css', 'ckwc-sync-past-orders-css' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/synchronous-ajax.js' );
+		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/sync-past-orders.js' );
+
 		// Wait a few seconds for the API call to be made.
 		$I->wait(5);
 

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -15,7 +15,7 @@
  * Text Domain: woocommerce-convertkit
  *
  * WC requires at least: 3.0
- * WC tested up to: 7.6.1
+ * WC tested up to: 7.7.0
  */
 
 // Bail if Plugin is already loaded.


### PR DESCRIPTION
## Summary

Removes the double forwardslash when some JS and stylesheets are loaded.

URLs do work with the double forwardslash, but it's best not to have it.

Bumps supported WooCommerce version to the latest version, 7.7.0.

## Testing

- `ProductCest:testProductFieldsWithIntegrationEnabled`: Confirm JS and CSS is loaded, and the URLs are of the expected format.
- `ProductCest:testQuickEditUsingDefinedResource`: Confirm JS and CSS is loaded, and the URLs are of the expected format.
- `ProductCest:testBulkEditUsingDefinedResource`: Confirm JS and CSS is loaded, and the URLs are of the expected format.
- `SyncPastOrdersCest:testSyncPastOrder`: Confirm JS and CSS is loaded, and the URLs are of the expected format.
- `SettingsAPIKeyAndSecretCest:testSaveBlankSettings`: Confirm JS and CSS is loaded, and the URLs are of the expected format.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)