### PR TITLE
Tests: Fix Checkout

### DIFF
--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -244,9 +244,6 @@ jobs:
       - name: Start nginx
         run: sudo systemctl start nginx.service
         
-      - name: Install chromedriver
-        uses: nanasess/setup-chromedriver@master
-
       - name: Start chromedriver
         run: |
           export DISPLAY=:99

--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -96,7 +96,7 @@ jobs:
     steps:
       - name: Define Test Group Name
         id: test-group
-        uses: mad9000/actions-find-and-replace-string@5
+        uses: mad9000/actions-find-and-replace-string@6
         with:
           source: ${{ matrix.test-groups }}
           find: '/'        
@@ -270,24 +270,22 @@ jobs:
 
       # Write any secrets, such as API keys, to the .env.testing file now.
       - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.3
-        with:
-          path: ${{ env.PLUGIN_DIR }}/.env.testing
-          contents: |
-            STRIPE_TEST_PUBLISHABLE_KEY=${{ env.STRIPE_TEST_PUBLISHABLE_KEY }}
-            STRIPE_TEST_SECRET_KEY=${{ env.STRIPE_TEST_SECRET_KEY }}
-            CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
-            CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
-            CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
-            CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
-            CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
-            KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
-          write-mode: overwrite
+        run: |
+          cat > ${{ env.PLUGIN_DIR }}/.env.testing << 'ENVEOF'
+          STRIPE_TEST_PUBLISHABLE_KEY=${{ env.STRIPE_TEST_PUBLISHABLE_KEY }}
+          STRIPE_TEST_SECRET_KEY=${{ env.STRIPE_TEST_SECRET_KEY }}
+          CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
+          CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
+          CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
+          CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
+          CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
+          KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
+          ENVEOF
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
       - name: Run Composer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,9 +263,6 @@ jobs:
       - name: Start nginx
         run: sudo systemctl start nginx.service
         
-      - name: Install chromedriver
-        uses: nanasess/setup-chromedriver@master
-
       - name: Start chromedriver
         run: |
           export DISPLAY=:99

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - name: Define Test Group Name
         id: test-group
-        uses: mad9000/actions-find-and-replace-string@5
+        uses: mad9000/actions-find-and-replace-string@6
         with:
           source: ${{ matrix.test-groups }}
           find: '/'        
@@ -289,24 +289,22 @@ jobs:
 
       # Write any secrets, such as API keys, to the .env.testing file now.
       - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.3
-        with:
-          path: ${{ env.PLUGIN_DIR }}/.env.testing
-          contents: |
-            STRIPE_TEST_PUBLISHABLE_KEY=${{ env.STRIPE_TEST_PUBLISHABLE_KEY }}
-            STRIPE_TEST_SECRET_KEY=${{ env.STRIPE_TEST_SECRET_KEY }}
-            CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
-            CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
-            CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
-            CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
-            CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
-            CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
-            CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
-            KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
-          write-mode: overwrite
+        run: |
+          cat > ${{ env.PLUGIN_DIR }}/.env.testing << 'ENVEOF'
+          STRIPE_TEST_PUBLISHABLE_KEY=${{ env.STRIPE_TEST_PUBLISHABLE_KEY }}
+          STRIPE_TEST_SECRET_KEY=${{ env.STRIPE_TEST_SECRET_KEY }}
+          CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
+          CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
+          CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
+          CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
+          CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
+          CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
+          CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
+          KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
+          ENVEOF
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
       - name: Run Composer

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ This security policy applies to public projects under the [Kit organization](htt
 If you discover a security vulnerability, please report via any of the below:
 
 - [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
-- [PatchStack](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d)
+- [PatchStack]()
 - [GitHub](https://github.com/Kit/convertkit-woocommerce/security/advisories)
 - [Email](mailto:security@kit.com)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+This security policy applies to public projects under the [Kit organization](https://github.com/kit) on GitHub.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report via any of the below:
+
+- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
+- [PatchStack](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d)
+- [GitHub](https://github.com/Kit/convertkit-woocommerce/security/advisories)
+- [Email](mailto:security@kit.com)
+
+Please do **not** report security issues publicly via GitHub issues or discussions. Security reports sent via the above channels be acknowledged within 48 hours.
+
+## Security Disclosure Process
+
+When reporting a security vulnerability, please include:
+
+1. **Description** - A clear description of the vulnerability
+2. **Impact** - What kind of vulnerability it is and who it impacts
+3. **Reproduction** - Detailed steps to reproduce the issue
+4. **Proof of Concept** - If applicable, include proof-of-concept code
+5. **Suggested Fix** - If you have ideas for how to fix the issue
+
+## Security Response Timeline
+
+- **Initial Response**: Within 48 hours of receiving the report
+- **Investigation**: We will investigate and validate the reported vulnerability
+- **Fix Development**: Development of a patch or mitigation strategy
+- **Release**: Coordinated disclosure and release of security update
+- **Public Disclosure**: After users have had time to upgrade

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ This security policy applies to public projects under the [Kit organization](htt
 
 If you discover a security vulnerability, please report via any of the below:
 
-- [BugCrowd](https://docs.bugcrowd.com/researchers/reporting-managing-submissions/reporting-a-bug/#creating-a-vulnerability-report)
-- [PatchStack]()
+- [Kit](https://kit.com/report-vulnerability)
+- [PatchStack](https://patchstack.com/database/vdp/b599634b-6960-4d4b-bb14-bd00c08392b0)
 - [GitHub](https://github.com/Kit/convertkit-woocommerce/security/advisories)
 - [Email](mailto:security@kit.com)
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-       "convertkit/convertkit-wordpress-libraries": "2.1.6"
+       "convertkit/convertkit-wordpress-libraries": "2.1.7"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -255,12 +255,18 @@ class CKWC_Checkout {
 			return $value;
 		}
 
-		// Store the value of the opt in checkbox in the `ckwc_opt_in` meta key,
-		// as we do for the block and shortcode methods.
-		$this->save_opt_in_for_order(
-			$wc_object,
-			(bool) $value
-		);
+		// Store the value of the opt in checkbox in the `ckwc_opt_in` meta key.
+		// We can't use save_opt_in_for_order() here: this action fires while WooCommerce is
+		// building the Store API Checkout Block order, before the order has been assigned an ID,
+		// so that method's `OrderUtil::get_order_type( $order->get_id() )` guard would bail on a
+		// zero ID. Instead set the meta directly on the order object. If the order already has an
+		// ID we persist immediately; otherwise WooCommerce saves the order after additional fields
+		// are set, which persists the meta for us.
+		$wc_object->update_meta_data( 'ckwc_opt_in', ( (bool) $value ) ? 'yes' : 'no' );
+
+		if ( $wc_object->get_id() ) {
+			$wc_object->save();
+		}
 
 		// Return original value.
 		return $value;

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -108,14 +108,14 @@ class CKWC_Order {
 		// Get WooCommerce Order.
 		$order = wc_get_order( $order_id );
 
-		// Bail if the Order does not require that we subscribe the Customer,
-		// or the Customer was already subscribed.
-		if ( ! $this->should_opt_in_customer( $order ) ) {
+		// If no Order could be fetched, bail.
+		if ( ! $order ) {
 			return;
 		}
 
-		// If no Order could be fetched, bail.
-		if ( ! $order ) {
+		// Bail if the Order does not require that we subscribe the Customer,
+		// or the Customer was already subscribed.
+		if ( ! $this->should_opt_in_customer( $order ) ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,10 +36,8 @@ Full plugin documentation is located [here](https://help.kit.com/en/articles/250
 == Frequently asked questions ==
 
 = Does this plugin require a paid service? =
-No. You must first have an account on kit.com, but you do not have to use a paid plan!
 
-= Where do I report security bugs found in this plugin? =
-Please report security bugs found in the source code of the Kit (formerly ConvertKit) plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+No. You must first have an account on kit.com, but you do not have to use a paid plan!
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,8 +36,10 @@ Full plugin documentation is located [here](https://help.kit.com/en/articles/250
 == Frequently asked questions ==
 
 = Does this plugin require a paid service? =
-
 No. You must first have an account on kit.com, but you do not have to use a paid plan!
+
+= Where do I report security bugs found in this plugin? =
+Please report security bugs found in the source code of the Kit (formerly ConvertKit) plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/1010ebe1-02b2-4144-8297-b8cddba0ce7d). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ Full plugin documentation is located [here](https://help.kit.com/en/articles/250
 
 No. You must first have an account on kit.com, but you do not have to use a paid plan!
 
+= Where do I report security bugs found in this plugin? =
+Please report security bugs found in the source code of the plugin through the [Patchstack Vulnerability Disclosure Program](https://patchstack.com/database/vdp/b599634b-6960-4d4b-bb14-bd00c08392b0). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
+
 == Screenshots ==
 
 1. Settings page

--- a/tests/Support/Helper/WooCommerce.php
+++ b/tests/Support/Helper/WooCommerce.php
@@ -841,7 +841,9 @@ class WooCommerce extends \Codeception\Module
 			default:
 				// Select COD Payment Method, if a radio button exists, depending on the checkout type.
 				if ($I->tryToSeeElement('#payment_method_cod')) {
-					$I->click('#payment_method_cod');
+					$I->scrollTo('#payment_method_cod', 0, -100);
+					$I->waitForElementNotVisible('.blockOverlay');
+					$I->executeJS("document.querySelector('#payment_method_cod').click();");
 				} elseif ($I->tryToSeeElement('#radio-control-wc-payment-method-options-cod')) {
 					$I->click('#radio-control-wc-payment-method-options-cod');
 				}

--- a/uninstall.php
+++ b/uninstall.php
@@ -30,14 +30,12 @@ if ( array_key_exists( 'access_token', $settings ) && ! empty( $settings['access
 		'https://api.kit.com/v4/oauth/revoke',
 		array(
 			'headers' => array(
-				'Accept'       => 'application/json',
-				'Content-Type' => 'application/json',
+				'Content-Type' => 'application/x-www-form-urlencoded',
 			),
-			'body'    => wp_json_encode(
-				array(
-					'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
-					'token'     => $settings['access_token'],
-				)
+			'body'    => array(
+				'client_id'       => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+				'token'           => $settings['access_token'],
+				'token_type_hint' => 'access_token',
 			),
 			'timeout' => 5,
 		)
@@ -50,14 +48,12 @@ if ( array_key_exists( 'refresh_token', $settings ) && ! empty( $settings['refre
 		'https://api.kit.com/v4/oauth/revoke',
 		array(
 			'headers' => array(
-				'Accept'       => 'application/json',
-				'Content-Type' => 'application/json',
+				'Content-Type' => 'application/x-www-form-urlencoded',
 			),
-			'body'    => wp_json_encode(
-				array(
-					'client_id' => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
-					'token'     => $settings['refresh_token'],
-				)
+			'body'    => array(
+				'client_id'       => 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A',
+				'token'           => $settings['refresh_token'],
+				'token_type_hint' => 'refresh_token',
 			),
 			'timeout' => 5,
 		)


### PR DESCRIPTION
## Summary

Fixes test failures at checkout due to changes in WooCommerce's checkout layout.

Store the value of the opt in checkbox using a different method when using the block version of WooCommerce's checkout, to ensure its setting / value is honored.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)