### PR TITLE
Use `ckwc_get_settings_link` helper method

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -231,16 +231,7 @@ class CKWC_Integration extends WC_Integration {
 			 */
 			case 'sync_past_orders':
 				// Define URL to return to main Integration Settings screen.
-				$return_url = admin_url(
-					add_query_arg(
-						array(
-							'page'    => 'wc-settings',
-							'tab'     => 'integration',
-							'section' => 'ckwc',
-						),
-						'admin.php'
-					)
-				);
+				$return_url = ckwc_get_settings_link();
 
 				// Load view.
 				include_once CKWC_PLUGIN_PATH . '/views/backend/settings/sync-past-orders.php';
@@ -251,18 +242,12 @@ class CKWC_Integration extends WC_Integration {
 			 */
 			default:
 				// Define variables.
-				$export_url = admin_url(
-					add_query_arg(
-						array(
-							'page'    => 'wc-settings',
-							'tab'     => 'integration',
-							'section' => 'ckwc',
-							'action'  => 'ckwc-export',
-							'nonce'   => wp_create_nonce( 'ckwc-nonce' ),
-						),
-						'admin.php'
+				$export_url = ckwc_get_settings_link(
+					array(
+						'action' => 'ckwc-export',
+						'nonce'  => wp_create_nonce( 'ckwc-nonce' ),
 					)
-				);
+				)
 
 				// Hide 'Save changes' button, so we can add our own to each panel.
 				$hide_save_button = true;
@@ -557,15 +542,9 @@ class CKWC_Integration extends WC_Integration {
 				'type'     => 'sync_past_orders_button',
 				'default'  => '',
 				'desc_tip' => false,
-				'url'      => admin_url(
-					add_query_arg(
-						array(
-							'page'        => 'wc-settings',
-							'tab'         => 'integration',
-							'section'     => 'ckwc',
-							'sub_section' => 'sync_past_orders',
-						),
-						'admin.php'
+				'url'      => ckwc_get_settings_link(
+					array(
+						'sub_section' => 'sync_past_orders',
 					)
 				),
 

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -247,7 +247,7 @@ class CKWC_Integration extends WC_Integration {
 						'action' => 'ckwc-export',
 						'nonce'  => wp_create_nonce( 'ckwc-nonce' ),
 					)
-				)
+				);
 
 				// Hide 'Save changes' button, so we can add our own to each panel.
 				$hide_save_button = true;


### PR DESCRIPTION
## Summary

Whilst working on the v4 API integration, there are a few sections that need to fetch the settings link, but weren't using the Plugin supplied `ckwc_get_settings_link` method to do this.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)