### PR TITLE
Export Configuration: Check nonce

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -277,16 +277,19 @@ class CKWC_Integration extends WC_Integration {
 	 */
 	public function maybe_export_configuration() {
 
-		// Bail if we're not on the settings screen.
-		if ( ! $this->get_integration_screen_name() ) {
+		// Bail if nonce verification fails.
+		if ( ! isset( $_REQUEST['nonce'] ) ) {
+			return;
+		}
+		if ( ! wp_verify_nonce( sanitize_key( $_REQUEST['nonce'] ), 'ckwc-nonce' ) ) {
 			return;
 		}
 
 		// Bail if the action isn't for exporting a configuration file.
-		if ( ! array_key_exists( 'action', $_REQUEST ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! array_key_exists( 'action', $_REQUEST ) ) {
 			return;
 		}
-		if ( $_REQUEST['action'] !== 'ckwc-export' ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( $_REQUEST['action'] !== 'ckwc-export' ) {
 			return;
 		}
 

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -277,6 +277,16 @@ class CKWC_Integration extends WC_Integration {
 	 */
 	public function maybe_export_configuration() {
 
+		// Bail if we're not on the settings screen.
+		if ( ! $this->get_integration_screen_name() ) {
+			return;
+		}
+
+		// Bail if the user isn't permitted to manage WooCommerce settings.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
 		// Bail if nonce verification fails.
 		if ( ! isset( $_REQUEST['nonce'] ) ) {
 			return;

--- a/languages/woocommerce-convertkit.pot
+++ b/languages/woocommerce-convertkit.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPLv3 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Kit (formerly ConvertKit) for WooCommerce 2.1.6\n"
+"Project-Id-Version: Kit (formerly ConvertKit) for WooCommerce 2.1.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/convertkit-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-09T02:35:20+00:00\n"
+"POT-Creation-Date: 2026-07-09T04:40:17+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-convertkit\n"
@@ -242,340 +242,340 @@ msgstr ""
 msgid "The Kit WordPress Libraries is missing the `revoke_tokens` method. Please update all Kit WordPress Plugins to their latest versions, and click Disconnect again."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:357
+#: includes/class-ckwc-integration.php:360
 msgid "The uploaded configuration file isn't valid."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:366
+#: includes/class-ckwc-integration.php:369
 msgid "The uploaded configuration file contains no settings."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:383
+#: includes/class-ckwc-integration.php:386
 msgid "Configuration imported successfully."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:498
+#: includes/class-ckwc-integration.php:501
 msgid "Account Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:500
+#: includes/class-ckwc-integration.php:503
 msgid "Disconnect"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:517
+#: includes/class-ckwc-integration.php:520
 msgid "Enable/Disable"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:519
+#: includes/class-ckwc-integration.php:522
 msgid "Enable Kit integration"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:525
+#: includes/class-ckwc-integration.php:528
 msgid "Subscribe Event"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:531
+#: includes/class-ckwc-integration.php:534
 msgid "When should customers be subscribed?"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:535
+#: includes/class-ckwc-integration.php:538
 msgid "Pending payment:"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:536
+#: includes/class-ckwc-integration.php:539
 msgid "WooCommerce order created, payment not received."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:541
-#: includes/class-ckwc-integration.php:756
+#: includes/class-ckwc-integration.php:544
+#: includes/class-ckwc-integration.php:759
 msgid "Processing:"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:542
-#: includes/class-ckwc-integration.php:757
+#: includes/class-ckwc-integration.php:545
+#: includes/class-ckwc-integration.php:760
 msgid "WooCommerce order created, payment received, order awaiting fulfilment."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:547
-#: includes/class-ckwc-integration.php:762
+#: includes/class-ckwc-integration.php:550
+#: includes/class-ckwc-integration.php:765
 msgid "Completed:"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:548
-#: includes/class-ckwc-integration.php:763
+#: includes/class-ckwc-integration.php:551
+#: includes/class-ckwc-integration.php:766
 msgid "WooCommerce order created, payment received, order fulfiled."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:554
+#: includes/class-ckwc-integration.php:557
 msgid "Order Pending payment"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:555
-#: includes/class-ckwc-integration.php:769
+#: includes/class-ckwc-integration.php:558
+#: includes/class-ckwc-integration.php:772
 msgid "Order Processing"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:556
-#: includes/class-ckwc-integration.php:770
+#: includes/class-ckwc-integration.php:559
+#: includes/class-ckwc-integration.php:773
 msgid "Order Completed"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:563
+#: includes/class-ckwc-integration.php:566
 msgid "Subscription"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:566
+#: includes/class-ckwc-integration.php:569
 msgid "The Kit form, tag or sequence to subscribe customers to."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:575
+#: includes/class-ckwc-integration.php:578
 msgid "Name Format"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:578
+#: includes/class-ckwc-integration.php:581
 msgid "How should the customer name be sent to Kit?"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:581
+#: includes/class-ckwc-integration.php:584
 msgid "Billing First Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:582
+#: includes/class-ckwc-integration.php:585
 msgid "Billing Last Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:583
+#: includes/class-ckwc-integration.php:586
 msgid "Billing First Name + Billing Last Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:592
+#: includes/class-ckwc-integration.php:595
 msgid "Send Last Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:595
+#: includes/class-ckwc-integration.php:598
 msgid "The Kit custom field to store the order's last name."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:601
+#: includes/class-ckwc-integration.php:604
 msgid "Send Phone Number"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:604
+#: includes/class-ckwc-integration.php:607
 msgid "The Kit custom field to store the order's phone number."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:610
+#: includes/class-ckwc-integration.php:613
 msgid "Send Billing Address"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:613
+#: includes/class-ckwc-integration.php:616
 msgid "The Kit custom field to store the order's billing address."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:619
+#: includes/class-ckwc-integration.php:622
 msgid "Send Shipping Address"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:622
+#: includes/class-ckwc-integration.php:625
 msgid "The Kit custom field to store the order's shipping address."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:628
+#: includes/class-ckwc-integration.php:631
 msgid "Address Format"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:639
+#: includes/class-ckwc-integration.php:642
 msgid "The format of the billing and shipping addresses to store in Kit."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:642
+#: includes/class-ckwc-integration.php:645
 msgid "Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:643
+#: includes/class-ckwc-integration.php:646
 msgid "Company Name"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:644
+#: includes/class-ckwc-integration.php:647
 msgid "Address 1"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:645
+#: includes/class-ckwc-integration.php:648
 msgid "Address 2"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:646
+#: includes/class-ckwc-integration.php:649
 msgid "City"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:647
+#: includes/class-ckwc-integration.php:650
 msgid "State"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:648
+#: includes/class-ckwc-integration.php:651
 msgid "Postcode"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:649
+#: includes/class-ckwc-integration.php:652
 msgid "Country"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:656
+#: includes/class-ckwc-integration.php:659
 msgid "Send Payment Method"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:659
+#: includes/class-ckwc-integration.php:662
 msgid "The Kit custom field to store the order's payment method."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:665
+#: includes/class-ckwc-integration.php:668
 msgid "Send Customer Note"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:668
+#: includes/class-ckwc-integration.php:671
 msgid "The Kit custom field to store the order's customer note."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:676
+#: includes/class-ckwc-integration.php:679
 msgid "Opt-In Checkbox"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:677
+#: includes/class-ckwc-integration.php:680
 msgid "Display an opt-in checkbox on checkout"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:680
+#: includes/class-ckwc-integration.php:683
 msgid ""
 "If enabled, customers will <strong>only</strong> be subscribed to the chosen forms, tags and sequences if they check the opt-in checkbox at checkout.<br />\n"
 "\t\t\t\t\t\t\t\t\t  If disabled, customers will <strong>always</strong> be subscribed to the chosen forms, tags and sequences at checkout."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:691
+#: includes/class-ckwc-integration.php:694
 msgid "Opt-In Checkbox: Label"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:693
+#: includes/class-ckwc-integration.php:696
 msgid "I want to subscribe to the newsletter"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:694
+#: includes/class-ckwc-integration.php:697
 msgid "Customize the label next to the opt-in checkbox."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:701
+#: includes/class-ckwc-integration.php:704
 msgid "Opt-In Checkbox: Default Status"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:704
+#: includes/class-ckwc-integration.php:707
 msgid "The default state of the opt-in checkbox."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:707
+#: includes/class-ckwc-integration.php:710
 msgid "Checked"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:708
+#: includes/class-ckwc-integration.php:711
 msgid "Unchecked"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:715
+#: includes/class-ckwc-integration.php:718
 msgid "Opt-In Checkbox: Display Location"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:718
+#: includes/class-ckwc-integration.php:721
 msgid "Where to display the opt-in checkbox on the checkout page (under \"Billing details\" or \"Additional information\")."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:721
+#: includes/class-ckwc-integration.php:724
 msgid "Billing"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:722
+#: includes/class-ckwc-integration.php:725
 msgid "Order"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:731
+#: includes/class-ckwc-integration.php:734
 msgid "Purchase Data"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:732
+#: includes/class-ckwc-integration.php:735
 msgid "Send purchase data to Kit."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:735
+#: includes/class-ckwc-integration.php:738
 msgid ""
 "If enabled, the customer's order data will be sent to Kit. Their email address will always be subscribed to Kit, <strong>regardless of the Customer's opt in status.</strong><br />\n"
 "\t\t\t\t\t\t\t\t\t  If disabled, no order data will be sent to Kit."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:746
+#: includes/class-ckwc-integration.php:749
 msgid "Purchase Data Event"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:752
+#: includes/class-ckwc-integration.php:755
 msgid "When should purchase data be sent?"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:777
+#: includes/class-ckwc-integration.php:780
 msgid "Sync Past Orders"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:778
+#: includes/class-ckwc-integration.php:781
 msgid "Send old purchase data to Kit i.e. Orders that were created in WooCommerce prior to this Plugin being installed."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:794
+#: includes/class-ckwc-integration.php:797
 msgid "Abandoned Cart"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:795
+#: includes/class-ckwc-integration.php:798
 msgid "Send abandoned cart data to Kit."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:798
+#: includes/class-ckwc-integration.php:801
 msgid "If enabled, the visitor will be subscribed to a tag in Kit, if they leave items in their cart without completing the checkout process after the below number of minutes. The tag is removed when they complete checkout."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:808
+#: includes/class-ckwc-integration.php:811
 msgid "Abandoned Cart: Threshold"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:811
+#: includes/class-ckwc-integration.php:814
 msgid "The number of minutes to wait before considering a cart abandoned."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:825
+#: includes/class-ckwc-integration.php:828
 msgid "Abandoned Cart: Tag"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:828
+#: includes/class-ckwc-integration.php:831
 msgid "The Kit tag to subscribe visitors to when they abandon their cart. This can be used in a Sequence or Automation to send abandoned cart emails to the subscriber. This tag is removed when the customer completes the checkout process."
 msgstr ""
 
-#: includes/class-ckwc-integration.php:839
+#: includes/class-ckwc-integration.php:842
 msgid "Debug"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:841
+#: includes/class-ckwc-integration.php:844
 msgid "Write data to a log file"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:846
+#: includes/class-ckwc-integration.php:849
 msgid "View log file"
 msgstr ""
 
-#: includes/class-ckwc-integration.php:916
+#: includes/class-ckwc-integration.php:919
 msgid "Do you want to send past WooCommerce Orders to Kit?"
 msgstr ""
 
 #. translators: Number of WooCommerce Orders
-#: includes/class-ckwc-integration.php:1107
+#: includes/class-ckwc-integration.php:1110
 #, php-format
 msgid "%s not been sent to Kit based on the Purchase Data Event setting above. This is either because sending purchase data is/was disabled, and/or orders were created prior to installing this integration.<br />Use the sync button to send data for these orders to Kit."
 msgstr ""
 
 #. translators: number of Orders not sent to ConvertKit
-#: includes/class-ckwc-integration.php:1110
+#: includes/class-ckwc-integration.php:1113
 #, php-format
 msgid "%s WooCommerce order has"
 msgid_plural "%s WooCommerce orders have"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -51,4 +51,13 @@
 			</property>
 		</properties>
 	</rule>
+
+	<!-- Register WooCommerce custom capabilities so they aren't flagged as unknown. -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="manage_woocommerce"/>
+			</property>
+		</properties>
+	</rule>
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: email, marketing, embed form, convertkit, capture
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.1
-Stable tag: 2.1.6
+Stable tag: 2.1.7
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -48,6 +48,9 @@ Please report security bugs found in the source code of the plugin through the [
 2. Checkout page with added checkbox
 
 == Changelog ==
+
+### 2.1.7 2026-07-09
+* Fix: Settings: Export configuration: check nonce to prevent an unauthenticated user from exporting the Plugin's configuration 
 
 ### 2.1.6 2026-07-09
 * Fix: Checkout: Correctly store opt in value against WooCommerce Order when using newer block checkout

--- a/tests/EndToEnd/settings/SettingImportExportCest.php
+++ b/tests/EndToEnd/settings/SettingImportExportCest.php
@@ -60,6 +60,26 @@ class SettingImportExportCest
 	}
 
 	/**
+	 * Test that the Export Configuration option fails when the nonce is not provided.
+	 *
+	 * @since   2.1.7
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testExportConfigurationFailsWithoutNonce(EndToEndTester $I)
+	{
+		// Load the admin-ajax.php page with the action 'ckwc-export', without a nonce.
+		$I->amOnAdminPage('admin-ajax.php?action=ckwc-export&page=wc-settings&tab=integration&section=ckwc');
+
+		// Wait 2 seconds in case the download is triggered.
+		sleep(2);
+
+		// Confirm that the response is 0, and no download file exists.
+		$I->seeInSource('0');
+		$I->dontSeeFileFound($_ENV['WORDPRESS_ROOT_DIR'] . '/ckwc-export.json');
+	}
+
+	/**
 	 * Test that the Import Configuration option works.
 	 *
 	 * @since   1.4.6

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -9,7 +9,7 @@
  * Plugin Name: Kit (formerly ConvertKit) for WooCommerce
  * Plugin URI:  https://www.kit.com
  * Description: Integrates WooCommerce with Kit, allowing customers to be automatically sent to your Kit account.
- * Version:     2.1.6
+ * Version:     2.1.7
  * Author:      Kit
  * Author URI:  https://www.kit.com
  * License:     GPLv3 or later
@@ -30,7 +30,7 @@ define( 'CKWC_PLUGIN_NAME', 'ConvertKitWooCommerce' ); // Used for user-agent in
 define( 'CKWC_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CKWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CKWC_PLUGIN_PATH', __DIR__ );
-define( 'CKWC_PLUGIN_VERSION', '2.1.6' );
+define( 'CKWC_PLUGIN_VERSION', '2.1.7' );
 define( 'CKWC_OAUTH_CLIENT_ID', 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A' );
 define( 'CKWC_OAUTH_CLIENT_REDIRECT_URI', 'https://app.kit.com/wordpress/redirect' );
 


### PR DESCRIPTION
## Summary

Fixes [this reported vulnerability](https://vdp.patchstack.com/vdp/vulnerabilities/7002d292-07bf-4c54-8c9e-0fca17739ee3/preview) by checking for a valid nonce before permitting the export configuration action, as we do for the main Kit Plugin:
https://github.com/Kit/convertkit-wordpress/blob/c9804a2630495fe8dcfc33a39eb728d88b7d9148/admin/section/class-convertkit-admin-section-tools.php#L209-L223

MemberMouse and WPForms don't have an export configuration option, so are unaffected.

## Testing

- `testExportConfigurationFailsWithoutNonce`: Test that attempting to export a configuration fails without a valid nonce, using the reproduction steps provided in the report.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)