### PR TITLE
Tests for Add Opt In Checkbox Block

### DIFF
--- a/resources/backend/js/opt-in-block.js
+++ b/resources/backend/js/opt-in-block.js
@@ -70,7 +70,7 @@
 							el(
 								CheckboxControl,
 								{
-									id: 'ckwc-opt-in',
+									id: 'ckwc_opt_in',
 									checked: ( optInStatus === 'checked' ? true : false ),
 									label: optInLabel,
 									disabled: true // Required so it cannot be interacted with in the editor.

--- a/resources/frontend/js/opt-in-block.js
+++ b/resources/frontend/js/opt-in-block.js
@@ -79,7 +79,7 @@
 						el(
 							CheckboxControl,
 							{
-								id: 'ckwc-opt-in',
+								id: 'ckwc_opt_in',
 								label: optInLabel,
 								checked: checked,
 								onChange: setChecked

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -216,7 +216,6 @@ class ConvertKitAPI extends \Codeception\Module
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
 		$I->assertEquals($subscriber['fields']['billing_address'], 'First Last, Address Line 1, City, CA 12345');
-		$I->assertEquals($subscriber['fields']['shipping_address'], 'First Last, Address Line 1, City, CA 12345');
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
 	}

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -216,7 +216,7 @@ class ConvertKitAPI extends \Codeception\Module
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
 		$I->assertEquals($subscriber['fields']['billing_address'], 'First Last, Address Line 1, City, CA 12345');
-		$I->assertEquals($subscriber['fields']['shipping_address'], '');
+		$I->assertEquals($subscriber['fields']['shipping_address'], 'First Last, Address Line 1, City, CA 12345');
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
 	}

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -59,18 +59,6 @@ class Plugin extends \Codeception\Module
 		// Flush Permalinks by visiting Settings > Permalinks, so that newly registered Post Types e.g.
 		// WooCommerce Products work.
 		$I->amOnAdminPage('options-permalink.php');
-
-		// Create Checkout Page using checkout shortcode, not block.
-		$pageID = $I->havePageInDatabase(
-			[
-				'post_title'   => 'Checkout',
-				'post_content' => '[woocommerce_checkout]',
-			]
-		);
-
-		// Configure WooCommerce to use this Page as the Checkout Page.
-		$I->dontHaveOptionInDatabase('woocommerce_checkout_page_id');
-		$I->haveOptionInDatabase('woocommerce_checkout_page_id', $pageID);
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -84,6 +84,29 @@ class WooCommerce extends \Codeception\Module
 	}
 
 	/**
+	 * Helper method to setup WooCommerce's checkout page to use the
+	 * legacy [woocommerce_shortcode].
+	 * 
+	 * @since 	1.7.1
+	 *
+	 * @param   AcceptanceTester $I     AcceptanceTester.
+	 */
+	public function setupWooCommerceCheckoutShortcode($I)
+	{
+		// Create Checkout Page using checkout shortcode, not block.
+		$pageID = $I->havePageInDatabase(
+			[
+				'post_title'   => 'Checkout',
+				'post_content' => '[woocommerce_checkout]',
+			]
+		);
+
+		// Configure WooCommerce to use this Page as the Checkout Page.
+		$I->dontHaveOptionInDatabase('woocommerce_checkout_page_id');
+		$I->haveOptionInDatabase('woocommerce_checkout_page_id', $pageID);
+	}
+
+	/**
 	 * Helper method to setup the Custom Order Numbers Plugin.
 	 *
 	 * @since   1.0.0

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -86,8 +86,8 @@ class WooCommerce extends \Codeception\Module
 	/**
 	 * Helper method to setup WooCommerce's checkout page to use the
 	 * legacy [woocommerce_shortcode].
-	 * 
-	 * @since 	1.7.1
+	 *
+	 * @since   1.7.1
 	 *
 	 * @param   AcceptanceTester $I     AcceptanceTester.
 	 */
@@ -186,7 +186,7 @@ class WooCommerce extends \Codeception\Module
 			'custom_fields'             => false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
-			'use_legacy_checkout'		=> true,
+			'use_legacy_checkout'       => true,
 		];
 
 		// If supplied options are an array, merge them with the defaults.
@@ -575,7 +575,7 @@ class WooCommerce extends \Codeception\Module
 	 * @param   string           $productName    Product Name.
 	 * @param   string           $emailAddress   Email Address (wordpress@convertkit.com).
 	 * @param   string           $paymentMethod  Payment Method (cod|stripe).
-	 * @param   bool             $useLegacyCheckout Use Legacy Checkout Shortcode
+	 * @param   bool             $useLegacyCheckout Use Legacy Checkout Shortcode.
 	 */
 	public function wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress = 'wordpress@convertkit.com', $paymentMethod = 'cod', $useLegacyCheckout = true)
 	{

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -280,7 +280,7 @@ class WooCommerce extends \Codeception\Module
 			case true:
 				$I->waitForElementNotVisible('.blockOverlay');
 				$I->scrollTo('#order_review_heading');
-				$I->click('Place Order');
+				$I->click('#place_order');
 				break;
 
 			case false:

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -185,6 +185,7 @@ class WooCommerce extends \Codeception\Module
 			'custom_fields'             => false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
+			'use_legacy_checkout'		=> true,
 		];
 
 		// If supplied options are an array, merge them with the defaults.
@@ -192,6 +193,11 @@ class WooCommerce extends \Codeception\Module
 			$options = array_merge($defaults, $options);
 		} else {
 			$options = $defaults;
+		}
+
+		// If using the legacy Checkout Shortcode, enable it now.
+		if ($options['use_legacy_checkout']) {
+			$I->setupWooCommerceCheckoutShortcode($I);
 		}
 
 		// Setup ConvertKit for WooCommerce Plugin.

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -276,9 +276,21 @@ class WooCommerce extends \Codeception\Module
 		}
 
 		// Click Place order button.
-		$I->waitForElementNotVisible('.blockOverlay');
-		$I->scrollTo('#order_review_heading');
-		$I->click('#place_order');
+		switch ($options['use_legacy_checkout']) {
+			case true:
+				$I->waitForElementNotVisible('.blockOverlay');
+				$I->scrollTo('#order_review_heading');
+				$I->click('Place Order');
+				break;
+
+			case false:
+				// WooCommerce has a bug where clicking the Place Order button the first time doesn't do anything.
+				// This can be reproduced without the ConvertKit for WooCommerce Plugin active, so it's not a conflict.
+				$I->click('button.wc-block-components-checkout-place-order-button');
+				$I->wait(5);
+				$I->click('button.wc-block-components-checkout-place-order-button');
+				break;
+		}
 
 		// Confirm order received is displayed.
 		// WooCommerce changed the default wording between 5.x and 6.x, so perform
@@ -612,15 +624,15 @@ class WooCommerce extends \Codeception\Module
 
 			// Checkout Block.
 			case false:
-				// @TODO.
-				$I->fillField('#billing_first_name', 'First');
-				$I->fillField('#billing_last_name', 'Last');
-				$I->fillField('#billing_address_1', 'Address Line 1');
-				$I->fillField('#billing_city', 'City');
-				$I->fillField('#billing_postcode', '12345');
-				$I->fillField('#billing_phone', '123-123-1234');
-				$I->fillField('#billing_email', $emailAddress);
-				$I->fillField('#order_comments', 'Notes');
+				$I->fillField('#billing-first_name', 'First');
+				$I->fillField('#billing-last_name', 'Last');
+				$I->fillField('#billing-address_1', 'Address Line 1');
+				$I->fillField('#billing-city', 'City');
+				$I->fillField('#billing-postcode', '12345');
+				$I->fillField('#billing-phone', '123-123-1234');
+				$I->fillField('#email', $emailAddress);
+				$I->checkOption('.wc-block-checkout__add-note input.wc-block-components-checkbox__input');
+				$I->fillField('.wc-block-components-textarea', 'Notes');
 				break;
 		}
 

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCheckoutBlock.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCheckoutBlock.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form,
+ * Tag or Sequence on the Order Completed event when an order is placed through WooCommerce
+ * Subscriptions.
+ *
+ * @since   1.7.1
+ */
+class WooCommerceSubscriptionsSubscribeEventCheckoutBlockCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugins.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Activate WooCommerce Subscriptions Plugin.
+		$I->activateThirdPartyPlugin($I, 'woo-subscriptions');
+
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - WooCommerce Subscriptions Plugin is enabled, and
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Subscription' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 * - The Customer is not resubscribed when the WooCommerce Subscription is renewed.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSubscriptionProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'product_type'             => 'subscription',
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Trigger a renewal of the subscription, as if the recurring payment was made, by visiting WooCommerce > Status >
+		// Scheduled Actions and searching for the Subscription ID.
+		// https://woocommerce.com/document/testing-subscription-renewal-payments/.
+		$I->amOnAdminPage('admin.php?page=wc-status&tab=action-scheduler&s=' . $result['subscription_id'] . '&action=-1&paged=1&action2=-1&status=pending');
+		$I->moveMouseOver('tbody tr td.column-hook');
+		$I->click('span.run a');
+
+		// Wait for task to complete.
+		$I->waitForElement('.updated', 10);
+
+		// Confirm that the email address is not subscribed to ConvertKit, as the Order is for a renewal, not a new subscription.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - WooCommerce Subscriptions Plugin is enabled, and
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' non-subscription WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndNonSubscriptionProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address wasn't yet added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Change the Order status = Completed, to trigger the Order Completed event.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the email address was now added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateWooCommerceAndConvertKitPlugins($I);
+		$I->deactivateThirdPartyPlugin($I, 'woo-subscriptions');
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCheckoutBlock.php
+++ b/tests/acceptance/integrations/WooCommerceSubscriptionsSubscribeEventCheckoutBlock.php
@@ -54,7 +54,7 @@ class WooCommerceSubscriptionsSubscribeEventCheckoutBlockCest
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'completed',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -107,7 +107,7 @@ class WooCommerceSubscriptionsSubscribeEventCheckoutBlockCest
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'completed',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 

--- a/tests/acceptance/purchase-data/PurchaseDataCheckoutBlockCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCheckoutBlockCest.php
@@ -52,7 +52,7 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'send_purchase_data' => true,
+				'send_purchase_data'  => true,
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -107,8 +107,8 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'product_type'       => 'virtual',
-				'send_purchase_data' => true,
+				'product_type'        => 'virtual',
+				'send_purchase_data'  => true,
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -136,7 +136,7 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'product_type' => 'virtual',
+				'product_type'        => 'virtual',
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -164,8 +164,8 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'product_type'       => 'zero',
-				'send_purchase_data' => true,
+				'product_type'        => 'zero',
+				'send_purchase_data'  => true,
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -193,7 +193,7 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'product_type' => 'zero',
+				'product_type'        => 'zero',
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -223,7 +223,7 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'send_purchase_data' => 'completed',
+				'send_purchase_data'  => 'completed',
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -262,7 +262,7 @@ class PurchaseDataCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'send_purchase_data' => 'completed',
+				'send_purchase_data'  => 'completed',
 				'use_legacy_checkout' => false,
 			]
 		);
@@ -301,7 +301,7 @@ class PurchaseDataCheckoutBlockCest
 				'subscription_event'       => 'pending',
 				'send_purchase_data'       => true,
 				'name_format'              => 'both',
-				'use_legacy_checkout' => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 

--- a/tests/acceptance/purchase-data/PurchaseDataCheckoutBlockCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCheckoutBlockCest.php
@@ -1,0 +1,339 @@
+<?php
+/**
+ * Tests that Purchase Data does (or does not) get sent to ConvertKit based on the integration
+ * settings.
+ *
+ * @since   1.7.1
+ */
+class PurchaseDataCheckoutBlockCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Enable HPOS.
+		$I->setupWooCommerceHPOS($I);
+
+		// Activate Custom Order Numbers, so that we can prefix Order IDs with
+		// an environment-specific string.
+		$I->activateThirdPartyPlugin($I, 'custom-order-numbers-for-woocommerce');
+
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
+		// Setup Custom Order Numbers Plugin.
+		$I->setupCustomOrderNumbersPlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataWithSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'send_purchase_data' => true,
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is not sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is disabled in the integration Settings, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDontSendPurchaseDataWithSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataWithVirtualProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'product_type'       => 'virtual',
+				'send_purchase_data' => true,
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is not sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is disabled in the integration Settings, and
+	 * - The Customer purchases a 'Virtual' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDontSendPurchaseDataWithVirtualProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'product_type' => 'virtual',
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Customer purchases a WooCommerce Product with zero value, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataWithZeroValueProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'product_type'       => 'zero',
+				'send_purchase_data' => true,
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is not sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Customer purchases a WooCommerce Product with zero value, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDontSendPurchaseDataWithZeroValueProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'product_type' => 'zero',
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Send Purchase Data Event is set to Order Completed, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout, and
+	 * - The Order's status is changed from processing to completed.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataOnOrderCompletedWithSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'send_purchase_data' => 'completed',
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+
+		// Change Order Status = Completed.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the Customer's purchase is not sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The Send Purchase Data Event is set to Order Completed, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout, and
+	 * - The Order's status is changed from processing to cancelled.
+	 *
+	 * @since   1.7.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testDontSendPurchaseDataOnOrderCancelledWithSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'send_purchase_data' => 'completed',
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+
+		// Change Order Status = Completed.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-cancelled');
+
+		// Confirm that the purchase was not added to ConvertKit.
+		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address']);
+
+		// Check that the Order's Notes does not include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+	}
+
+	/**
+	 * Test that the name format setting is honored for the created subscriber in ConvertKit when
+	 * they opt in to subscribe and purchase data is also sent.
+	 *
+	 * @since   1.6.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataNameFormatHonoredWhenSubscribed(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'send_purchase_data'       => true,
+				'name_format'              => 'both',
+				'use_legacy_checkout' => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$I->apiCheckSubscriberExists($I, $result['email_address']);
+
+		// Confirm that the subscriber's name = First Last.
+		$I->apiCheckSubscriberEmailAndNameExists($I, $result['email_address'], 'First Last');
+
+		// Confirm that the purchase was added to ConvertKit.
+		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully');
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateWooCommerceAndConvertKitPlugins($I);
+		$I->deactivateThirdPartyPlugin($I, 'custom-order-numbers-for-woocommerce');
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCheckoutBlockCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCheckoutBlockCest.php
@@ -1,0 +1,680 @@
+<?php
+/**
+ * Tests the various settings do (or do not) subscribe the customer to a ConvertKit Form,
+ * Tag or Sequence on the Order Processing event when an order is placed through WooCommerce,
+ * and that any Order data is correctly stored e.g. Order Notes.
+ *
+ * @since   1.4.2
+ */
+class SubscribeOnOrderProcessingEventCheckoutBlockCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Enable HPOS.
+		$I->setupWooCommerceHPOS($I);
+
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
+		// Populate resoruces.
+		$I->setupConvertKitPluginResources($I);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is NOT subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenUncheckedWithFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is disabled in the integration Settings, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInDisabledWithFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithTagCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithSequenceCustomFieldsAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+	}
+
+	/**
+	 * Test that the Customer is not subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - No Form is selected in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'     => true,
+				'check_opt_in'       => true,
+				'subscription_event' => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was still not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+	}
+
+	/**
+	 * Test that the Customer is NOT subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - No Form is selected in the integration Settings, and
+	 * - The opt in checkbox is unchecked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenUncheckedWithNoFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'     => true,
+				'subscription_event' => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was still not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+	}
+
+	/**
+	 * Test that the Customer is not subscribed to ConvertKit when:
+	 * - The opt in checkbox is disabled in the integration Settings, and
+	 * - No Form is selected in the integration Settings, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is created.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInDisabledWithNoFormAndSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'subscription_event' => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was still not added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
+		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The 'Simple' WooCommerce Product also defines a Form (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductForm(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The 'Simple' WooCommerce Product also defines a Tag (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductTag(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The 'Simple' WooCommerce Product also defines a Sequence (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithProductSequence(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Form (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponForm(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Tag (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponTag(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The WooCommerce Coupon used defines a Sequence (separate to the Plugin settings), and
+	 * - The Customer purchases a 'Simple' WooCommerce Product with the WooCommerce Coupon, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.5.9
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProductWithCouponSequence(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+	}
+
+	/**
+	 * Test that the Customer is not resubscribed ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing, and
+	 * - The Customer unsubscribes from ConvertKit, and
+	 * - The Order's Status is changed to a non-Processing status, and
+	 * - The Order's Status is changed back to Processing.
+	 *
+	 * @since   1.4.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testCustomerIsNotResubscribedWhenOrderStatusChanges(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'use_legacy_checkout'	   => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($result['email_address']);
+
+		// Change the Order's Status to any status other than 'Processing'.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Pending payment');
+
+		// Change the Order's Status to 'Processing'.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Processing');
+
+		// Confirm that the email address was not added to ConvertKit a second time.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+	}
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.4.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateWooCommerceAndConvertKitPlugins($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCheckoutBlockCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCheckoutBlockCest.php
@@ -51,7 +51,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -89,7 +89,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'display_opt_in'           => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -121,7 +121,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 			[
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -162,7 +162,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
 				'custom_fields'            => true,
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -199,7 +199,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
 				'subscription_event'       => 'processing',
 				'custom_fields'            => true,
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -236,7 +236,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
 				'subscription_event'       => 'processing',
 				'custom_fields'            => true,
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 
@@ -268,10 +268,10 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'     => true,
-				'check_opt_in'       => true,
-				'subscription_event' => 'processing',
-				'use_legacy_checkout'	   => false,
+				'display_opt_in'      => true,
+				'check_opt_in'        => true,
+				'subscription_event'  => 'processing',
+				'use_legacy_checkout' => false,
 			]
 		);
 
@@ -303,9 +303,9 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'     => true,
-				'subscription_event' => 'processing',
-				'use_legacy_checkout'	   => false,
+				'display_opt_in'      => true,
+				'subscription_event'  => 'processing',
+				'use_legacy_checkout' => false,
 			]
 		);
 
@@ -336,8 +336,8 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'subscription_event' => 'processing',
-				'use_legacy_checkout'	   => false,
+				'subscription_event'  => 'processing',
+				'use_legacy_checkout' => false,
 			]
 		);
 
@@ -374,7 +374,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -418,7 +418,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -462,7 +462,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -506,7 +506,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -550,7 +550,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'tag:' . $_ENV['CONVERTKIT_API_TAG_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -594,7 +594,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'product_form_tag_sequence' => 'course:' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'],
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'       => false,
 			]
 		);
 
@@ -639,7 +639,7 @@ class SubscribeOnOrderProcessingEventCheckoutBlockCest
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
-				'use_legacy_checkout'	   => false,
+				'use_legacy_checkout'      => false,
 			]
 		);
 


### PR DESCRIPTION
## Summary

Adds tests for the opt in checkbox when using the WooCommerce Checkout.

## Testing

- `PurchaseDataCheckoutBlockCest`: Add tests matching `PurchaseDataCest`, using the Checkout Block instead of the legacy Checkout Shortcode.
- `SubscribeOnOrderProcessingEventCheckoutBlockCest: Add tests matching `SubscribeOnOrderProcessingEventCest`, using the Checkout Block instead of the legacy Checkout Shortcode.
- `WooCommerceSubscriptionsSubscribeEventCheckoutBlockCest: Add tests matching `WooCommerceSubscriptionsSubscribeEventCest`, using the Checkout Block instead of the legacy Checkout Shortcode.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)