### PR TITLE
v4 API: Use ConvertKit-hosted redirect URI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         id: check_files
         uses: andstor/file-existence-action@v1
         with:
-          files: "vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php"
+          files: "vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-traits.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-api-v4.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-resource.php, vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-review-request.php"
 
       # Deploy to wordpress.org
       - name: WordPress Plugin Deploy

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "dev-v4-api"
+        "convertkit/convertkit-wordpress-libraries": "2.0.0"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -10,6 +10,36 @@ namespace Helper\Acceptance;
 class ConvertKitAPI extends \Codeception\Module
 {
 	/**
+	 * Returns an encoded `state` parameter compatible with OAuth.
+	 *
+	 * @since   2.5.0
+	 *
+	 * @param   string $returnTo   Return URL.
+	 * @param   string $clientID   OAuth Client ID.
+	 * @return  string
+	 */
+	public function apiEncodeState($returnTo, $clientID)
+	{
+		$str = json_encode( // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+			array(
+				'return_to' => $returnTo,
+				'client_id' => $clientID,
+			)
+		);
+
+		// Encode to Base64 string.
+		$str = base64_encode( $str ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions
+
+		// Convert Base64 to Base64URL by replacing “+” with “-” and “/” with “_”.
+		$str = strtr( $str, '+/', '-_' );
+
+		// Remove padding character from the end of line.
+		$str = rtrim( $str, '=' );
+
+		return $str;
+	}
+
+	/**
 	 * Check the given email address exists as a subscriber on ConvertKit.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -307,10 +307,6 @@ class WooCommerce extends \Codeception\Module
 				break;
 
 			case false:
-				// WooCommerce has a bug where clicking the Place Order button the first time doesn't do anything.
-				// This can be reproduced without the ConvertKit for WooCommerce Plugin active, so it's not a conflict.
-				$I->click('button.wc-block-components-checkout-place-order-button');
-				$I->wait(2);
 				$I->click('button.wc-block-components-checkout-place-order-button');
 				break;
 		}

--- a/tests/acceptance/settings/SettingOAuthCest.php
+++ b/tests/acceptance/settings/SettingOAuthCest.php
@@ -46,7 +46,12 @@ class SettingOAuthCest
 
 		// Check that a link to the OAuth auth screen exists and includes the state parameter.
 		$I->seeInSource('<a href="https://app.convertkit.com/oauth/authorize?client_id=' . $_ENV['CONVERTKIT_OAUTH_CLIENT_ID'] . '&amp;response_type=code&amp;redirect_uri=' . urlencode( $_ENV['CONVERTKIT_OAUTH_REDIRECT_URI'] ) );
-		$I->seeInSource('&amp;state=' . urlencode( $_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=wc-settings&tab=integration&section=ckwc' ) );
+		$I->seeInSource(
+			'&amp;state=' . $I->apiEncodeState(
+				$_ENV['TEST_SITE_WP_URL'] . '/wp-admin/admin.php?page=wc-settings&tab=integration&section=ckwc',
+				$_ENV['CONVERTKIT_OAUTH_CLIENT_ID']
+			)
+		);
 
 		// Click the connect button.
 		$I->click('Connect');

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -30,7 +30,7 @@ define( 'CKWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CKWC_PLUGIN_PATH', __DIR__ );
 define( 'CKWC_PLUGIN_VERSION', '1.8.0' );
 define( 'CKWC_OAUTH_CLIENT_ID', 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A' );
-define( 'CKWC_OAUTH_CLIENT_REDIRECT_URI', 'https://cktestplugins.wpengine.com/' );
+define( 'CKWC_OAUTH_CLIENT_REDIRECT_URI', 'https://app.convertkit.com/wordpress/redirect' );
 
 // Load shared classes, if they have not been included by another ConvertKit Plugin.
 if ( ! trait_exists( 'ConvertKit_API_Traits' ) ) {


### PR DESCRIPTION
## Summary

Use the ConvertKit-hosted redirect URL with the `2.0` WordPress Libraries.

## Testing

Updates tests that check the `state` parameter for beginning the OAuth process to its new encoded version.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)