### PR TITLE
Updated WordPress Libraries to 1.3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "1.3.8"
+        "convertkit/convertkit-wordpress-libraries": "1.3.9"
     },
     "require-dev": {
         "lucatume/wp-browser": "^3.0",

--- a/includes/class-ckwc-api.php
+++ b/includes/class-ckwc-api.php
@@ -58,38 +58,51 @@ class CKWC_API extends ConvertKit_API {
 		// WordPress requires that the text domain be a string (e.g. 'woocommerce-convertkit') and not a variable,
 		// otherwise localization won't work.
 		$this->error_messages = array(
-			'form_subscribe_form_id_empty'                => __( 'form_subscribe(): the form_id parameter is empty.', 'woocommerce-convertkit' ),
-			'form_subscribe_email_empty'                  => __( 'form_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'form_subscribe_form_id_empty'                 => __( 'form_subscribe(): the form_id parameter is empty.', 'woocommerce-convertkit' ),
+			'form_subscribe_email_empty'                   => __( 'form_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
 
-			'sequence_subscribe_sequence_id_empty'        => __( 'sequence_subscribe(): the sequence_id parameter is empty.', 'woocommerce-convertkit' ),
-			'sequence_subscribe_email_empty'              => __( 'sequence_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'sequence_subscribe_sequence_id_empty'         => __( 'sequence_subscribe(): the sequence_id parameter is empty.', 'woocommerce-convertkit' ),
+			'sequence_subscribe_email_empty'               => __( 'sequence_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
 
-			'tag_subscribe_tag_id_empty'                  => __( 'tag_subscribe(): the tag_id parameter is empty.', 'woocommerce-convertkit' ),
-			'tag_subscribe_email_empty'                   => __( 'tag_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'tag_subscribe_tag_id_empty'                   => __( 'tag_subscribe(): the tag_id parameter is empty.', 'woocommerce-convertkit' ),
+			'tag_subscribe_email_empty'                    => __( 'tag_subscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
 
-			'get_subscriber_by_email_email_empty'         => __( 'get_subscriber_by_email(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'get_subscriber_by_email_email_empty'          => __( 'get_subscriber_by_email(): the email parameter is empty.', 'woocommerce-convertkit' ),
 			/* translators: Email Address */
-			'get_subscriber_by_email_none'                => __( 'No subscriber(s) exist in ConvertKit matching the email address %s.', 'woocommerce-convertkit' ),
+			'get_subscriber_by_email_none'                 => __( 'No subscriber(s) exist in ConvertKit matching the email address %s.', 'woocommerce-convertkit' ),
 
-			'get_subscriber_by_id_subscriber_id_empty'    => __( 'get_subscriber_by_id(): the subscriber_id parameter is empty.', 'woocommerce-convertkit' ),
+			'get_subscriber_by_id_subscriber_id_empty'     => __( 'get_subscriber_by_id(): the subscriber_id parameter is empty.', 'woocommerce-convertkit' ),
 
-			'get_subscriber_tags_subscriber_id_empty'     => __( 'get_subscriber_tags(): the subscriber_id parameter is empty.', 'woocommerce-convertkit' ),
+			'get_subscriber_tags_subscriber_id_empty'      => __( 'get_subscriber_tags(): the subscriber_id parameter is empty.', 'woocommerce-convertkit' ),
 
-			'unsubscribe_email_empty'                     => __( 'unsubscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'unsubscribe_email_empty'                      => __( 'unsubscribe(): the email parameter is empty.', 'woocommerce-convertkit' ),
+
+			'broadcast_delete_broadcast_id_empty'          => __( 'broadcast_delete(): the broadcast_id parameter is empty.', 'woocommerce-convertkit' ),
 
 			'get_all_posts_posts_per_request_bound_too_low' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or greater than 1.', 'woocommerce-convertkit' ),
 			'get_all_posts_posts_per_request_bound_too_high' => __( 'get_all_posts(): the posts_per_request parameter must be equal to or less than 50.', 'woocommerce-convertkit' ),
 
-			'get_posts_page_parameter_bound_too_low'      => __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'woocommerce-convertkit' ),
-			'get_posts_per_page_parameter_bound_too_low'  => __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'woocommerce-convertkit' ),
-			'get_posts_per_page_parameter_bound_too_high' => __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'woocommerce-convertkit' ),
+			'get_posts_page_parameter_bound_too_low'       => __( 'get_posts(): the page parameter must be equal to or greater than 1.', 'woocommerce-convertkit' ),
+			'get_posts_per_page_parameter_bound_too_low'   => __( 'get_posts(): the per_page parameter must be equal to or greater than 1.', 'woocommerce-convertkit' ),
+			'get_posts_per_page_parameter_bound_too_high'  => __( 'get_posts(): the per_page parameter must be equal to or less than 50.', 'woocommerce-convertkit' ),
+
+			'subscriber_authentication_send_code_email_empty' => __( 'subscriber_authentication_send_code(): the email parameter is empty.', 'woocommerce-convertkit' ),
+			'subscriber_authentication_send_code_redirect_url_empty' => __( 'subscriber_authentication_send_code(): the redirect_url parameter is empty.', 'woocommerce-convertkit' ),
+			'subscriber_authentication_send_code_redirect_url_invalid' => __( 'subscriber_authentication_send_code(): the redirect_url parameter is not a valid URL.', 'woocommerce-convertkit' ),
+			'subscriber_authentication_send_code_response_token_missing' => __( 'subscriber_authentication_send_code(): the token parameter is missing from the API response.', 'woocommerce-convertkit' ),
+
+			'subscriber_authentication_verify_token_empty' => __( 'subscriber_authentication_verify(): the token parameter is empty.', 'woocommerce-convertkit' ),
+			'subscriber_authentication_verify_subscriber_code_empty' => __( 'subscriber_authentication_verify(): the subscriber_code parameter is empty.', 'woocommerce-convertkit' ),
+			'subscriber_authentication_verify_response_error' => __( 'The entered code is invalid. Please try again, or click the link sent in the email.', 'woocommerce-convertkit' ),
+
+			'profiles_signed_subscriber_id_empty'          => __( 'profiles(): the signed_subscriber_id parameter is empty.', 'woocommerce-convertkit' ),
 
 			/* translators: HTTP method */
-			'request_method_unsupported'                  => __( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
-			'request_rate_limit_exceeded'                 => __( 'ConvertKit API Error: Rate limit hit.', 'woocommerce-convertkit' ),
-			'request_internal_server_error'               => __( 'ConvertKit API Error: Internal server error.', 'woocommerce-convertkit' ),
-			'request_bad_gateway'                         => __( 'ConvertKit API Error: Bad gateway.', 'woocommerce-convertkit' ),
-			'response_type_unexpected'                    => __( 'ConvertKit API Error: The response is not of the expected type array.', 'woocommerce-convertkit' ),
+			'request_method_unsupported'                   => __( 'API request method %s is not supported in ConvertKit_API class.', 'woocommerce-convertkit' ),
+			'request_rate_limit_exceeded'                  => __( 'ConvertKit API Error: Rate limit hit.', 'woocommerce-convertkit' ),
+			'request_internal_server_error'                => __( 'ConvertKit API Error: Internal server error.', 'woocommerce-convertkit' ),
+			'request_bad_gateway'                          => __( 'ConvertKit API Error: Bad gateway.', 'woocommerce-convertkit' ),
+			'response_type_unexpected'                     => __( 'ConvertKit API Error: The response is not of the expected type array.', 'woocommerce-convertkit' ),
 		);
 
 	}


### PR DESCRIPTION
## Summary

Updates WordPress Libraries to [1.3.9](https://github.com/ConvertKit/convertkit-wordpress-libraries/releases/tag/1.3.9)

Updates localized API error messages.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)