### PR TITLE
Send Custom Field Data with Purchase Data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Start chromedriver
         run: |
           export DISPLAY=:99
-          chromedriver --url-base=/wd/hub &
+          chromedriver --port=9515 --url-base=/wd/hub &
           sudo Xvfb -ac :99 -screen 0 1920x1080x24 > /dev/null 2>&1 & # optional
 
       # Write any secrets, such as API keys, to the .env.dist.testing file now.

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -571,8 +571,8 @@ class CKWC_Order {
 				sprintf(
 					/* translators: %1$s: Error Code, %2$s: Error Message */
 					__( '[ConvertKit] Purchase Data: Custom Fields: Get Subscriber Error: %1$s %2$s', 'woocommerce-convertkit' ),
-					$response->get_error_code(),
-					$response->get_error_message()
+					$subscriber_id->get_error_code(),
+					$subscriber_id->get_error_message()
 				)
 			);
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -612,6 +612,15 @@ class CKWC_Order {
 			);
 		}
 
+		// Add a note to the WooCommerce Order that the custom fields data sent successfully.
+		$order->add_order_note(
+			sprintf(
+				/* translators: ConvertKit Subscriber ID */
+				__( '[ConvertKit] Purchase Data: Custom Fields sent successfully: Subscriber ID [%s]', 'woocommerce-convertkit' ),
+				$subscriber_id
+			)
+		);
+
 		// Return.
 		return $response;
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -556,6 +556,62 @@ class CKWC_Order {
 		// it is never displayed again.
 		WP_CKWC()->get_class( 'review_request' )->request_review();
 
+		// Check if any custom field data needs to be added to the subscriber.
+		$fields = $this->custom_field_data( $order );
+		if ( ! count( $fields ) ) {
+			return $response;
+		}
+
+		// Get subscriber ID by email address.
+		$subscriber_id = $this->api->get_subscriber_id( $purchase['email_address'] );
+
+		// If an error occured fetching the subscriber, add a WooCommerce Order note and bail.
+		if ( is_wp_error( $subscriber_id ) ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: Error Code, %2$s: Error Message */
+					__( '[ConvertKit] Purchase Data: Custom Fields: Get Subscriber Error: %1$s %2$s', 'woocommerce-convertkit' ),
+					$response->get_error_code(),
+					$response->get_error_message()
+				)
+			);
+
+			return $subscriber_id;
+		}
+
+		// If no subscriber could be found, add a WooCommerce Order note and bail.
+		if ( ! $subscriber_id ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: Error Code, %2$s: Error Message */
+					__( '[ConvertKit] Purchase Data: Custom Fields: No subscriber found for email address %s', 'woocommerce-convertkit' ),
+					$purchase['email_address']
+				)
+			);
+
+			return $subscriber_id;
+		}
+
+		// Update subscriber with custom field data.
+		$response = $this->api->update_subscriber(
+			$subscriber_id,
+			$purchase['first_name'],
+			$purchase['email_address'],
+			$fields
+		);
+
+		// If an error occured updating the subscriber, add a WooCommerce Order note.
+		if ( is_wp_error( $response ) ) {
+			$order->add_order_note(
+				sprintf(
+					/* translators: %1$s: Error Code, %2$s: Error Message */
+					__( '[ConvertKit] Purchase Data: Custom Fields: Update Subscriber Error: %1$s %2$s', 'woocommerce-convertkit' ),
+					$response->get_error_code(),
+					$response->get_error_message()
+				)
+			);
+		}
+
 		// Return.
 		return $response;
 

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -53,6 +53,7 @@ class PurchaseDataCest
 			$I,
 			[
 				'send_purchase_data' => true,
+				'custom_fields'      => false,
 			]
 		);
 
@@ -65,6 +66,60 @@ class PurchaseDataCest
 		// Confirm that the Transaction ID is stored in the Order's metadata.
 		$I->wooCommerceOrderMetaKeyAndValueExist($I, $result['order_id'], 'ckwc_purchase_data_sent', 'yes', true);
 		$I->wooCommerceOrderMetaKeyAndValueExist($I, $result['order_id'], 'ckwc_purchase_data_id', $purchaseDataID, true);
+
+		// Confirm that the email address was added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+	}
+
+	/**
+	 * Test that the Customer's purchase is sent to ConvertKit when:
+	 * - The 'Send purchase data to ConvertKit' is enabled in the integration Settings, and
+	 * - The opt in settings are disabled, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Order is created via the frontend checkout.
+	 *
+	 * @since   1.8.4
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSendPurchaseDataWithCustomFieldsOnSimpleProductCheckout(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'     => false,
+				'check_opt_in'       => false,
+				'send_purchase_data' => true,
+				'custom_fields'      => true,
+			]
+		);
+
+		// Confirm that the purchase was added to ConvertKit.
+		$purchaseDataID = $I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the purchase was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data sent successfully: ID [' . $purchaseDataID . ']');
+
+		// Confirm that the Transaction ID is stored in the Order's metadata.
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $result['order_id'], 'ckwc_purchase_data_sent', 'yes', true);
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $result['order_id'], 'ckwc_purchase_data_id', $purchaseDataID, true);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct.
+		$I->apiCustomFieldDataIsValid($I, $subscriber);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the custom field data was added to ConvertKit.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[ConvertKit] Purchase Data: Custom Fields sent successfully: Subscriber ID [' . $subscriber['id'] . ']');
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds [this feature request](https://app.intercom.com/a/inbox/e4n3xtxz/inbox/shared/all/conversation/12263830580153?view=List), by adding custom field data to the subscriber created when purchase data is sent to ConvertKit.

![Screenshot 2024-09-11 at 15 52 01](https://github.com/user-attachments/assets/06cee30d-b384-41ab-8e28-26c8d9ef4f35)

Previously, this data would only be sent if the subscribe option was configured (to subscribe to a form, tag, sequence).

## Testing

- `testSendPurchaseDataWithCustomFieldsOnSimpleProductCheckout`: Test that custom field data is assigned to the subscriber created when purchase data is sent to ConvertKit for a WooCommerce order.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)