### PR TITLE
Exclude Name from Billing + Shipping Addresses

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -571,7 +571,7 @@ class CKWC_Integration extends WC_Integration {
 				'class'       => 'enabled subscribe',
 			),
 			'custom_field_address_exclude_name' => array(
-				'title'       => __( 'Exclude Name from Billing + Shipping Addresses', 'woocommerce-convertkit' ),
+				'title'       => __( 'Exclude Name from Billing & Shipping Addresses', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'default'     => 'no',
 				'description' => __( 'If enabled, removes the order\'s first name, last name and company name when storing the billing and shipping address above.', 'woocommerce-convertkit' ),

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -443,7 +443,7 @@ class CKWC_Integration extends WC_Integration {
 
 		$this->form_fields = array(
 			// Account name.
-			'account_name'                  => array(
+			'account_name'                      => array(
 				'title' => __( 'Account Name', 'woocommerce-convertkit' ),
 				'type'  => 'oauth_disconnect',
 				'label' => __( 'Disconnect', 'woocommerce-convertkit' ),
@@ -462,7 +462,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Enable/Disable entire integration.
-			'enabled'                       => array(
+			'enabled'                           => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce-convertkit' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable ConvertKit integration', 'woocommerce-convertkit' ),
@@ -470,7 +470,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Subscribe.
-			'event'                         => array(
+			'event'                             => array(
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
@@ -508,7 +508,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'subscription'                  => array(
+			'subscription'                      => array(
 				'title'       => __( 'Subscription', 'woocommerce-convertkit' ),
 				'type'        => 'subscription',
 				'default'     => '',
@@ -517,7 +517,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'name_format'                   => array(
+			'name_format'                       => array(
 				'title'       => __( 'Name Format', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'first',
@@ -534,7 +534,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Custom Field Mappings.
-			'custom_field_last_name'        => array(
+			'custom_field_last_name'            => array(
 				'title'       => __( 'Send Last Name', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -543,7 +543,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_phone'            => array(
+			'custom_field_phone'                => array(
 				'title'       => __( 'Send Phone Number', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -552,7 +552,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_billing_address'  => array(
+			'custom_field_billing_address'      => array(
 				'title'       => __( 'Send Billing Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -561,7 +561,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_shipping_address' => array(
+			'custom_field_shipping_address'     => array(
 				'title'       => __( 'Send Shipping Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -570,7 +570,16 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_payment_method'   => array(
+			'custom_field_address_exclude_name' => array(
+				'title'       => __( 'Exclude Name from Billing + Shipping Addresses', 'woocommerce-convertkit' ),
+				'type'        => 'checkbox',
+				'default'     => 'no',
+				'description' => __( 'If enabled, removes the order\'s first name, last name and company name when storing the billing and shipping address above.', 'woocommerce-convertkit' ),
+
+				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
+				'class'       => 'enabled subscribe',
+			),
+			'custom_field_payment_method'       => array(
 				'title'       => __( 'Send Payment Method', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -579,7 +588,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_customer_note'    => array(
+			'custom_field_customer_note'        => array(
 				'title'       => __( 'Send Customer Note', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -590,7 +599,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Subscribe: Display Opt In Checkbox Settings.
-			'display_opt_in'                => array(
+			'display_opt_in'                    => array(
 				'title'       => __( 'Opt-In Checkbox', 'woocommerce-convertkit' ),
 				'label'       => __( 'Display an opt-in checkbox on checkout', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -605,7 +614,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'opt_in_label'                  => array(
+			'opt_in_label'                      => array(
 				'title'       => __( 'Opt-In Checkbox: Label', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => __( 'I want to subscribe to the newsletter', 'woocommerce-convertkit' ),
@@ -615,7 +624,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_status'                 => array(
+			'opt_in_status'                     => array(
 				'title'       => __( 'Opt-In Checkbox: Default Status', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'checked',
@@ -629,7 +638,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_location'               => array(
+			'opt_in_location'                   => array(
 				'title'       => __( 'Opt-In Checkbox: Display Location', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'billing',
@@ -645,7 +654,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Purchase Data.
-			'send_purchases'                => array(
+			'send_purchases'                    => array(
 				'title'       => __( 'Purchase Data', 'woocommerce-convertkit' ),
 				'label'       => __( 'Send purchase data to ConvertKit.', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -660,7 +669,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'send_purchases_event'          => array(
+			'send_purchases_event'              => array(
 				'title'       => __( 'Purchase Data Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'processing',
@@ -691,7 +700,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe send_purchases',
 			),
-			'sync_past_orders'              => array(
+			'sync_past_orders'                  => array(
 				'title'    => __( 'Sync Past Orders', 'woocommerce-convertkit' ),
 				'label'    => __( 'Send old purchase data to ConvertKit i.e. Orders that were created in WooCommerce prior to this Plugin being installed.', 'woocommerce-convertkit' ),
 				'type'     => 'sync_past_orders_button',
@@ -708,7 +717,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Debugging.
-			'debug'                         => array(
+			'debug'                             => array(
 				'title'       => __( 'Debug', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'label'       => __( 'Write data to a log file', 'woocommerce-convertkit' ),

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -966,6 +966,14 @@ class CKWC_Order {
 
 		$fields = array();
 
+		// If the name and company name should be excluded from the billing and shipping address
+		// fetched using get_formatted_billing_address() / get_formatted_shipping_address(),
+		// add filters now.
+		if ( $this->integration->get_option_bool( 'custom_field_address_exclude_name' ) ) {
+			add_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'remove_name_from_address' ) );
+			add_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'remove_name_from_address' ) );
+		}
+
 		if ( $this->integration->get_option( 'custom_field_last_name' ) ) {
 			$fields[ $this->integration->get_option( 'custom_field_last_name' ) ] = $order->get_billing_last_name();
 		}
@@ -985,6 +993,14 @@ class CKWC_Order {
 			$fields[ $this->integration->get_option( 'custom_field_customer_note' ) ] = $order->get_customer_note();
 		}
 
+		// If the name and company name should be excluded from the billing and shipping address
+		// fetched using get_formatted_billing_address() / get_formatted_shipping_address(),
+		// remove filters now so these WooCommerce functions work correctly for other Plugins.
+		if ( $this->integration->get_option_bool( 'custom_field_address_exclude_name' ) ) {
+			remove_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'remove_name_from_address' ) );
+			remove_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'remove_name_from_address' ) );
+		}
+
 		/**
 		 * Returns an array of ConvertKit Custom Field Key/Value pairs, with values
 		 * comprising of Order data based, to be sent to ConvertKit when an Order's
@@ -1000,6 +1016,22 @@ class CKWC_Order {
 		$fields = apply_filters( 'convertkit_for_woocommerce_custom_field_data', $fields, $order );
 
 		return $fields;
+
+	}
+
+	/**
+	 * Removes the first name, last name and company name from the WooCommerce Order address,
+	 * when calling WC_Order->get_formatted_billing_address() and WC_Order->get_formatted_shipping_address().
+	 *
+	 * @since   1.8.5
+	 *
+	 * @param   array $address    Billing or Shipping Address.
+	 * @return  array
+	 */
+	public function remove_name_from_address( $address ) {
+
+		unset( $address['first_name'], $address['last_name'], $address['company_name'] );
+		return $address;
 
 	}
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -215,14 +215,15 @@ class ConvertKitAPI extends \Codeception\Module
 	/**
 	 * Check the subscriber array's custom field data is valid.
 	 *
-	 * @param   AcceptanceTester $I             AcceptanceTester.
-	 * @param   array            $subscriber     Subscriber from API.
+	 * @param   AcceptanceTester $I                         AcceptanceTester.
+	 * @param   array            $subscriber                Subscriber from API.
+	 * @param   bool             $excludeNameFromAddress    Exclude name from billing address.
 	 */
-	public function apiCustomFieldDataIsValid($I, $subscriber)
+	public function apiCustomFieldDataIsValid($I, $subscriber, $excludeNameFromAddress = false)
 	{
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
-		$I->assertEquals($subscriber['fields']['billing_address'], 'First Last, Address Line 1, City, CA 12345');
+		$I->assertEquals($subscriber['fields']['billing_address'], ( $excludeNameFromAddress ? 'Address Line 1, City, CA 12345' : 'First Last, Address Line 1, City, CA 12345' ));
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
 	}

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -85,15 +85,16 @@ class Plugin extends \Codeception\Module
 	 *
 	 * @since   1.6.0
 	 *
-	 * @param   AcceptanceTester $I                     Acceptance Tester.
-	 * @param   bool|string      $accessToken           Access Token (if specified, used instead of CONVERTKIT_OAUTH_ACCESS_TOKEN).
-	 * @param   bool|string      $refreshToken          Refresh Token (if specified, used instead of CONVERTKIT_OAUTH_REFRESH_TOKEN).
-	 * @param   string           $subscriptionEvent     Subscribe Event.
-	 * @param   bool|string      $subscription          Form, Tag or Sequence to subscribe customer to.
-	 * @param   string           $nameFormat            Name Format.
-	 * @param   bool             $mapCustomFields       Map Order data to Custom Fields.
-	 * @param   bool             $displayOptIn          Display Opt-In Checkbox.
-	 * @param   bool             $sendPurchaseDataEvent Send Purchase Data to ConvertKit on Order Event.
+	 * @param   AcceptanceTester $I                      Acceptance Tester.
+	 * @param   bool|string      $accessToken            Access Token (if specified, used instead of CONVERTKIT_OAUTH_ACCESS_TOKEN).
+	 * @param   bool|string      $refreshToken           Refresh Token (if specified, used instead of CONVERTKIT_OAUTH_REFRESH_TOKEN).
+	 * @param   string           $subscriptionEvent      Subscribe Event.
+	 * @param   bool|string      $subscription           Form, Tag or Sequence to subscribe customer to.
+	 * @param   string           $nameFormat             Name Format.
+	 * @param   bool             $mapCustomFields        Map Order data to Custom Fields.
+	 * @param   bool             $displayOptIn           Display Opt-In Checkbox.
+	 * @param   bool             $sendPurchaseDataEvent  Send Purchase Data to ConvertKit on Order Event.
+	 * @param   bool             $excludeNameFromAddress Exclude name from billing and shipping addresses.
 	 */
 	public function setupConvertKitPlugin(
 		$I,
@@ -104,39 +105,41 @@ class Plugin extends \Codeception\Module
 		$nameFormat = 'first',
 		$mapCustomFields = false,
 		$displayOptIn = false,
-		$sendPurchaseDataEvent = false
+		$sendPurchaseDataEvent = false,
+		$excludeNameFromAddress = false
 	) {
 		// Define Plugin's settings.
 		$I->haveOptionInDatabase(
 			'woocommerce_ckwc_settings',
 			[
-				'enabled'                       => 'yes',
-				'access_token'                  => ( $accessToken !== false ? $accessToken : $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] ),
-				'refresh_token'                 => ( $refreshToken !== false ? $refreshToken : $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] ),
-				'event'                         => $subscriptionEvent,
-				'subscription'                  => ( $subscription ? $subscription : '' ),
-				'name_format'                   => $nameFormat,
+				'enabled'                           => 'yes',
+				'access_token'                      => ( $accessToken !== false ? $accessToken : $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] ),
+				'refresh_token'                     => ( $refreshToken !== false ? $refreshToken : $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] ),
+				'event'                             => $subscriptionEvent,
+				'subscription'                      => ( $subscription ? $subscription : '' ),
+				'name_format'                       => $nameFormat,
 
 				// Custom Field mappings.
-				'custom_field_last_name'        => ( $mapCustomFields ? 'last_name' : '' ),
-				'custom_field_phone'            => ( $mapCustomFields ? 'phone_number' : '' ),
-				'custom_field_billing_address'  => ( $mapCustomFields ? 'billing_address' : '' ),
-				'custom_field_shipping_address' => ( $mapCustomFields ? 'shipping_address' : '' ),
-				'custom_field_payment_method'   => ( $mapCustomFields ? 'payment_method' : '' ),
-				'custom_field_customer_note'    => ( $mapCustomFields ? 'notes' : '' ),
+				'custom_field_last_name'            => ( $mapCustomFields ? 'last_name' : '' ),
+				'custom_field_phone'                => ( $mapCustomFields ? 'phone_number' : '' ),
+				'custom_field_billing_address'      => ( $mapCustomFields ? 'billing_address' : '' ),
+				'custom_field_shipping_address'     => ( $mapCustomFields ? 'shipping_address' : '' ),
+				'custom_field_payment_method'       => ( $mapCustomFields ? 'payment_method' : '' ),
+				'custom_field_customer_note'        => ( $mapCustomFields ? 'notes' : '' ),
+				'custom_field_address_exclude_name' => ( $excludeNameFromAddress ? 'yes' : 'no' ),
 
 				// Opt-In Checkbox.
-				'display_opt_in'                => ( $displayOptIn ? 'yes' : 'no' ),
-				'opt_in_label'                  => 'I want to subscribe to the newsletter',
-				'opt_in_status'                 => 'checked',
-				'opt_in_location'               => 'billing',
+				'display_opt_in'                    => ( $displayOptIn ? 'yes' : 'no' ),
+				'opt_in_label'                      => 'I want to subscribe to the newsletter',
+				'opt_in_status'                     => 'checked',
+				'opt_in_location'                   => 'billing',
 
 				// Purchase Data.
-				'send_purchases'                => ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
-				'send_purchases_event'          => ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
+				'send_purchases'                    => ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
+				'send_purchases_event'              => ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
 
 				// Debug.
-				'debug'                         => 'yes',
+				'debug'                             => 'yes',
 			]
 		);
 	}

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -233,7 +233,8 @@ class WooCommerce extends \Codeception\Module
 			$options['name_format'],
 			$options['custom_fields'],
 			$options['display_opt_in'],
-			( ( $options['send_purchase_data'] === true ) ? 'processing' : $options['send_purchase_data'] )
+			( ( $options['send_purchase_data'] === true ) ? 'processing' : $options['send_purchase_data'] ),
+			$options['exclude_name_from_address']
 		);
 
 		// Create Product.

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -210,6 +210,7 @@ class WooCommerce extends \Codeception\Module
 			'send_purchase_data'        => false,
 			'product_form_tag_sequence' => false,
 			'custom_fields'             => false,
+			'exclude_name_from_address' => false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
 			'use_legacy_checkout'       => true,

--- a/tests/acceptance/settings/SettingCustomFieldsCest.php
+++ b/tests/acceptance/settings/SettingCustomFieldsCest.php
@@ -53,6 +53,7 @@ class SettingCustomFieldsCest
 		$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+		$I->checkOption('#woocommerce_ckwc_custom_field_address_exclude_name');
 		$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
 		$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
 
@@ -67,6 +68,7 @@ class SettingCustomFieldsCest
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
+		$I->seeCheckboxIsChecked('#woocommerce_ckwc_custom_field_address_exclude_name');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
 	}

--- a/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -180,6 +180,46 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * - The Customer's name is not included in the address custom field.
+	 *
+	 * @since   1.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'custom_fields'             => true,
+				'exclude_name_from_address' => true,
+				'use_legacy_checkout'       => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct, and the name
+		// is not included in the address.
+		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
 	 *
 	 * @since   1.4.3
 	 *

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -249,6 +249,51 @@ class SubscribeOnOrderCompletedEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
+	 * - The Customer's name is not included in the address custom field.
+	 *
+	 * @since   1.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'completed',
+				'custom_fields'             => true,
+				'exclude_name_from_address' => true,
+			]
+		);
+
+		// Confirm that the email address wasn't yet added to ConvertKit.
+		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+
+		// Change the Order status = Completed, to trigger the Order Completed event.
+		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct, and the name
+		// is not included in the address.
+		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as completed.
 	 *
 	 * @since   1.4.3
 	 *

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -157,6 +157,45 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * - The Customer's name is not included in the address custom field.
+	 *
+	 * @since   1.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'pending',
+				'custom_fields'             => true,
+				'exclude_name_from_address' => true,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct, and the name
+		// is not included in the address.
+		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is created.
 	 *
 	 * @since   1.4.3

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -176,6 +176,45 @@ class SubscribeOnOrderProcessingEventCest
 	 * - The opt in checkbox is checked on the WooCommerce checkout, and
 	 * - The Customer purchases a 'Simple' WooCommerce Product, and
 	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 * - The Customer's name is not included in the address custom field.
+	 *
+	 * @since   1.8.5
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(AcceptanceTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'            => true,
+				'check_opt_in'              => true,
+				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'        => 'processing',
+				'custom_fields'             => true,
+				'exclude_name_from_address' => true,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data exists and is correct, and the name
+		// is not included in the address.
+		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
+	}
+
+	/**
+	 * Test that the Customer is subscribed to ConvertKit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - Order data is mapped to ConvertKit Custom fields in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
 	 *
 	 * @since   1.4.3
 	 *


### PR DESCRIPTION
## Summary

Adds an option to exclude the name from the billing and shipping address when stored as custom fields in ConvertKit, [as requested here](https://linear.app/kit/issue/BCDC-3223/woocommerce-billing-address-issue).

![Screenshot 2024-09-17 at 11 11 58](https://github.com/user-attachments/assets/c34951ec-f013-40aa-ba39-5d1f6e7b5b0d)

## Testing

Added the following tests to confirm the name is excluded from the address custom field when this setting is enabled:

- `testSendPurchaseDataWithCustomFieldsAndExcludeNameFromAddressOnSimpleProductCheckout`
- `testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct`
- `testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct`
- `testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct`
- `testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct`

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)