### PR TITLE
Create subscriber with `inactive` state when a Form option is selected

### DIFF
--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -257,7 +257,7 @@ class CKWC_Order {
 
 				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
 				if ( is_wp_error( $subscriber ) ) {
-					break;
+					return;
 				}
 
 				// For Legacy Forms, a different endpoint is used.

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -252,14 +252,23 @@ class CKWC_Order {
 		// Call API to subscribe the email address to the given Form, Tag or Sequence.
 		switch ( $resource_type ) {
 			case 'form':
-				// For Legacy Forms, a different endpoint is used.
-				$forms = new CKWC_Resource_Forms();
-				if ( $forms->is_legacy( $resource_id ) ) {
-					$result = $this->api->legacy_form_subscribe( $resource_id, $email, $name, $custom_fields );
+				// Subscribe with inactive state.
+				$subscriber = $this->api->create_subscriber( $email, $name, 'inactive', $custom_fields );
+
+				// If an error occured, don't attempt to add the subscriber to the Form, as it won't work.
+				if ( is_wp_error( $subscriber ) ) {
 					break;
 				}
 
-				$result = $this->api->form_subscribe( $resource_id, $email, $name, $custom_fields );
+				// For Legacy Forms, a different endpoint is used.
+				$forms = new CKWC_Resource_Forms();
+				if ( $forms->is_legacy( $resource_id ) ) {
+					$result = $this->api->add_subscriber_to_legacy_form( $resource_id, $subscriber['subscriber']['id'] );
+					break;
+				}
+
+				// Add subscriber to form.
+				$result = $this->api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
 				break;
 
 			case 'tag':

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -56,6 +56,9 @@ class ConvertKitAPI extends \Codeception\Module
 			[
 				'email_address'       => $emailAddress,
 				'include_total_count' => true,
+
+				// Check all subscriber states.
+				'status'              => 'all',
 			]
 		);
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/PLAT-2027/platform-v4-api-issue-post-to-create-a-subscriber-doesnt-appear-to), by calling `create_subscriber` with `state` = `inactive` when a Form is selected as the resource to assign to the subscriber to.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)