### PR TITLE
Tests: Create `wc-logs` folder with permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,6 +213,13 @@ jobs:
           sudo chmod g+w ${{ env.PLUGIN_DIR }}
           sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
 
+      # This ensures WooCommerce log files can be written to.
+      - name: Set Permissions for WooCommerce Logs Directory
+        run: |
+          sudo mkdir ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+
       # Build Codeception Tests.
       - name: Build Tests
         working-directory: ${{ env.PLUGIN_DIR }}

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -646,11 +646,12 @@ class WooCommerce extends \Codeception\Module
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
+		$I->wait(3);
+
 		// Complete Billing Details.
 		switch ($useLegacyCheckout) {
 			// Legacy Checkout Shortcode.
 			case true:
-				$I->waitForElementVisible('#billing_first_name');
 				$I->fillField('#billing_first_name', 'First');
 				$I->fillField('#billing_last_name', 'Last');
 				$I->fillField('#billing_address_1', 'Address Line 1');
@@ -663,7 +664,6 @@ class WooCommerce extends \Codeception\Module
 
 			// Checkout Block.
 			case false:
-				$I->waitForElementVisible('#billing-first_name');
 				$I->fillField('#billing-first_name', 'First');
 				$I->fillField('#billing-last_name', 'Last');
 				$I->fillField('#billing-address_1', 'Address Line 1');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -650,6 +650,7 @@ class WooCommerce extends \Codeception\Module
 		switch ($useLegacyCheckout) {
 			// Legacy Checkout Shortcode.
 			case true:
+				$I->waitForElementVisible('#billing_first_name');
 				$I->fillField('#billing_first_name', 'First');
 				$I->fillField('#billing_last_name', 'Last');
 				$I->fillField('#billing_address_1', 'Address Line 1');
@@ -662,6 +663,7 @@ class WooCommerce extends \Codeception\Module
 
 			// Checkout Block.
 			case false:
+				$I->waitForElementVisible('#billing-first_name');
 				$I->fillField('#billing-first_name', 'First');
 				$I->fillField('#billing-last_name', 'Last');
 				$I->fillField('#billing-address_1', 'Address Line 1');


### PR DESCRIPTION
## Summary

Create `wc-logs` directory and set permissions to ensure tests pass.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)