### PR TITLE
v4 API: Save updated tokens on refresh

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -117,7 +117,7 @@ class CKWC_Integration extends WC_Integration {
 	 * @since   1.8.0
 	 *
 	 * @param   array  $result      New Access Token, Refresh Token and Expiry.
-	 * @param 	string $client_id 	OAuth Client ID used for the Access and Refresh Tokens.
+	 * @param   string $client_id   OAuth Client ID used for the Access and Refresh Tokens.
 	 */
 	public function update_credentials( $result, $client_id ) {
 

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -112,7 +112,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Mocks an API response as if the Access Token expired.
 	 *
-	 * @since   1.5.0
+	 * @since   1.8.0
 	 *
 	 * @param   mixed  $response       HTTP Response.
 	 * @param   array  $parsed_args    Request arguments.
@@ -152,7 +152,7 @@ class APITest extends \Codeception\TestCase\WPTestCase
 	/**
 	 * Mocks an API response as if a refresh token was used to fetch new tokens.
 	 *
-	 * @since   1.5.0
+	 * @since   1.8.0
 	 *
 	 * @param   mixed  $response       HTTP Response.
 	 * @param   array  $parsed_args    Request arguments.

--- a/tests/wpunit/APITest.php
+++ b/tests/wpunit/APITest.php
@@ -32,11 +32,8 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		parent::setUp();
 
 		// Activate Plugin, to include the Plugin's constants in tests.
+		activate_plugins('woocommerce/woocommerce.php');
 		activate_plugins('convertkit-woocommerce/woocommerce-convertkit.php');
-
-		// Include class from /includes to test, as they won't be loaded by the Plugin
-		// because WooCommerce is not active.
-		require_once 'includes/class-ckwc-api.php';
 
 		// Initialize the classes we want to test.
 		$this->api = new CKWC_API(
@@ -58,6 +55,32 @@ class APITest extends \Codeception\TestCase\WPTestCase
 		unset($this->api);
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Test that the Access Token is refreshed when a call is made to the API
+	 * using an expired Access Token, and that the new tokens are saved in
+	 * the Plugin settings.
+	 *
+	 * @since   1.8.0
+	 */
+	public function testAccessTokenRefreshedAndSavedWhenExpired()
+	{
+		// Confirm no Access or Refresh Token exists in the Plugin settings.
+		$this->assertEquals( WP_CKWC_Integration()->get_access_token(), '' );
+		$this->assertEquals( WP_CKWC_Integration()->get_refresh_token(), '' );
+
+		// Filter requests to mock the token expiry and refreshing the token.
+		add_filter( 'pre_http_request', array( $this, 'mockAccessTokenExpiredResponse' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mockRefreshTokenResponse' ), 10, 3 );
+
+		// Run request, which will trigger the above filters as if the token expired and refreshes automatically.
+		$result = $this->api->get_account();
+
+		// Confirm "new" tokens now exist in the Plugin's settings, which confirms the `convertkit_api_refresh_token` hook was called when
+		// the tokens were refreshed.
+		$this->assertEquals( WP_CKWC_Integration()->get_access_token(), $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] );
+		$this->assertEquals( WP_CKWC_Integration()->get_refresh_token(), $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] );
 	}
 
 	/**
@@ -84,5 +107,89 @@ class APITest extends \Codeception\TestCase\WPTestCase
 
 		// Perform a request.
 		$result = $this->api->get_account();
+	}
+
+	/**
+	 * Mocks an API response as if the Access Token expired.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   mixed  $response       HTTP Response.
+	 * @param   array  $parsed_args    Request arguments.
+	 * @param   string $url            Request URL.
+	 * @return  mixed
+	 */
+	public function mockAccessTokenExpiredResponse( $response, $parsed_args, $url )
+	{
+		// Only mock requests made to the /account endpoint.
+		if ( strpos( $url, 'https://api.convertkit.com/v4/account' ) === false ) {
+			return $response;
+		}
+
+		// Remove this filter, so we don't end up in a loop when retrying the request.
+		remove_filter( 'pre_http_request', array( $this, 'mockAccessTokenExpiredResponse' ) );
+
+		// Return a 401 unauthorized response with the errors body as if the API
+		// returned "The access token expired".
+		return array(
+			'headers'       => array(),
+			'body'          => wp_json_encode(
+				array(
+					'errors' => array(
+						'The access token expired',
+					),
+				)
+			),
+			'response'      => array(
+				'code'    => 401,
+				'message' => 'The access token expired',
+			),
+			'cookies'       => array(),
+			'http_response' => null,
+		);
+	}
+
+	/**
+	 * Mocks an API response as if a refresh token was used to fetch new tokens.
+	 *
+	 * @since   1.5.0
+	 *
+	 * @param   mixed  $response       HTTP Response.
+	 * @param   array  $parsed_args    Request arguments.
+	 * @param   string $url            Request URL.
+	 * @return  mixed
+	 */
+	public function mockRefreshTokenResponse( $response, $parsed_args, $url )
+	{
+		// Only mock requests made to the /token endpoint.
+		if ( strpos( $url, 'https://api.convertkit.com/oauth/token' ) === false ) {
+			return $response;
+		}
+
+		// Remove this filter, so we don't end up in a loop when retrying the request.
+		remove_filter( 'pre_http_request', array( $this, 'mockRefreshTokenResponse' ) );
+
+		// Return a mock access and refresh token for this API request, as calling
+		// refresh_token results in a new access and refresh token being provided,
+		// which would result in other tests breaking due to changed tokens.
+		return array(
+			'headers'       => array(),
+			'body'          => wp_json_encode(
+				array(
+					'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+					'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+					'token_type'    => 'bearer',
+					'created_at'    => strtotime( 'now' ),
+					'expires_in'    => 10000,
+					'scope'         => 'public',
+				)
+			),
+			'response'      => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'       => array(),
+			'http_response' => null,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

Stores the refreshed Access + Refresh Tokens when an API request is made and the Access Token has expired.

## Testing

- `testAccessTokenRefreshedAndSavedWhenExpired`: Tests that the new Access and Refresh Tokens are saved in the Plugin's settings when the WordPress Libraries make a call to an API endpoint with an expired Access Token.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)