### PR TITLE
Tests: Downgrade `php-webdriver` to `1.14.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "codeception/util-universalframework": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.7",
+        "php-webdriver/webdriver": "<=1.14.0",
         "szepeviktor/phpstan-wordpress": "^1.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
## Summary

`php-webdriver` `1.15.0` [changes the capability key](https://github.com/php-webdriver/php-webdriver/commit/235c2aa07f9e2686f2b876083fc081b00d330d48) that is read to define chromedriver's options when running tests.

This isn't reflected in `wp-browser`, meaning the `chromeOptions` specified aren't honored, resulting in tests failing:
https://github.com/ConvertKit/convertkit-wordpress/blob/plugin-tools-download-log-test/tests/acceptance.suite.yml#L91

![Screenshot 2023-08-30 at 14 01 34](https://github.com/ConvertKit/convertkit-woocommerce/assets/1462305/ade16a5d-ed52-49ce-937a-2307dc54c91c)

Changing `chromeOptions` to match the capability key doesn't resolve, so downgrading the test library for now until this is fixed upstream.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)