### PR TITLE
Change `update_option` parameter from `yes` to `true`

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -323,7 +323,7 @@ class CKWC_Integration extends WC_Integration {
 		remove_action( "woocommerce_update_options_integration_{$this->id}", array( $this, 'process_admin_options' ) );
 
 		// Import: Settings.
-		update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $import['settings'] ), 'yes' );
+		update_option( $this->get_option_key(), apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $this->id, $import['settings'] ), true );
 
 		// Initialize the settings again, so the imported settings that were saved above are read.
 		$this->init_settings();


### PR DESCRIPTION
## Summary

The `autoload` parameter of `update_option()` WordPress function prefers either `null` or a boolean.  The string `yes` / `no` [is supported for backward compatibility](https://developer.wordpress.org/reference/functions/update_option/), but for best practice this PR updates it to `true`.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)