### PR TITLE
Upgrade to WordPress Coding Standards v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,8 @@
         "codeception/module-filesystem": "^1.0",                                   
         "codeception/module-cli": "^1.0",                                          
         "codeception/util-universalframework": "^1.0",
-        "squizlabs/php_codesniffer": "3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-        "wp-coding-standards/wpcs": "*",
-        "phpstan/phpstan": "^1.4",
+        "wp-coding-standards/wpcs": "^3.0.0",
+        "phpstan/phpstan": "^1.7",
         "szepeviktor/phpstan-wordpress": "^1.0"
     },
     "minimum-stability": "dev",

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -113,12 +113,10 @@ class CKWC_Checkout {
 		// If no opt in checkbox is displayed, opt in.
 		if ( ! $this->integration->get_option_bool( 'display_opt_in' ) ) {
 			$opt_in = 'yes';
-		} else {
+		} elseif ( isset( $_POST['ckwc_opt_in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Opt in checkbox is displayed at checkout.
 			// Opt in if it is checked.
-			if ( isset( $_POST['ckwc_opt_in'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$opt_in = 'yes';
-			}
+			$opt_in = 'yes';
 		}
 
 		// Update Order Post Meta.

--- a/phpcs.tests.xml
+++ b/phpcs.tests.xml
@@ -2,6 +2,13 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
     <description>Coding Standards for Tests</description>
 
+    <!-- Inspect files in the /tests folder -->
+    <file>tests</file>
+
+    <!-- Run in verbose mode and specify the precise rule that failed in output -->
+    <arg value="sv"/>
+    <arg name="colors"/>
+
     <!-- Check that code meets WordPress-Extra standards. -->
     <rule ref="WordPress-Extra">
         <!-- Don't use yoda conditions -->
@@ -15,26 +22,28 @@
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceAfterOpenParenthesis" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.ExtraSpaceAfterCloseParenthesis" />
         <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingAfterOpen" />
+        <exclude name="Squiz.Functions.FunctionDeclarationArgumentSpacing.SpacingBeforeClose" />
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
         <exclude name="Generic.Classes.OpeningBraceSameLine.BraceOnNewLine" />
         <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
         <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction" />
 
         <!-- _before() and _passed() must use underscores in Codeception -->
         <exclude name="PSR2.Methods.MethodDeclaration.Underscore" />
 
         <!-- Permit [] instead of array() -->
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
-        
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />
+
         <!-- We might use some datetime functions for tests -->
         <exclude name="WordPress.DateTime.RestrictedFunctions" />
 
         <!-- Handles false positives where Coding Standards thinks we did something wrong when we're just checking for e.g. a stylesheet -->
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.PHP.DiscouragedPHPFunctions" />
-        <exclude name="WordPress.WP.CapitalPDangit.Misspelled" />
+        <exclude name="WordPress.WP.CapitalPDangit.MisspelledInText" />
     </rule>
 
     <!-- Check that code is documented to WordPress Standards. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -29,6 +29,8 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
+		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
 
 	<!-- Check that code is documented to WordPress Standards. -->

--- a/resources/backend/js/bulk-edit.js
+++ b/resources/backend/js/bulk-edit.js
@@ -14,7 +14,7 @@
  * @since 	1.4.8
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Move Bulk Edit fields from footer into the hidden bulk-edit table row,
 		// if a bulk-edit table row exists (it won't exist if searching returns no pages).

--- a/resources/backend/js/integration.js
+++ b/resources/backend/js/integration.js
@@ -19,7 +19,7 @@ var ckwcSettings = {
  * @since 	1.4.2
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		// Bail if we're not viewing the Integration Settings,
 		// which can be determined by WooCommerce's hidden input field 'section'.
@@ -40,7 +40,7 @@ jQuery( document ).ready(
 		// Update settings and refresh UI when a setting is changed.
 		$( 'input[type=checkbox]' ).on(
 			'change',
-			function() {
+			function () {
 
 				ckwcSettings[ $( this ).attr( 'id' ).replace( 'woocommerce_ckwc_', '' ) ] = $( this ).prop( 'checked' );
 
@@ -77,11 +77,11 @@ jQuery( document ).ready(
  */
 function ckwcRefreshUI() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Show all rows.
 		$( 'table.form-table tr' ).each(
-			function() {
+			function () {
 				$( this ).show();
 			}
 		);
@@ -90,7 +90,7 @@ function ckwcRefreshUI() {
 		for ( let setting in ckwcSettings ) {
 			if ( ! ckwcSettings[ setting ] ) {
 				$( 'table.form-table tr' ).each(
-					function() {
+					function () {
 						// Skip if this table row is for the setting we've just checked/unchecked.
 						if ( $( '[id="woocommerce_ckwc_' + setting + '"]', $( this ) ).length > 0 ) {
 							return;

--- a/resources/backend/js/quick-edit.js
+++ b/resources/backend/js/quick-edit.js
@@ -16,12 +16,12 @@
  * @since 	1.4.8
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		var ckwcInlineEditPost = inlineEditPost.edit;
 
 		// Extend WordPress' quick edit function.
-		inlineEditPost.edit = function( id ) {
+		inlineEditPost.edit = function ( id ) {
 
 			// Merge arguments from original function.
 			ckwcInlineEditPost.apply( this, arguments );
@@ -39,7 +39,7 @@ jQuery( document ).ready(
 
 			// Iterate through any ConvertKit inline data, assigning values to Quick Edit fields.
 			$( '.ckwc', $( '#inline_' + id ) ).each(
-				function() {
+				function () {
 
 					// Assign the setting's value to the setting's Quick Edit field.
 					$( '#ckwc-quick-edit select[name="' + $( this ).data( 'setting' ) + '"]' ).val( $( this ).data( 'value' ) );

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -11,11 +11,11 @@
  * @since 	1.4.8
  */
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		$( 'button.ckwc-refresh-resources' ).on(
 			'click',
-			function( e ) {
+			function ( e ) {
 
 				e.preventDefault();
 
@@ -61,7 +61,7 @@ jQuery( document ).ready(
 
 							// Remove existing select options.
 							$( 'option', $( field ) ).each(
-								function() {
+								function () {
 									// Skip if data-preserve-on-refresh is specified, as this means we want to keep this specific option.
 									// This will be present on the 'None' and 'Default' options.
 									if ( typeof $( this ).data( 'preserve-on-refresh' ) !== 'undefined' ) {
@@ -79,7 +79,7 @@ jQuery( document ).ready(
 								// resource = forms, sequences, tags.
 								// resoruces = array of resources.
 								resources.forEach(
-									function( item ) {
+									function ( item ) {
 										var value = $( 'optgroup#ckwc-' + resource, $( field ) ).data( 'option-value-prefix' ) + item.id;
 										$( 'optgroup#ckwc-' + resource, $( field ) ).append(
 											new Option(
@@ -131,7 +131,7 @@ jQuery( document ).ready(
  */
 function ckwcRefreshResourcesRemoveNotices() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$( 'div.ckwc-error' ).remove();
 
@@ -149,7 +149,7 @@ function ckwcRefreshResourcesRemoveNotices() {
  */
 function ckwcRefreshResourcesOutputErrorNotice( message ) {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		// Show a WordPress style error notice.
 		$( 'hr.wp-header-end' ).after( '<div id="message" class="error ckwc-error notice is-dismissible"><p>' + message + '</p></div>' );

--- a/resources/backend/js/select2.js
+++ b/resources/backend/js/select2.js
@@ -14,7 +14,7 @@
  */
 function ckwcSelect2Init() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$( '.ckwc-select2' ).select2();
 
@@ -23,7 +23,7 @@ function ckwcSelect2Init() {
 }
 
 jQuery( document ).ready(
-	function( $ ) {
+	function ( $ ) {
 
 		ckwcSelect2Init();
 

--- a/resources/backend/js/sync-past-orders.js
+++ b/resources/backend/js/sync-past-orders.js
@@ -13,7 +13,7 @@
  */
 function ckwcSyncPastOrders() {
 
-	( function( $ ) {
+	( function ( $ ) {
 
 		$( '#progress-bar' ).synchronous_request(
 			{

--- a/resources/backend/js/synchronous-ajax.js
+++ b/resources/backend/js/synchronous-ajax.js
@@ -17,14 +17,14 @@
  * @author ConvertKit
  */
 
-( function( $ ) {
+( function ( $ ) {
 
 	/**
 	 * Init Synchronous Request
 	 *
 	 * @param object options Override Default Settings
 	 */
-	$.fn.synchronous_request = function( options ) {
+	$.fn.synchronous_request = function ( options ) {
 
 		// Default Settings.
 		var settings = $.extend(
@@ -55,7 +55,7 @@
 				 * @param   object  response        Response
 				 * @param   int     currentIndex    Current Index
 				 */
-				onRequestSuccess: function( response, currentIndex ) {
+				onRequestSuccess: function ( response, currentIndex ) {
 
 					// Maybe reset log if it's more than 100 lines, for UI performance.
 					this.maybeResetLog();
@@ -102,7 +102,7 @@
 				 *
 				 * @since   1.4.3
 				 */
-				onRequestError: function( xhr, textStatus, e, currentIndex ) {
+				onRequestError: function ( xhr, textStatus, e, currentIndex ) {
 
 					// If the log exceeds 100 items, reset it.
 					if ( $( '#log ul li' ).length >= 100 ) {
@@ -127,7 +127,7 @@
 				 *
 				 * @since   1.4.3
 				 */
-				onFinished: function() {
+				onFinished: function () {
 
 					if ( this.cancelled ) {
 						$( 'ul', $( this.log ) ).append( '<li class="success">Process cancelled by user.</li>' );
@@ -146,7 +146,7 @@
 				 *
 				 * @since 	1.4.3
 				 */
-				maybeResetLog: function() {
+				maybeResetLog: function () {
 
 					// If the log exceeds 100 items, reset it.
 					if ( $( 'ul li', $( this.log ) ).length >= 100 ) {
@@ -170,7 +170,7 @@
 
 			$( settings.cancel_button ).on(
 				'click',
-				function( e ) {
+				function ( e ) {
 
 					e.preventDefault();
 					settings.cancelled = true;
@@ -220,7 +220,7 @@
 					id: 			settings.ids[ currentIndex ],
 					current_index: 	currentIndex
 				},
-				success: function( response ) {
+				success: function ( response ) {
 
 					// Call onRequestSuccess closure.
 					var cancelled = settings.onRequestSuccess( response, currentIndex );
@@ -253,7 +253,7 @@
 					// next request.
 					if ( ! response.success ) {
 						setTimeout(
-							function() {
+							function () {
 								// Start next request.
 								synchronousAjaxRequest( settings, currentIndex, progressbar, progressCounter );
 								return;
@@ -267,7 +267,7 @@
 					}
 
 				},
-				error: function(xhr, textStatus, e) {
+				error: function (xhr, textStatus, e) {
 
 					// Call closure.
 					var cancelled = settings.onRequestError( xhr, textStatus, e, currentIndex );
@@ -292,7 +292,7 @@
 
 					// Wait the required period of time before sending the next request.
 					setTimeout(
-						function() {
+						function () {
 							// Start next request.
 							synchronousAjaxRequest( settings, currentIndex, progressbar, progressCounter );
 							return;

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -105,8 +105,7 @@ class Plugin extends \Codeception\Module
 		$mapCustomFields = false,
 		$displayOptIn = false,
 		$sendPurchaseDataEvent = false
-	)
-	{
+	) {
 		// Define Plugin's settings.
 		$I->haveOptionInDatabase(
 			'woocommerce_ckwc_settings',

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -133,8 +133,7 @@ class WooCommerce extends \Codeception\Module
 		$customFields = false,
 		$nameFormat = 'first',
 		$couponFormTagSequence = false
-	)
-	{
+	) {
 		// Setup ConvertKit for WooCommerce Plugin.
 		$I->setupConvertKitPlugin(
 			$I,

--- a/tests/acceptance/settings/SettingOptInCheckboxCest.php
+++ b/tests/acceptance/settings/SettingOptInCheckboxCest.php
@@ -94,7 +94,6 @@ class SettingOptInCheckboxCest
 
 		// Confirm that the label is the default value.
 		$I->seeInSource('I want to subscribe to the newsletter');
-
 	}
 
 	/**

--- a/tests/acceptance/settings/SettingSubscribeEventCest.php
+++ b/tests/acceptance/settings/SettingSubscribeEventCest.php
@@ -50,7 +50,6 @@ class SettingSubscribeEventCest
 
 		// Confirm the setting saved.
 		$I->seeOptionIsSelected('#woocommerce_ckwc_event', 'Order Pending payment');
-
 	}
 	/**
 	 * Test that the Order Processing option is saved when selected at

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -346,7 +346,6 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
 		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
-
 	}
 
 	/**

--- a/views/backend/post-type/disabled.php
+++ b/views/backend/post-type/disabled.php
@@ -10,7 +10,7 @@
 
 <p>
 	<?php
-	echo sprintf(
+	printf(
 		/* translators: %1$s: Post Type Singular Name, %2$s: Link to Integration Settings */
 		esc_html__( 'To configure the ConvertKit form, tag or sequence to subscribe customers to who use this %1$s, %2$s and enter a valid API Key and API Secret.', 'woocommerce-convertkit' ),
 		esc_attr( $post_type->labels->singular_name ),

--- a/views/backend/settings/sync-past-orders-button.php
+++ b/views/backend/settings/sync-past-orders-button.php
@@ -14,7 +14,7 @@
 			<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
 			<a href="<?php echo esc_attr( $data['url'] ); ?>" id="ckwc_sync_past_orders" class="button button-secondary <?php echo esc_attr( $data['class'] ); ?>">
 				<?php
-				echo sprintf(
+				printf(
 					/* translators: number of orders not sent to ConvertKit */
 					esc_html( _n( 'Sync %s past order', 'Sync %s past orders', count( $unsynced_order_ids ), 'woocommerce-convertkit' ) ),
 					esc_html( number_format_i18n( count( $unsynced_order_ids ) ) )


### PR DESCRIPTION
## Summary

Applies changes per the upgrade guide [here](https://github.com/WordPress/WordPress-Coding-Standards/wiki/Upgrade-Guide-to-WordPressCS-3.0.0-for-Developers-of-external-standards), to support `3.0.0` of the WordPress Coding Standards rulesets, released August 21st.

This covers:
- Using `printf` instead of `echo sprintf`
- Spacing for anonymous functions
- Renaming some exclusion rules as they have been renamed in WordPress Coding Standards `3.0.0`

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)