### PR TITLE
Run PHPStan against PHP 7.1+

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -151,5 +151,4 @@ jobs:
       # Run PHPStan for static analysis.
       - name: Run PHPStan Static Analysis
         working-directory: ${{ env.PLUGIN_DIR }}
-        if: ${{ contains('8.0 8.1 8.2 8.3 8.4', matrix.php-versions) }}
         run: php vendor/bin/phpstan analyse --memory-limit=1024M

--- a/phpstan-dev.neon
+++ b/phpstan-dev.neon
@@ -6,6 +6,11 @@ includes:
 
 # Parameters
 parameters:
+    # Analyse against the minimum supported PHP version.
+    # This flags features (union types, enums, str_contains, etc.) that would
+    # fail on older PHP versions regardless of which PHP version PHPStan runs on.
+    phpVersion: 70100
+
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:

--- a/phpstan-dev.neon
+++ b/phpstan-dev.neon
@@ -30,11 +30,17 @@ parameters:
     scanFiles:
         - /wp/wp-config.php
 
-    # Should not need to edit anything below here
-    # Rule Level: https://phpstan.org/user-guide/rule-levels
-    level: 5
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
 
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
+        - '#unknown class WC_Session_Handler#'
+        - '#unknown class WC_Order_Item#'
         - '#Call to an undefined method WC_Order_Item::get_product\(\).#'
+        - '#No error to ignore is reported#'
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,11 @@ includes:
 
 # Parameters
 parameters:
+    # Analyse against the minimum supported PHP version.
+    # This flags features (union types, enums, str_contains, etc.) that would
+    # fail on older PHP versions regardless of which PHP version PHPStan runs on.
+    phpVersion: 70100
+
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,11 +30,17 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-config.php
 
-    # Should not need to edit anything below here
-    # Rule Level: https://phpstan.org/user-guide/rule-levels
-    level: 5
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
 
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
+        - '#unknown class WC_Session_Handler#'
+        - '#unknown class WC_Order_Item#'
         - '#Call to an undefined method WC_Order_Item::get_product\(\).#'
+        - '#No error to ignore is reported#'
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -6,6 +6,11 @@ includes:
 
 # Parameters
 parameters:
+    # Analyse against the minimum supported PHP version.
+    # This flags features (union types, enums, str_contains, etc.) that would
+    # fail on older PHP versions regardless of which PHP version PHPStan runs on.
+    phpVersion: 70100
+
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -30,11 +30,17 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-config.php
 
-    # Should not need to edit anything below here
-    # Rule Level: https://phpstan.org/user-guide/rule-levels
-    level: 5
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
 
     # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
     # so they're false positives.
     ignoreErrors:
+        - '#unknown class WC_Session_Handler#'
+        - '#unknown class WC_Order_Item#'
         - '#Call to an undefined method WC_Order_Item::get_product\(\).#'
+        - '#No error to ignore is reported#'
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5


### PR DESCRIPTION
## Summary

2.1.1 and 2.1.1.1 shipped with Kit WordPress Libraries 2.1.4, which introduced a parse error on PHP ≤7.4 due to union types (PHP 8+ only) in the SDK:

`syntax error, unexpected '|', expecting variable (T_VARIABLE)`

2.1.2 was released, restoring the Kit WordPress Libraries back to 2.1.3. PHP 7.1+ compatibility was then restored in the Kit WordPress Libraries 2.1.5 via a [backport](https://github.com/Kit/convertkit-wordpress-libraries/pull/114).

This PR sets PHPStan’s phpVersion to ensure analysis targets PHP 7.1+ for the Plugin's code, to protect against a similar issue stemming from outside the Kit WordPress Libraries in the future.

While dropping older PHP support would be ideal, [current usage](https://linear.app/kit/issue/WP-79/wp-high-fatal-error-occurring-for-kit-plugins-in-wordpress) indicates it’s not yet practical.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)