### PR TITLE
Tests: Remove `nanasess/setup-chromedriver@master`

### DIFF
--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -244,9 +244,6 @@ jobs:
       - name: Start nginx
         run: sudo systemctl start nginx.service
         
-      - name: Install chromedriver
-        uses: nanasess/setup-chromedriver@master
-
       - name: Start chromedriver
         run: |
           export DISPLAY=:99

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,9 +263,6 @@ jobs:
       - name: Start nginx
         run: sudo systemctl start nginx.service
         
-      - name: Install chromedriver
-        uses: nanasess/setup-chromedriver@master
-
       - name: Start chromedriver
         run: |
           export DISPLAY=:99


### PR DESCRIPTION
## Summary

Removes the`nanasess/setup-chromedriver@master` step in GitHub actions, as it's no longer needed.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)