### PR TITLE
Tests: Check for Log in WP_List_Table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "convertkit/convertkit-wordpress-libraries": "1.4.1"
     },
     "require-dev": {
-        "lucatume/wp-browser": "^3.0",
+        "lucatume/wp-browser": "<3.5",
         "codeception/module-asserts": "^1.3",                                      
         "codeception/module-phpbrowser": "^1.0",                                   
         "codeception/module-webdriver": "^1.0",                                    

--- a/tests/acceptance/settings/SettingDebugLogCest.php
+++ b/tests/acceptance/settings/SettingDebugLogCest.php
@@ -49,8 +49,8 @@ class SettingDebugLogCest
 		// Load WooCommerce's Logs screen.
 		$I->amOnAdminPage('admin.php?page=wc-status&tab=logs');
 
-		// Confirm that a ConvertKit Log File exists in the dropdown selection of logs.
-		$I->seeInSource('<option value="convertkit-' . date('Y-m-d'));
+		// Confirm that a ConvertKit Log File exists in the table of logs for today's date.
+		$I->seeInSource('<a class="row-title" href="' . $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=wc-status&amp;tab=logs&amp;view=single_file&amp;file_id=convertkit-' . date('Y-m-d') . '">convertkit</a>');
 	}
 
 	/**

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -15,7 +15,7 @@
  * Text Domain: woocommerce-convertkit
  *
  * WC requires at least: 3.0
- * WC tested up to: 8.5.1
+ * WC tested up to: 8.6.1
  */
 
 // Bail if Plugin is already loaded.


### PR DESCRIPTION
## Summary

Updates a failing test due to WooCommerce 8.6.0 now using a table view for logs

![Screenshot 2024-03-08 at 17 18 21](https://github.com/ConvertKit/convertkit-woocommerce/assets/1462305/c65270f5-098a-4327-b3a6-d98774b44d2f)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)