### PR TITLE
PHPStan: Remove `WP_PLUGIN_DIR` ignoreErrors directive

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,5 +28,4 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Constant WP_PLUGIN_DIR not found.#'
         - '#Call to an undefined method WC_Order_Item::get_product\(\).#'

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -28,5 +28,4 @@ parameters:
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
-        - '#Constant WP_PLUGIN_DIR not found.#'
         - '#Call to an undefined method WC_Order_Item::get_product\(\).#'

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -21,7 +21,7 @@ class WooCommerceSubscriptionsSubscribeEventCest
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
 		// Activate WooCommerce Subscriptions Plugin.
-		$I->activateThirdPartyPlugin($I, 'woocommerce-subscriptions');
+		$I->activateThirdPartyPlugin($I, 'woo-subscriptions');
 
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
@@ -131,7 +131,7 @@ class WooCommerceSubscriptionsSubscribeEventCest
 	public function _passed(AcceptanceTester $I)
 	{
 		$I->deactivateWooCommerceAndConvertKitPlugins($I);
-		$I->deactivateThirdPartyPlugin($I, 'woocommerce-subscriptions');
+		$I->deactivateThirdPartyPlugin($I, 'woo-subscriptions');
 		$I->resetConvertKitPlugin($I);
 	}
 }


### PR DESCRIPTION
## Summary

For static analysis, removes the `WP_PLUGIN_DIR` ignoreErrors directive, as `phpstan-wordpress` no longer requires this in `1.3.1` and higher.

![Screenshot 2023-10-19 at 14 41 48](https://github.com/ConvertKit/convertkit-woocommerce/assets/1462305/18d28040-4424-45e3-bc9a-c03b928dc243)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)