### PR TITLE
Fix `Save changes` button padding

### DIFF
--- a/resources/backend/css/settings.css
+++ b/resources/backend/css/settings.css
@@ -37,7 +37,8 @@ body.woocommerce_page_wc-settings .wrap .postbox p {
 body.woocommerce_page_wc-settings .wrap p.submit {
 	padding: 0;
 }
-body.woocommerce_page_wc-settings .wrap p.submit .button {
+body.woocommerce_page_wc-settings .wrap p.submit .button,
+body.woocommerce_page_wc-settings .wrap p.submit .button-primary {
 	margin: 0 5px 0 0;
 	padding: 4px 12px;
 	font-size: 14px;


### PR DESCRIPTION
## Summary

WooCommerce 8.9 changes the CSS class on the `Save changes` button to `button-primary`, meaning the styles to pad the button weren’t being applied.
![Screenshot 2024-06-05 at 12 33 51](https://github.com/ConvertKit/convertkit-woocommerce/assets/1462305/3d20df73-5d7f-4a25-a315-5ce31f1e7e29)

Includes `.button-primary` in the CSS styles to ensure `Save changes` button has padding applied.
![Screenshot 2024-06-05 at 12 34 32](https://github.com/ConvertKit/convertkit-woocommerce/assets/1462305/a3947b9c-312e-49e4-b539-67928b6eb564)

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)