### PR TITLE
Remove v3 API Key and Secret on Plugin Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-       "convertkit/convertkit-wordpress-libraries": "2.1.3"
+       "convertkit/convertkit-wordpress-libraries": "2.1.5"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/includes/class-ckwc-setup.php
+++ b/includes/class-ckwc-setup.php
@@ -50,8 +50,36 @@ class CKWC_Setup {
 			$this->maybe_get_access_token_by_api_key_and_secret();
 		}
 
+		// Actions that should run regardless of the version number
+		// whenever the Plugin is updated.
+		$this->remove_v3_api_key_and_secret_from_settings();
+
 		// Update the installed version number in the options table.
 		update_option( 'ckwc_version', CKWC_PLUGIN_VERSION );
+
+	}
+
+	/**
+	 * Remove v3 API key and Secret from settings.
+	 *
+	 * @since   2.1.4
+	 */
+	private function remove_v3_api_key_and_secret_from_settings() {
+
+		// Get settings.
+		$settings = get_option( 'woocommerce_ckwc_settings' );
+
+		// Bail if no settings exist.
+		if ( ! $settings ) {
+			return;
+		}
+
+		// Remove v3 API Secret from settings.
+		$settings['api_key']    = '';
+		$settings['api_secret'] = '';
+
+		// Save settings.
+		update_option( 'woocommerce_ckwc_settings', $settings );
 
 	}
 

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -148,6 +148,39 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Tests that the v3 API Key and Secret are removed from settings when upgrading to 2.1.3 or later.
+	 *
+	 * @since   2.1.3
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testV3APIKeyAndSecretRemovedFromSettings(EndToEndTester $I)
+	{
+		// Setup Plugin with v3 API Key and Secret.
+		$I->haveOptionInDatabase(
+			'woocommerce_ckwc_settings',
+			[
+				'access_token'  => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+				'refresh_token' => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+				'api_key'       => $_ENV['CONVERTKIT_API_KEY'],
+				'api_secret'    => $_ENV['CONVERTKIT_API_SECRET'],
+				'enabled'       => 'yes',
+			]
+		);
+
+		// Define an installation version older than 2.1.3.
+		$I->haveOptionInDatabase('ckwc_version', '2.0.4');
+
+		// Activate the WooCommerce and Kit Plugins.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Confirm the settings no longer have a value for the v3 API Key and Secret.
+		$settings = $I->grabOptionFromDatabase('woocommerce_ckwc_settings');
+		$I->assertEmpty($settings['api_key']);
+		$I->assertEmpty($settings['api_secret']);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -43,12 +43,6 @@ class UpgradePathsCest
 		$I->assertArrayHasKey('refresh_token', $settings);
 		$I->assertArrayHasKey('token_expires', $settings);
 
-		// Confirm the API Key and Secret are retained, in case we need them in the future.
-		$I->assertArrayHasKey('api_key', $settings);
-		$I->assertArrayHasKey('api_secret', $settings);
-		$I->assertEquals($settings['api_key'], $_ENV['CONVERTKIT_API_KEY']);
-		$I->assertEquals($settings['api_secret'], $_ENV['CONVERTKIT_API_SECRET']);
-
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
 


### PR DESCRIPTION
## Summary

Whenever a new Plugin release is published and the creator updates to the latest version, checks if a v3 API Key and/or Secret exists, and if so deletes it from the Plugin's settings.

v3 API Keys and Secrets were retained following the introduction of the v4 API, to [permit automatic exchange](https://github.com/Kit/convertkit-woocommerce/pull/181) of v3 API Keys for v4 tokens. This was in July 2024, so by now the v3 API key secret isn't needed.

## Testing

- `testV3APIKeyAndSecretRemovedFromSettings`: Test that a v3 API Key and Secret are removed from the Plugin's settings when specified.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)