### PR TITLE
Run Dependabot on Composer Packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "production"
+    versioning-strategy: "increase"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,29 @@ on:
       - main
 
 jobs:
+  dependabot-metadata:
+    # Name.
+    name: Dependabot Metadata
+
+    # Virtual Environment to use.
+    # @see: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-latest
+
+    # Don't run if the PR is not from Dependabot.
+    if: github.actor == 'dependabot[bot]'
+
+    # Outputs.
+    outputs:
+      package-ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}
+
+    # Steps to fetch Dependabot metadata.
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   tests:
     # Name.
     name: Coding Standards / WordPress ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
@@ -19,10 +42,17 @@ jobs:
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
 
-    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
-    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
-    # Plugin tests.
-    if: github.actor != 'dependabot[bot]'
+    # Requieres the dependabot-metadata job to have run successfully.
+    needs: [dependabot-metadata]
+
+    # Always allow non-Dependabot PRs and pushes.
+    # For Dependabot PRs, only run when the update is for composer (skip github-actions updates).
+    if: |
+      always() &&
+      (
+        github.actor != 'dependabot[bot]' ||
+        needs.dependabot-metadata.outputs.package-ecosystem == 'composer'
+      )
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -11,6 +11,29 @@ on:
       - main
 
 jobs:
+  dependabot-metadata:
+    # Name.
+    name: Dependabot Metadata
+
+    # Virtual Environment to use.
+    # @see: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-latest
+
+    # Don't run if the PR is not from Dependabot.
+    if: github.actor == 'dependabot[bot]'
+
+    # Outputs.
+    outputs:
+      package-ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}
+
+    # Steps to fetch Dependabot metadata.
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   tests:
     # Name.
     name: ${{ matrix.test-groups }} / WordPress ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
@@ -19,10 +42,17 @@ jobs:
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
 
-    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
-    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
-    # Plugin tests.
-    if: github.actor != 'dependabot[bot]'
+    # Requieres the dependabot-metadata job to have run successfully.
+    needs: [dependabot-metadata]
+
+    # Always allow non-Dependabot PRs and pushes.
+    # For Dependabot PRs, only run when the update is for composer (skip github-actions updates).
+    if: |
+      always() &&
+      (
+        github.actor != 'dependabot[bot]' ||
+        needs.dependabot-metadata.outputs.package-ecosystem == 'composer'
+      )
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,29 @@ on:
       - main
 
 jobs:
+  dependabot-metadata:
+    # Name.
+    name: Dependabot Metadata
+
+    # Virtual Environment to use.
+    # @see: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-latest
+
+    # Don't run if the PR is not from Dependabot.
+    if: github.actor == 'dependabot[bot]'
+
+    # Outputs.
+    outputs:
+      package-ecosystem: ${{ steps.metadata.outputs.package-ecosystem }}
+
+    # Steps to fetch Dependabot metadata.
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
   tests:
     # Name.
     name: ${{ matrix.test-groups }} / WordPress ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
@@ -19,10 +42,17 @@ jobs:
     # @see: https://github.com/actions/virtual-environments
     runs-on: ubuntu-latest
 
-    # Don't run if the PR is from Dependabot, as it doesn't have access to the repository's secrets.
-    # Dependabot also only checks for GitHub action dependencies, so it's not necessary to run
-    # Plugin tests.
-    if: github.actor != 'dependabot[bot]'
+    # Requieres the dependabot-metadata job to have run successfully.
+    needs: [dependabot-metadata]
+
+    # Always allow non-Dependabot PRs and pushes.
+    # For Dependabot PRs, only run when the update is for composer (skip github-actions updates).
+    if: |
+      always() &&
+      (
+        github.actor != 'dependabot[bot]' ||
+        needs.dependabot-metadata.outputs.package-ecosystem == 'composer'
+      )
 
     # Environment Variables.
     # Accessible by using ${{ env.NAME }}


### PR DESCRIPTION
## Summary

Configures Dependabot to create PR's and run tests when any packages (currently only Kit's WordPress Libraries) in `composer.json` `require` section have a newer version available, ensuring they remain up to date.

Dependabot PR's relating to GitHub Action packages will still skip tests, which is intentional.

Currently, manual PR's would need to be submitted to update Kit's WordPress Libraries.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)