### PR TITLE
Remove most PHPStan ignores

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.4"
+        "convertkit/convertkit-wordpress-libraries": "dev-docblock-log-supported-types"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-docblock-log-supported-types"
+        "convertkit/convertkit-wordpress-libraries": "1.3.5"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -17,9 +17,9 @@ class CKWC_API extends ConvertKit_API {
 	/**
 	 * Holds the log class for writing to the log file
 	 *
-	 * @var bool|WC_Logger
+	 * @var bool|ConvertKit_Log|WC_Logger
 	 */
-	public $log = false; // @phpstan-ignore-line
+	public $log = false;
 
 	/**
 	 * Holds an array of error messages, localized to the plugin

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -89,7 +89,7 @@ class CKWC_Integration extends WC_Integration {
 
 			// Takes the form data and saves it to WooCommerce's settings.
 			// PHPStan: WooCommerce's process_admin_options() returns a value, which PHPStan rightly flags, so we need to ignore this line.
-			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) ); // @phpstan-ignore-line 
+			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) ); // @phpstan-ignore-line
 
 			// Sanitizes and tests specific setting fields to ensure they're valid.
 			add_filter( "woocommerce_settings_api_sanitized_fields_{$this->id}", array( $this, 'sanitize_settings' ) );
@@ -744,7 +744,7 @@ class CKWC_Integration extends WC_Integration {
 			$this->forms = new CKWC_Resource_Forms();
 			$this->forms->refresh();
 		}
-		if ( ! $this->sequences ) { 
+		if ( ! $this->sequences ) {
 			$this->sequences = new CKWC_Resource_Sequences();
 			$this->sequences->refresh();
 		}

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -30,36 +30,36 @@ class CKWC_Integration extends WC_Integration {
 	 *
 	 * @since   1.4.3
 	 *
-	 * @var     CKWC_Resource_Forms
+	 * @var     bool|CKWC_Resource_Forms
 	 */
-	private $forms;
+	private $forms = false;
 
 	/**
 	 * Holds the Form resources instance.
 	 *
 	 * @since   1.4.3
 	 *
-	 * @var     CKWC_Resource_Tags
+	 * @var     bool|CKWC_Resource_Tags
 	 */
-	private $tags;
+	private $tags = false;
 
 	/**
 	 * Holds the Form resources instance.
 	 *
 	 * @since   1.4.3
 	 *
-	 * @var     CKWC_Resource_Sequences
+	 * @var     bool|CKWC_Resource_Sequences
 	 */
-	private $sequences;
+	private $sequences = false;
 
 	/**
 	 * Holds the Form resources instance.
 	 *
 	 * @since   1.4.3
 	 *
-	 * @var     CKWC_Resource_Custom_Fields
+	 * @var     bool|CKWC_Resource_Custom_Fields
 	 */
-	private $custom_fields;
+	private $custom_fields = false;
 
 	/**
 	 * Constructor
@@ -88,7 +88,8 @@ class CKWC_Integration extends WC_Integration {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
 			// Takes the form data and saves it to WooCommerce's settings.
-			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) ); // @phpstan-ignore-line
+			// PHPStan: WooCommerce's process_admin_options() returns a value, which PHPStan rightly flags, so we need to ignore this line.
+			add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) ); // @phpstan-ignore-line 
 
 			// Sanitizes and tests specific setting fields to ensure they're valid.
 			add_filter( "woocommerce_settings_api_sanitized_fields_{$this->id}", array( $this, 'sanitize_settings' ) );
@@ -739,15 +740,15 @@ class CKWC_Integration extends WC_Integration {
 
 		// Get Forms, Tags and Sequences, refreshing them to fetch the latest data from the API,
 		// if we haven't already fetched them.
-		if ( ! $this->forms ) { // @phpstan-ignore-line
+		if ( ! $this->forms ) {
 			$this->forms = new CKWC_Resource_Forms();
 			$this->forms->refresh();
 		}
-		if ( ! $this->sequences ) { // @phpstan-ignore-line
+		if ( ! $this->sequences ) { 
 			$this->sequences = new CKWC_Resource_Sequences();
 			$this->sequences->refresh();
 		}
-		if ( ! $this->tags ) { // @phpstan-ignore-line
+		if ( ! $this->tags ) {
 			$this->tags = new CKWC_Resource_Tags();
 			$this->tags->refresh();
 		}
@@ -807,7 +808,7 @@ class CKWC_Integration extends WC_Integration {
 
 		// Get Custom Fields, refreshing them to fetch the latest data from the API,
 		// if we haven't already fetched them.
-		if ( ! $this->custom_fields ) { // @phpstan-ignore-line
+		if ( ! $this->custom_fields ) {
 			$this->custom_fields = new CKWC_Resource_Custom_Fields();
 			$this->custom_fields->refresh();
 		}

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -77,7 +77,7 @@ class CKWC_Order {
 
 		// Send Purchase Data.
 		if ( $this->integration->get_option_bool( 'send_purchases' ) ) {
-			add_action( 'woocommerce_order_status_changed', array( $this, 'send_purchase_data' ), 99999, 3 ); // @phpstan-ignore-line
+			add_action( 'woocommerce_order_status_changed', array( $this, 'send_purchase_data_action' ), 99999, 3 );
 		}
 
 	}
@@ -346,6 +346,22 @@ class CKWC_Order {
 	}
 
 	/**
+	 * Action called when a WooCommerce Order's status is changed, to send purchase
+	 * data to ConvertKit for the given WooCommerce Order ID.
+	 *
+	 * @since   1.6.5
+	 *
+	 * @param   int    $order_id   WooCommerce Order ID.
+	 * @param   string $status_old Order's Old Status.
+	 * @param   string $status_new Order's New Status.
+	 */
+	public function send_purchase_data_action( $order_id, $status_old = 'new', $status_new = 'pending' ) {
+
+		$this->send_purchase_data( $order_id, $status_old, $status_new );
+
+	}
+
+	/**
 	 * Send purchase data to ConvertKit for the given WooCommerce Order ID.
 	 *
 	 * @since   1.4.2
@@ -400,17 +416,17 @@ class CKWC_Order {
 		$products = array();
 		foreach ( $order->get_items() as $item_key => $item ) {
 			// If this Order Item's Product could not be found, skip it.
-			if ( ! $item->get_product() ) { // @phpstan-ignore-line
+			if ( ! $item->get_product() ) {
 				continue;
 			}
 
 			// Add Product to array of Products.
 			$products[] = array(
-				'pid'        => $item->get_product()->get_id(), // @phpstan-ignore-line
+				'pid'        => $item->get_product()->get_id(),
 				'lid'        => $item_key,
 				'name'       => $item->get_name(),
-				'sku'        => $item->get_product()->get_sku(), // @phpstan-ignore-line
-				'unit_price' => $item->get_product()->get_price(), // @phpstan-ignore-line
+				'sku'        => $item->get_product()->get_sku(),
+				'unit_price' => $item->get_product()->get_price(),
 				'quantity'   => $item->get_quantity(),
 			);
 		}

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -22,7 +22,7 @@ class WP_CKWC {
 	 *
 	 * @var     object
 	 */
-	public static $instance;
+	private static $instance;
 
 	/**
 	 * Holds singleton initialized classes that include
@@ -167,7 +167,10 @@ class WP_CKWC {
 	 */
 	public function load_language_files() {
 
-		load_plugin_textdomain( 'woocommerce-convertkit', false, basename( dirname( CKWC_PLUGIN_FILE ) ) . '/languages/' ); // @phpstan-ignore-line
+		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit
+		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit-for-woocommerce/,
+		// it will be used instead of the .mo file in convertkit-for-woocommerce/languages.
+		load_plugin_textdomain( 'woocommerce-convertkit', false, 'convertkit-for-woocommerce/languages' );
 
 	}
 
@@ -224,7 +227,7 @@ class WP_CKWC {
 	 */
 	public static function get_instance() {
 
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) { // @phpstan-ignore-line
+		if ( null === self::$instance ) {
 			self::$instance = new self();
 		}
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -29,3 +29,4 @@ parameters:
     # so they're false positives.
     ignoreErrors:
         - '#Constant WP_PLUGIN_DIR not found.#'
+        - '#Call to an undefined method WC_Order_Item::get_product\(\).#'

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -29,3 +29,4 @@ parameters:
     # so they're false positives.
     ignoreErrors:
         - '#Constant WP_PLUGIN_DIR not found.#'
+        - '#Call to an undefined method WC_Order_Item::get_product\(\).#'

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -79,16 +79,13 @@ function WP_CKWC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionNa
  * Main function to return the WooCommerce Integration class.
  *
  * @since   1.0.0
+ * 
+ * @return  bool|CKWC_Integration
  */
 function WP_CKWC_Integration() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 
 	// Bail if WooCommerce isn't active.
 	if ( ! function_exists( 'WC' ) ) {
-		return false;
-	}
-
-	// Bail if integrations is null.
-	if ( is_null( WC()->integrations ) ) { // @phpstan-ignore-line
 		return false;
 	}
 

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -79,7 +79,7 @@ function WP_CKWC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionNa
  * Main function to return the WooCommerce Integration class.
  *
  * @since   1.0.0
- * 
+ *
  * @return  bool|CKWC_Integration
  */
 function WP_CKWC_Integration() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName


### PR DESCRIPTION
## Summary

Removes most of the remaining PHPStan ignore directives in our code by making the applicable improvements to pass PHPStan static analysis.

Two exclusions remaining:
- `Call to an undefined method WC_Order_Item::get_product()`: PHPStan assumes that a WooCommerce's order item is derived from the `WC_Order_Item` class, when it's derived from the `WC_Order_Item_Product` class, which supports the `get_product()` method.
- `add_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) )`: WooCommerce's `process_admin_options()` function incorrectly returns data, when WordPress actions should not return data. PHPStan correctly detects this, but we can't control WooCommerce's code here.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)