### PR TITLE
Tests: Fix Cart Product Check

### DIFF
--- a/tests/Support/Helper/WooCommerce.php
+++ b/tests/Support/Helper/WooCommerce.php
@@ -752,18 +752,15 @@ class WooCommerce extends \Codeception\Module
 		$I->click('button[name=add-to-cart]');
 
 		// View Cart.
+		$I->waitForElementVisible('a.wc-forward');
 		$I->click('a.wc-forward');
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
 
 		// Check that the Product exists in the Cart.
-		if ($useLegacyCheckout) {
-			$I->seeInSource($productName);
-		} else {
-			$I->waitForElementVisible('.wc-block-components-product-name');
-			$I->assertEquals($productName, $I->grabTextFrom('.wc-block-components-product-name'));
-		}
+		$I->waitForElementVisible('.wc-block-components-product-name');
+		$I->assertEquals($productName, $I->grabTextFrom('.wc-block-components-product-name'));
 
 		// Proceed to Checkout.
 		$I->click('Proceed to Checkout');


### PR DESCRIPTION
## Summary

A recent WooCommerce update loads the cart asynchronously, resulting in test failures when asserting if the product was added:

<img width="1919" height="940" alt="Tests EndToEnd SubscribeCheckoutBlockOnOrderProcessingEventCest testOptInWhenCheckedWithFormAndSimpleProduct fail" src="https://github.com/user-attachments/assets/7c21d616-3663-4862-8731-5f6f4c14fec7" />

This PR resolves by waiting for the cart table to fully load, before performing checks and proceeding.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)