### PR TITLE
Tests: Refactor `wooCommerceCreateProductAndCheckoutWithConfig` method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '8.0' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.0' ] #[ '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -59,18 +59,6 @@ class Plugin extends \Codeception\Module
 		// Flush Permalinks by visiting Settings > Permalinks, so that newly registered Post Types e.g.
 		// WooCommerce Products work.
 		$I->amOnAdminPage('options-permalink.php');
-
-		// Create Checkout Page using checkout shortcode, not block.
-		$pageID = $I->havePageInDatabase(
-			[
-				'post_title'   => 'Checkout',
-				'post_content' => '[woocommerce_checkout]',
-			]
-		);
-
-		// Configure WooCommerce to use this Page as the Checkout Page.
-		$I->dontHaveOptionInDatabase('woocommerce_checkout_page_id');
-		$I->haveOptionInDatabase('woocommerce_checkout_page_id', $pageID);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -59,6 +59,9 @@ class Plugin extends \Codeception\Module
 		// Flush Permalinks by visiting Settings > Permalinks, so that newly registered Post Types e.g.
 		// WooCommerce Products work.
 		$I->amOnAdminPage('options-permalink.php');
+
+		// Create Checkout Page using checkout shortcode, not block.
+		$I->enableWooCommerceLegacyCheckoutShortcode($I);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -246,8 +246,8 @@ class WooCommerce extends \Codeception\Module
 		}
 
 		// Handle Opt-In Checkbox.
-		if ($displayOptIn) {
-			if ($checkOptIn) {
+		if ($options['display_opt_in']) {
+			if ($options['check_opt_in']) {
 				$I->checkOption('#ckwc_opt_in');
 			} else {
 				$I->uncheckOption('#ckwc_opt_in');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -146,7 +146,6 @@ class WooCommerce extends \Codeception\Module
 	 *     @type string $custom_fields              Map WooCommerce fields to ConvertKit Custom Fields.
 	 *     @type string $name_format                Name format.
 	 *     @type string $coupon_form_tag_sequence   Coupon Setting for Form, Tag or Sequence to subscribe the Customer to.
-	 *     @type string $use_legacy_checkout        Use the legacy WooCommerce Checkout Shortcode.
 	 * }
 	 */
 	public function wooCommerceCreateProductAndCheckoutWithConfig($I, $options = false)
@@ -163,7 +162,6 @@ class WooCommerce extends \Codeception\Module
 			'custom_fields'             => false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
-			'use_legacy_checkout'       => true,
 		];
 
 		// If supplied options are an array, merge them with the defaults.
@@ -185,11 +183,6 @@ class WooCommerce extends \Codeception\Module
 			$options['display_opt_in'],
 			( ( $options['send_purchase_data'] === true ) ? 'processing' : $options['send_purchase_data'] )
 		);
-
-		// If the test needs to run against the legacy Checkout shortcode, enable it now.
-		if ($options['use_legacy_checkout']) {
-			$I->enableWooCommerceLegacyCheckoutShortcode($I);
-		}
 
 		// Create Product.
 		switch ($options['product_type']) {

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -242,7 +242,8 @@ class WooCommerce extends \Codeception\Module
 			$I->waitForElementVisible('input#coupon_code');
 			$I->fillField('input#coupon_code', '20off');
 			$I->click('Apply coupon');
-			$I->waitForText('Coupon code applied successfully.', 5, '.woocommerce-message');
+
+			$I->waitForText('Coupon code applied successfully.', 5, '.is-success');
 		}
 
 		// Handle Opt-In Checkbox.
@@ -267,13 +268,13 @@ class WooCommerce extends \Codeception\Module
 		$I->waitForElement('body.woocommerce-order-received');
 		$I->seeInSource('Order');
 		$I->seeInSource('received');
-		$I->seeInSource('<h2 class="woocommerce-order-details__title">Order details</h2>');
+		$I->seeInSource('Order details</h3>');
 
 		// Return data.
 		return [
 			'email_address'   => $emailAddress,
 			'product_id'      => $productID,
-			'order_id'        => $I->grabTextFrom('.woocommerce-order-overview__order strong'),
+			'order_id'        => $I->grabTextFrom('ul.wc-block-order-confirmation-summary-list li:first-child span.wc-block-order-confirmation-summary-list-item__value'),
 			'subscription_id' => ( ( $productType === 'subscription' ) ? (int) filter_var($I->grabTextFrom('.woocommerce-orders-table__cell-order-number a'), FILTER_SANITIZE_NUMBER_INT) : 0 ),
 		];
 	}

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -275,7 +275,7 @@ class WooCommerce extends \Codeception\Module
 			'email_address'   => $emailAddress,
 			'product_id'      => $productID,
 			'order_id'        => $I->grabTextFrom('ul.wc-block-order-confirmation-summary-list li:first-child span.wc-block-order-confirmation-summary-list-item__value'),
-			'subscription_id' => ( ( $productType === 'subscription' ) ? (int) filter_var($I->grabTextFrom('.woocommerce-orders-table__cell-order-number a'), FILTER_SANITIZE_NUMBER_INT) : 0 ),
+			'subscription_id' => ( ( $options['product_type'] === 'subscription' ) ? (int) filter_var($I->grabTextFrom('.woocommerce-orders-table__cell-order-number a'), FILTER_SANITIZE_NUMBER_INT) : 0 ),
 		];
 	}
 

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -557,7 +557,7 @@ class WooCommerce extends \Codeception\Module
 		$I->click('button[name=add-to-cart]');
 
 		// View Cart.
-		$I->click('.woocommerce-message a.button.wc-forward');
+		$I->click('a.wc-forward');
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -566,7 +566,7 @@ class WooCommerce extends \Codeception\Module
 		$I->seeInSource($productName);
 
 		// Proceed to Checkout.
-		$I->click('a.checkout-button');
+		$I->click('Proceed to Checkout');
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -178,7 +178,7 @@ class WooCommerce extends \Codeception\Module
 			$I,
 			$_ENV['CONVERTKIT_API_KEY'],
 			$_ENV['CONVERTKIT_API_SECRET'],
-			$options['subscription_Event'],
+			$options['subscription_event'],
 			$options['plugin_form_tag_sequence'],
 			$options['name_format'],
 			$options['custom_fields'],

--- a/tests/acceptance/general/ReviewRequestCest.php
+++ b/tests/acceptance/general/ReviewRequestCest.php
@@ -41,11 +41,12 @@ class ReviewRequestCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Check that the options table does have a review request set.
@@ -71,11 +72,11 @@ class ReviewRequestCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			$_ENV['CONVERTKIT_API_FORM_NAME'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'           => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Check that the options table does not have a review request set.
@@ -101,12 +102,9 @@ class ReviewRequestCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			true // Send purchase data to ConvertKit.
+			[
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Check that the options table does have a review request set.

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -49,6 +49,7 @@ class WooCommerceSubscriptionsSubscribeEventCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
+				'product_type'             => 'subscription',
 				'display_opt_in'           => true,
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -48,11 +48,12 @@ class WooCommerceSubscriptionsSubscribeEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'subscription', // Subscription Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+			]
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -99,11 +100,12 @@ class WooCommerceSubscriptionsSubscribeEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -51,12 +51,9 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			true // Send purchase data to ConvertKit.
+			[
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Confirm that the purchase was added to ConvertKit.
@@ -79,10 +76,7 @@ class PurchaseDataCest
 	public function testDontSendPurchaseDataWithSimpleProductCheckout(AcceptanceTester $I)
 	{
 		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Confirm that the purchase was not added to ConvertKit.
 		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
@@ -106,12 +100,10 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'virtual', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			true // Send purchase data to ConvertKit.
+			[
+				'product_type'       => 'virtual',
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Confirm that the purchase was added to ConvertKit.
@@ -136,7 +128,9 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'virtual' // Simple Product.
+			[
+				'product_type' => 'virtual',
+			]
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -161,12 +155,10 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'zero', // Zero value Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			true // Send purchase data to ConvertKit.
+			[
+				'product_type'       => 'zero',
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Confirm that the purchase was added to ConvertKit.
@@ -191,7 +183,9 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'zero' // Zero value Simple Product.
+			[
+				'product_type' => 'zero',
+			]
 		);
 
 		// Confirm that the purchase was added to ConvertKit.
@@ -530,10 +524,7 @@ class PurchaseDataCest
 	public function testDontSendPurchaseDataWithSimpleProductCODManualOrder(AcceptanceTester $I)
 	{
 		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
@@ -613,10 +604,7 @@ class PurchaseDataCest
 	public function testDontSendPurchaseDataWithVirtualProductCODManualOrder(AcceptanceTester $I)
 	{
 		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateVirtualProduct($I);
@@ -696,10 +684,7 @@ class PurchaseDataCest
 	public function testDontSendPurchaseDataWithZeroValueProductCODManualOrder(AcceptanceTester $I)
 	{
 		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Create Product for this test.
 		$productID = $I->wooCommerceCreateZeroValueProduct($I);
@@ -737,12 +722,9 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			'completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
+			[
+				'send_purchase_data' => 'completed',
+			]
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -778,12 +760,9 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Subscribe Event.
-			'completed' // Send purchase data to ConvertKit when the Order status = Order Completed.
+			[
+				'send_purchase_data' => 'completed',
+			]
 		);
 
 		// Confirm that the purchase was not added to ConvertKit.
@@ -815,16 +794,12 @@ class PurchaseDataCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			true, // Send purchase data to ConvertKit.
-			false, // Don't define product level form, tag or sequence to subscribe to.
-			false, // Don't map custom fields.
-			'both', // Name format.
-			false // Don't define coupon level form, tag or sequence to subscribe to.
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'send_purchase_data'       => true,
+				'name_format'              => 'both',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/settings/SettingNameFormatCest.php
+++ b/tests/acceptance/settings/SettingNameFormatCest.php
@@ -54,16 +54,12 @@ class SettingNameFormatCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define product level form, tag or sequence to subscribe to.
-			false, // Don't map custom fields.
-			'first', // Name format.
-			false // Don't define coupon level form, tag or sequence to subscribe to.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -102,16 +98,13 @@ class SettingNameFormatCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define product level form, tag or sequence to subscribe to.
-			false, // Don't map custom fields.
-			'last', // Name format.
-			false // Don't define coupon level form, tag or sequence to subscribe to.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'name_format'              => 'last',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -150,16 +143,13 @@ class SettingNameFormatCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define product level form, tag or sequence to subscribe to.
-			false, // Don't map custom fields.
-			'both', // Name format.
-			false // Don't define coupon level form, tag or sequence to subscribe to.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'name_format'              => 'both',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -45,11 +45,12 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -81,11 +82,11 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'           => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+			]
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -116,11 +117,10 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+			]
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -153,11 +153,11 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'     => true,
+				'check_opt_in'       => true,
+				'subscription_event' => 'completed',
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -190,11 +190,10 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'display_opt_in'     => true,
+				'subscription_event' => 'completed',
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -227,14 +226,13 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'completed', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -270,14 +268,13 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
-			'completed', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'subscription_event'       => 'completed',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -313,14 +310,13 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
-			'completed', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'subscription_event'       => 'completed',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.
@@ -355,11 +351,9 @@ class SubscribeOnOrderCompletedEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'completed' // Subscribe on WooCommerce "Order Completed" event.
+			[
+				'subscription_event' => 'completed',
+			]
 		);
 
 		// Confirm that the email address wasn't yet added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -45,11 +45,12 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -75,11 +76,11 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'display_opt_in'           => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+			]
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -104,11 +105,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+			]
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -135,14 +135,13 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -172,14 +171,13 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'subscription_event'       => 'pending',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -209,14 +207,13 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
-			'pending', // Subscribe on WooCommerce "Order Pending payment" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'subscription_event'       => 'pending',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -277,11 +274,10 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'display_opt_in'     => true,
+				'subscription_event' => 'pending',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -307,11 +303,9 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'subscription_event' => 'pending',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -243,11 +243,11 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'pending' // Subscribe on WooCommerce "Order Pending payment" event.
+			[
+				'display_opt_in'     => true,
+				'check_opt_in'       => true,
+				'subscription_event' => 'pending',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -295,11 +295,10 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'     => true,
+				'subscription_event' => 'processing',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -620,11 +619,12 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -46,11 +46,12 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -83,11 +84,11 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'           => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Confirm that the email address was not added to ConvertKit.
@@ -115,11 +116,10 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+			]
 		);
 
 		// Confirm that the email address was added to ConvertKit.
@@ -153,14 +153,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -190,14 +189,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'], // Tag to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -227,14 +225,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'], // Tag to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // Don't define a Product level Form, Tag or Sequence.
-			true // Map Order data to Custom Fields.
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -264,11 +261,11 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'display_opt_in'     => true,
+				'check_opt_in'       => true,
+				'subscription_event' => 'processing',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -331,11 +328,9 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Don't select a Form to subscribe the email address to.
-			'processing' // Subscribe on WooCommerce "Order Processing" event.
+			[
+				'subscription_event' => 'processing',
+			]
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
@@ -365,13 +360,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Product level Form to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -408,13 +403,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Product level Tag to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -451,13 +446,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Product level Sequence to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -494,16 +489,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // No Product level Form, Tag or Sequence.
-			false, // No Custom Field mapping.
-			'first', // Name format.
-			'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] // Coupon level Form to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -540,16 +532,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // No Product level Form, Tag or Sequence.
-			false, // No Custom Field mapping.
-			'first', // Name format.
-			'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'] // Coupon level Tag to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
@@ -586,16 +575,13 @@ class SubscribeOnOrderProcessingEventCest
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			true, // Display Opt-In checkbox on Checkout.
-			true, // Check Opt-In checkbox on Checkout.
-			'form:' . $_ENV['CONVERTKIT_API_FORM_ID'], // Form to subscribe email address to.
-			'processing', // Subscribe on WooCommerce "Order Processing" event.
-			false, // Don't send purchase data to ConvertKit.
-			false, // No Product level Form, Tag or Sequence.
-			false, // No Custom Field mapping.
-			'first', // Name format.
-			'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] // Coupon level Sequence to subscribe email address to.
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+			]
 		);
 
 		// Confirm that the email address was now added to ConvertKit.

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -99,10 +99,7 @@ class SyncPastOrdersCest
 		$I->wooCommerceDeleteAllOrders($I);
 
 		// Create Product and Checkout for this test.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Login as the Administrator.
 		$I->loginAsAdmin();
@@ -166,12 +163,9 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Don't define a subscribe Event.
-			true // Send purchase data to ConvertKit.
+			[
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Load Settings screen.
@@ -200,10 +194,7 @@ class SyncPastOrdersCest
 
 		// Create Product and Checkout for this test, not sending the Order
 		// to ConvertKit.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Login as the Administrator.
 		$I->loginAsAdmin();
@@ -282,12 +273,9 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
-			'simple', // Simple Product.
-			false, // Don't display Opt-In checkbox on Checkout.
-			false, // Don't check Opt-In checkbox on Checkout.
-			false, // Form to subscribe email address to (not used).
-			false, // Don't define a subscribe Event.
-			true // Don't send purchase data to ConvertKit.
+			[
+				'send_purchase_data' => true,
+			]
 		);
 
 		// Extract the Post ID from the Order ID, as the Custom Order Numbers Plugin does not prefix
@@ -347,10 +335,7 @@ class SyncPastOrdersCest
 
 		// Create Product and Checkout for this test, not sending the Order
 		// to ConvertKit.
-		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
-			$I,
-			'simple' // Simple Product.
-		);
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Login as the Administrator.
 		$I->loginAsAdmin();


### PR DESCRIPTION
## Summary

Refactors the `wooCommerceCreateProductAndCheckoutWithConfig` method by accepting an array of named key/value pairs.

PHP 8's named parameters would be preferable, however with ~ 40% of API requests from this Plugin coming from PHP 7.4 and lower, tests need to be compatible with PHP 7.4 for the time being.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)